### PR TITLE
Location.prototype.reload leaks a global "errors"

### DIFF
--- a/lib/jsdom/browser/utils.js
+++ b/lib/jsdom/browser/utils.js
@@ -18,6 +18,6 @@ exports.NOT_IMPLEMENTED = function (target, nameForErrorMessage) {
       return;
     }
 
-    raise.call(this, "error", message);
+    raise.call(target, "error", message);
   };
 };


### PR DESCRIPTION
Hey,

I'm not precisely sure why, but calling `window.location.reload` leaks `errors` to the global scope:

```
> require("jsdom").jsdom().parentWindow.location.reload()
undefined
> global.errors
[ { type: 'error',
    message: 'NOT IMPLEMENTED: location.reload',
    data: null } ]
```

Adding some sort of an automatic globals checking to your test suite can catch this quickly in the future.