### PR TITLE
Use travis container system for faster test startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   include:
     - env: TEST_SUITE=node
       node_js: "0.10"
+      sudo: false
     - env: TEST_SUITE=browser
       node_js: "0.10"
       addons:


### PR DESCRIPTION
Only enable container structure for node builds, because it currently fails with browser builds due to errors with the travis tunnel.