### PR TITLE
handle null bytes in html

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -119,7 +119,9 @@ exports.env = exports.jsdom.env = function () {
     } else {
       fs.readFile(config.somethingToAutodetect, 'utf-8', function (err, text) {
         if (err) {
-          if (err.code === 'ENOENT' || err.code === 'ENAMETOOLONG') {
+          if (err.code === 'ENOENT' || err.code === 'ENAMETOOLONG'
+          	|| (err.toString() == 'Error: Path must be a string without null bytes.') // err.code and err.errno are both undefined at this point
+          ) {
             config.html = config.somethingToAutodetect;
             processHTML(config);
           } else {

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -324,6 +324,6 @@ exports["handle null bytes in html"] = function (t) {
 		"<div>\0</div>",
 		function(errors, window) {
 			t.ifError(errors);
-			t.ok(window.document.querySelector("div") != null, "div was parsed");
+			t.ok(window.document.querySelector("div") !== null, "div was parsed");
 		});
 };

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -324,6 +324,6 @@ exports["handle null bytes in html"] = function (t) {
 		"<div>\0</div>",
 		function(errors, window) {
 			t.ifError(errors);
-			t.ok(window.document.querySelector('div') != null, "div was parsed");
+			t.ok(window.document.querySelector("div") != null, "div was parsed");
 		});
 };

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -317,3 +317,13 @@ exports["void tags set by innerHTML from createElement (GH-863/872)"] = function
 
   t.done();
 };
+
+exports["handle null bytes in html"] = function (t) {
+	t.expect(2);
+	jsdom.env(
+		"<div>\0</div>",
+		function(errors, window) {
+			t.ifError(errors);
+			t.ok(window.document.querySelector('div') != null, "div was parsed");
+		});
+};


### PR DESCRIPTION
While building a sitemap generator using your lib, I found it not uncommon to receive null bytes in page content. fs.readFile will fail without an error code in this case.