### PR TITLE
Browserified jsdom cannot execute <script> tags

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,5 +1,4 @@
 lib/jsdom.js
-lib/jsdom/contextify-shim.js
 lib/jsdom/browser/documentAdapter.js
 lib/jsdom/browser/documentfeatures.js
 lib/jsdom/browser/domtohtml.js

--- a/lib/jsdom/contextify-shim.js
+++ b/lib/jsdom/contextify-shim.js
@@ -1,5 +1,53 @@
+"use strict";
+
+var acorn = require("acorn");
+var findGlobals = require("acorn-globals");
+var escodegen = require("escodegen");
+
 module.exports = function (o) {
   o.getGlobal = function () {
     return o;
+  };
+
+  o.run = function (code, filename) {
+    var comments = [], tokens = [];
+    var ast = acorn.parse(code, {
+      ecmaVersion: 6,
+      allowReturnOutsideFunction: true,
+      ranges: true,
+      // collect comments in Esprima's format 
+      onComment: comments,
+      // collect token ranges 
+      onToken: tokens
+    });
+
+    // make sure we keep comments
+    escodegen.attachComments(ast, comments, tokens);
+
+    var globals = findGlobals(ast);
+    for (var i = 0; i < globals.length; ++i) {
+      if (globals[i].name === "window") {
+        continue;
+      }
+
+      var nodes = globals[i].nodes;
+      for (var j = 0; j < nodes.length; ++j) {
+        var type = nodes[j].type;
+        var name = nodes[j].name;
+        nodes[j].type = "MemberExpression";
+        nodes[j].property = {
+          name: name,
+          type: type
+        };
+        nodes[j].computed = false;
+        nodes[j].object = {
+          name: "window",
+          type: "Identifier"
+        };
+      }
+    }
+
+    code = escodegen.generate(ast, { comment: true });
+    new Function("window", code + "\n//# sourceURL=" + filename).bind(o)(o); // jshint ignore:line
   };
 };

--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
     "parse5": ">= 1.3.1 < 2.0.0",
     "request": ">= 2.44.0 < 3.0.0",
     "xml-name-validator": "^1.0.0",
-    "xmlhttprequest": ">= 1.6.0 < 2.0.0"
+    "xmlhttprequest": ">= 1.6.0 < 2.0.0",
+    "acorn-globals": "^1.0.2",
+    "acorn": "0.11.0",
+    "escodegen":  "^1.6.1"
   },
   "devDependencies": {
     "browserify": "^8.1.3",

--- a/test/jsdom/inside-worker-smoke-tests.js
+++ b/test/jsdom/inside-worker-smoke-tests.js
@@ -32,3 +32,44 @@ exports["jsdom.env: string, full HTML document"] = function (t) {
     }
   );
 };
+
+exports["execute scripts with global variables / window scope reference"] = function (t) {
+  t.expect(3);
+
+  env({
+    html: "<!doctype html><html><head><script>test = 'true'; navigator.foo = 'bar'</script></head><body></body></html>",
+    done: function (err, window) {
+      t.ifError(err);
+
+      t.strictEqual(window.test, "true", "global variables should be on window");
+      t.strictEqual(window.navigator.foo, "bar", "nested reference should work");
+
+      t.done();
+    },
+    features: {
+      ProcessExternalResources: ["script"]
+    }
+  });
+};
+
+exports["test async global variable context"] = function (t) {
+  t.expect(3);
+
+  env({
+    html: "<!doctype html><html><head><script>test = 'true'; setTimeout(function(){test = 'baz'}, 100);</script>" +
+      "</head><body></body></html>",
+    done: function (err, window) {
+      t.ifError(err);
+
+      t.strictEqual(window.test, "true", "global variables should be on window");
+
+      setTimeout(function () {
+        t.strictEqual(window.test, "baz", "async write should be reflected");
+        t.done();
+      }, 1000);
+    },
+    features: {
+      ProcessExternalResources: ["script"]
+    }
+  });
+};

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -22,7 +22,7 @@ self.onmessage = function (e) {
     "level1/html": require("../test/level1/html"), // ok
     "level2/core": require("../test/level2/core"), // ok
     "level2/html": require("../test/level2/html"), // 6/708
-    "level2/style": require("../test/level2/style"), // 0/15
+    "level2/style": require("../test/level2/style"), // 13/15
     "level2/extra": require("../test/level2/extra"), // ok
     "level2/events": require("../test/level2/events"), // ok
     //"level3/core": require("../test/level3/core"),
@@ -30,16 +30,16 @@ self.onmessage = function (e) {
     "level3/textContent.js": require("../test/level3/textContent.js"), // ok
     "level3/xpath": require("../test/level3/xpath"), // 0/93
 
-    "living-dom/attributes.js": require("../test/living-dom/attributes.js"), // 0/10
+    "living-dom/attributes.js": require("../test/living-dom/attributes.js"), // 1/11
     "living-dom/compare-document-position.js": require("../test/living-dom/compare-document-position.js"), // 0/20
     "living-dom/node-contains.js": require("../test/living-dom/node-contains.js"), // 0/20
     "living-dom/node-parent-element.js": require("../test/living-dom/node-parent-element.js"), // 0/11
     "living-html/location.js": require("../test/living-html/location.js"), // ok
-    "living-html/navigator.js": require("../test/living-html/navigator.js"), // 0/2
+    "living-html/navigator.js": require("../test/living-html/navigator.js"), // ok
 
-    "window/history": require("../test/window/history"), // 0/5
+    "window/history": require("../test/window/history"), // ok
     "window/script": require("../test/window/script"), // 0/10
-    "window/console": require("../test/window/console"), // 0/2
+    "window/console": require("../test/window/console"), // ok
     //"window/frame": require("../test/window/frame"), // fail
     //"sizzle/index": require("../test/sizzle/index"), // fail
     //"jsdom/index": require("../test/jsdom/index"), // fail
@@ -48,8 +48,8 @@ self.onmessage = function (e) {
     "jsdom/utils": require("../test/jsdom/utils"), // ok
     "jsdom/inside-worker-smoke-tests": require("../test/jsdom/inside-worker-smoke-tests"),
     "jsonp/jsonp": require("../test/jsonp/jsonp"), // 0/1
-    "browser/css": require("../test/browser/css"), // 0/1
-    "browser/index": require("../test/browser/index"), // 30/34
+    "browser/css": require("../test/browser/css"), // ok
+    "browser/index": require("../test/browser/index"), // ok
     "w3c/index.js": require("../test/w3c/index"), // 0/2
   };
 
@@ -67,9 +67,16 @@ self.onmessage = function (e) {
     "level2/extra",
     "level2/events",
     "level3/textContent.js",
-    "window/index",
+
+    "living-html/location.js",
+    "living-html/navigator.js",
+
+    "window/history",
+    "window/console",
     "jsdom/utils",
-    "jsdom/inside-worker-smoke-tests"
+    "jsdom/inside-worker-smoke-tests",
+    "browser/css",
+    "browser/index"
   ];
 
   if (options.tests) {


### PR DESCRIPTION
Our contextify-shim.js doesn't even have a run function. I tried to add one, just

```js
  o.run = function (code, filename) {
    o.eval(code + "\n//# sourceURL=" + filename);
  };
```

but this of course doesn't work since it's running the code in the global scope (e.g. in a worker), where variables like `window` and `document` don't work right.