### PR TITLE
Fix "cannot read property 'cssText' of undefined"

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -163,7 +163,7 @@ inheritFrom(core.Attr, StyleAttr, {
     if (typeof this._node._style === 'string') {
       return this._node._style;
     } else {
-      return this._node.style.cssText;
+      return this._node._style.cssText;
     }
   },
   set nodeValue(value) {


### PR DESCRIPTION
This looks like it's just a typo, and it's breaking our app. :)

I'll see if I can't find a snippet that illustrates the bug, but you'll see the diff is pretty simple and obvious.