### PR TITLE
Improve the performance of define by about ~40%

### DIFF
--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -100,12 +100,20 @@ exports.inheritFrom = function inheritFrom(Superclass, Subclass, properties) {
  *
  * - `object` {Object} the target object
  * - `properties` {Object} the source from which to copy property descriptors
+ * 
+ * This function is performance sensitive, it's used to copy the DOM into every window.
  */
 exports.define = function define(object, properties) {
-  Object.getOwnPropertyNames(properties).forEach(function (name) {
+  var keys = Object.getOwnPropertyNames(properties);
+  for (var i = 0; i < keys.length; ++i) {
+    var name = keys[i];
     var propDesc = Object.getOwnPropertyDescriptor(properties, name);
-    Object.defineProperty(object, name, propDesc);
-  });
+    if (propDesc.value && propDesc.writable && propDesc.enumerable && propDesc.configurable) {
+      object[name] = propDesc.value;
+    } else {
+      Object.defineProperty(object, name, propDesc);
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
Since define is used to copy over all of our dom properties (which are a lot), it has to be pretty performant.
This patch does two things:
* Removes the need to allocate a new anonymous function by replacing the forEach with a standard for loop
* If the property to copy is a simple defined property (not defined with defineProperty), avoid the call to defineProperty ourselves too

Especially the second point is important. It shaves off about 40% of time in define, and about 20% of overall initialization time, which reduces the time for 10000 instances from about 8 seconds to 6 seconds on my laptop.