### PR TITLE
Add virtual console

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,30 @@ serializeDocument(doc) === "<!DOCTYPE html><html><head></head><body>hello</body>
 doc.documentElement.outerHTML === "<html><head></head><body>hello</body></html>";
 ```
 
+### Capturing Console Output
+
+#### Forward a window's console output to the Node.js console
+
+```js
+var jsdom = require("jsdom");
+var window = jsdom.jsdom().parentWindow;
+
+jsdom.getVirtualConsole(window).sendTo(console);
+```
+
+#### Get an event emitter for a window's console
+
+```js
+var jsdom = require("jsdom");
+var window = jsdom.jsdom().parentWindow;
+
+var virtualConsole = jsdom.getVirtualConsole(window);
+
+virtualConsole.on("log", function (message) {
+  console.log("console.log called ->", message);
+});
+```
+
 ## What Standards Does jsdom Support, Exactly?
 
 Our mission is to get something very close to a headless browser, with emphasis more on the DOM/HTML side of things than the CSS side. As such, our primary goals are supporting [The DOM Standard](http://dom.spec.whatwg.org/) and [The HTML Standard](http://www.whatwg.org/specs/web-apps/current-work/multipage/). We only support some subset of these so far; in particular we have the subset covered by the outdated DOM 2 spec family down pretty well. We're slowly including more and more from the modern DOM and HTML specs, including some `Node` APIs, `querySelector(All)`, attribute semantics, the history and URL APIs, and the HTML parsing algorithm.

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -8,14 +8,17 @@ var defineSetter = require('./jsdom/utils').defineSetter;
 var features = require('./jsdom/browser/documentfeatures');
 var dom = require('./jsdom/living');
 var browserAugmentation = require('./jsdom/browser/index').browserAugmentation;
-
 var domToHtml = require('./jsdom/browser/domtohtml').domToHtml;
+var VirtualConsole = require('./jsdom/virtual-console');
 
 var request = function() { // lazy loading request
   request = require('request');
   return request.apply(undefined, arguments);
 }
 
+exports.getVirtualConsole = function (window) {
+  return window._virtualConsole;
+};
 exports.debugMode = false;
 
 // Proxy feature functions to features module.

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -92,11 +92,7 @@ function Window(options) {
     clear: wrapConsoleMethod("clear"),
     count: wrapConsoleMethod("count"),
     debug: wrapConsoleMethod("debug"),
-    error: function (message) {
-      var args = Array.prototype.slice.call(arguments);
-      window._virtualConsole.emit.apply(window._virtualConsole, ["error"].concat(args));
-      window.raise("error", message);
-    },
+    error: wrapConsoleMethod("error"),
     group: wrapConsoleMethod("group"),
     groupCollapse: wrapConsoleMethod("groupCollapse"),
     groupEnd: wrapConsoleMethod("groupEnd"),

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -9,6 +9,7 @@ var createFrom = require("../utils").createFrom;
 var Location = require("./location");
 var History = require("./history");
 var toFileUrl = require("../utils").toFileUrl;
+var VirtualConsole = require("../virtual-console");
 
 var cssSelectorSplitRE = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
 
@@ -77,34 +78,35 @@ function Window(options) {
   this.clearTimeout = stopTimer.bind(this, window);
   this.__stopAllTimers = stopAllTimers.bind(this, window);
 
+  this._virtualConsole = new VirtualConsole();
+
+  function wrapConsoleMethod(method) {
+    return function () {
+      var args = Array.prototype.slice.call(arguments);
+      window._virtualConsole.emit.apply(window._virtualConsole, [method].concat(args));
+    };
+  }
+
   this.console = {
-    assert: function (expression, message) {
-      if (!expression) {
-        window.raise("error", "Assertion failed: " + message);
-      }
-    },
-    clear: function () {},
-    count: function () {},
-    debug: function () {},
+    assert: wrapConsoleMethod("assert"),
+    clear: wrapConsoleMethod("clear"),
+    count: wrapConsoleMethod("count"),
+    debug: wrapConsoleMethod("debug"),
     error: function (message) {
+      var args = Array.prototype.slice.call(arguments);
+      window._virtualConsole.emit.apply(window._virtualConsole, ["error"].concat(args));
       window.raise("error", message);
     },
-    group: function () {},
-    groupCollapse: function () {},
-    groupEnd: function () {},
-    info: function (message) {
-      window.raise("info", message);
-    },
-    log: function (message) {
-      window.raise("log", message);
-    },
-    table: function () {},
-    time: function () {},
-    timeEnd: function () {},
-    trace: function () {},
-    warn: function (message) {
-      window.raise("warn", message);
-    }
+    group: wrapConsoleMethod("group"),
+    groupCollapse: wrapConsoleMethod("groupCollapse"),
+    groupEnd: wrapConsoleMethod("groupEnd"),
+    info: wrapConsoleMethod("info"),
+    log: wrapConsoleMethod("log"),
+    table: wrapConsoleMethod("table"),
+    time: wrapConsoleMethod("time"),
+    timeEnd: wrapConsoleMethod("timeEnd"),
+    trace: wrapConsoleMethod("trace"),
+    warn: wrapConsoleMethod("warn")
   };
 
   this.XMLHttpRequest = function () {

--- a/lib/jsdom/virtual-console.js
+++ b/lib/jsdom/virtual-console.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var EventEmitter = require("events").EventEmitter;
+var utils = require("./utils");
+
+function VirtualConsole() {
+  // If "error" event has no listeners,
+  // EventEmitter throws an exception
+  this.on("error", function () {});
+}
+
+utils.inheritFrom(EventEmitter, VirtualConsole, {
+  sendTo: function (anyConsole) {
+    Object.keys(anyConsole).forEach(function (method) {
+      if (typeof anyConsole[method] === "function") {
+        this.on(method, function () {
+          anyConsole[method].apply(anyConsole, arguments);
+        });
+      }
+    }, this);
+  }
+});
+
+module.exports = VirtualConsole;

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -1,0 +1,96 @@
+"use strict";
+
+var jsdom = require("../..");
+var EventEmitter = require("events").EventEmitter;
+
+var consoleMethods = [
+  "assert",
+  "clear",
+  "count",
+  "debug",
+  "error",
+  "group",
+  "groupCollapse",
+  "groupEnd",
+  "info",
+  "log",
+  "table",
+  "time",
+  "timeEnd",
+  "trace",
+  "warn",
+];
+
+exports["jsdom.getVirtualConsole returns an instance of EventEmitter"] = function(t) {
+  var window = jsdom.jsdom().parentWindow;
+  var vc = jsdom.getVirtualConsole(window);
+  t.ok(vc instanceof EventEmitter, "getVirtualConsole returns an instance of EventEmitter");
+  t.done();
+};
+
+exports["virtualConsole passes through any arguments"] = function(t) {
+  var window = jsdom.jsdom().parentWindow;
+  var vc = jsdom.getVirtualConsole(window);
+
+  consoleMethods.forEach(function (method) {
+    var called = false;
+
+    vc.on(method, function (arg1, arg2) {
+      called = true;
+      t.ok(arg1 === "yay", "virtualConsole.on '"+method+"' passes through any arguments (1)");
+      t.ok(arg2 === "woo", "virtualConsole.on '"+method+"' passes through any arguments (2)");
+    });
+    window.console[method]("yay", "woo");
+
+    t.ok(called, "virtualConsole emits '"+method+"' event");
+
+    vc.removeAllListeners();
+  });
+
+  t.done();
+};
+
+exports["virtualConsole separates output by window"] = function(t) {
+  var window1 = jsdom.jsdom().parentWindow;
+  var window2 = jsdom.jsdom().parentWindow;
+  var vc1Called = false;
+  var vc2Called = false;
+  var virtualConsole1 = jsdom.getVirtualConsole(window1);
+  var virtualConsole2 = jsdom.getVirtualConsole(window2);
+
+  virtualConsole1.on("log", function () {
+    vc1Called = true;
+  });
+  virtualConsole2.on("log", function () {
+    vc2Called = true;
+  });
+
+  window1.console.log("yay");
+
+  t.ok(vc1Called === true, "should forward to window on which console was called");
+  t.ok(vc2Called === false, "should not forward to window on which console was not called");
+
+  t.done();
+};
+
+exports["virtualConsole.sendTo proxies console methods"] = function(t) {
+  var window = jsdom.jsdom().parentWindow;
+  var virtualConsole = jsdom.getVirtualConsole(window);
+  var counter = 0;
+  var inc = function () { counter += 1; };
+  var fakeConsole = {};
+
+  consoleMethods.forEach(function (method) {
+    fakeConsole[method] = inc;
+  });
+
+  virtualConsole.sendTo(fakeConsole);
+
+  consoleMethods.forEach(function (method) {
+    window.console[method]();
+  });
+
+  t.ok(counter === consoleMethods.length, "sendTo works on console methods");
+
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -60,6 +60,7 @@ var files = [
   "jsdom/env.js",
   "jsdom/utils.js",
   "jsdom/namespaces.js",
+  "jsdom/virtual-console.js",
   "jsdom/xml.js",
 
   "jsonp/jsonp.js",

--- a/test/window/console.js
+++ b/test/window/console.js
@@ -32,28 +32,3 @@ exports["console has all methods in spec"] = function (t) {
 
   t.done();
 };
-
-exports["only console.error should put errors in the window.document.errors array"] = function (t) {
-  var window = jsdom("<!DOCTYPE html><html><body>Hi</body></html>").parentWindow;
-
-  window.console.log("foo");
-  window.console.info("bar");
-  window.console.warn("baz");
-  window.console.error("qux");
-
-  t.deepEqual(window.document.errors, [{ type: "error", message: "qux", data: null }]);
-  t.done();
-};
-
-exports["should send errors to the correct window when multiple are in play (GH-658)"] = function (t) {
-  var window1 = jsdom("<!DOCTYPE html><html><body>Hi</body></html>").parentWindow;
-  var window2 = jsdom("<!DOCTYPE html><html><body>Hi</body></html>").parentWindow;
-
-  window1.console.error("foo");
-  window2.console.error("bar");
-
-  t.notEqual(window1.console, window2.console);
-  t.deepEqual(window1.document.errors, [{ type: "error", message: "foo", data: null }]);
-  t.deepEqual(window2.document.errors, [{ type: "error", message: "bar", data: null }]);
-  t.done();
-};


### PR DESCRIPTION
(via #971)

#### Adds:

- `jsdom.getVirtualConsole`, for fetching an internal console emitter
- `virtualConsole.sendTo`, for forwarding internal output to any console

#### Design decisions:

1. `sendTo` requires its argument to only have at least one valid console method. I did this so that you could pick and choose which methods you wanted to proxy. Let me know if you think it should be fully compliant.
1. Kept the `window.raise` calls in the original console handlers (it looks like `'error'` is [the only method that has a side effect](https://github.com/jeffcarp/jsdom/blob/virtual-console/lib/jsdom/level1/core.js#L969)  in `raise`).

#### Questions:

1. The way I accomplished keeping console events separate between windows doesn't feel super elegant. If anything comes to mind in this area I'd love to hear how to improve it.
1. This PR doesn't replicate any console functionality (like `console.count` having internal state). Is that a needed feature?

~~[edit] jshint fixes forthcoming...~~