### PR TITLE
Switch to w3c-xmlhttprequest

### DIFF
--- a/lib/jsdom/browser/index.js
+++ b/lib/jsdom/browser/index.js
@@ -226,30 +226,8 @@ exports.createWindow = function(dom, options) {
       get cookieEnabled() { return true; }
     },
     XMLHttpRequest: function() {
-      var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
-      var xhr = new XMLHttpRequest();
-      var lastUrl = '';
-      xhr._open = xhr.open;
-      xhr.open = function(method, url, async, user, password) {
-        url = URL.resolve(options.url, url);
-        lastUrl = url;
-        return xhr._open(method, url, async, user, password);
-      };
-      xhr._send = xhr.send;
-      xhr.send = function(data) {
-        if (window.document.cookie) {
-          var cookieDomain = window.document._cookieDomain;
-          var url = URL.parse(lastUrl);
-          var host = url.host.split(':')[0];
-          if (host.indexOf(cookieDomain, host.length - cookieDomain.length) !== -1) {
-            xhr.setDisableHeaderCheck(true);
-            xhr.setRequestHeader('cookie', window.document.cookie);
-            xhr.setDisableHeaderCheck(false);
-          }
-        }
-        return xhr._send(data);
-      };
-      return xhr;
+      // global.window must be available within module for cookie support
+      return new require('w3c-xmlhttprequest').XMLHttpRequest();
     },
 
     name: 'nodejs',

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
        "parse5":  "~1.0.0",
        "nwmatcher": "~1.3.2",
        "request": "2.x",
-       "xmlhttprequest": ">=1.5.0",
+       "w3c-xmlhttprequest": "~1.2.0",
        "cssom": "~0.3.0",
        "cssstyle": "~0.2.9",
        "contextify": "~0.1.5"


### PR DESCRIPTION
Closes #790.
Brings several improvements over legacy node-xmlhttprequest, like
support for "responseType" and "response" properties (allowing binary xhr requests through 'arraybuffer' responseType, see spec); better event support, xhr streaming, and room for improvement (code is quite well structured).