### PR TITLE
Defer the initialization of vm

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -235,10 +235,6 @@ function processHTML(config) {
     return;
   }
 
-  window.document.implementation._addFeature('FetchExternalResources', ['script']);
-  window.document.implementation._addFeature('ProcessExternalResources', ['script']);
-  window.document.implementation._addFeature('MutationEvents', ['2.0']);
-
   function scriptComplete() {
     docsLoaded++;
 
@@ -273,6 +269,10 @@ function processHTML(config) {
   }
 
   if (config.scripts.length > 0 || config.src.length > 0) {
+    window.document.implementation._addFeature('FetchExternalResources', ['script']);
+    window.document.implementation._addFeature('ProcessExternalResources', ['script']);
+    window.document.implementation._addFeature('MutationEvents', ['2.0']);
+
     config.scripts.forEach(function (scriptSrc) {
       var script = window.document.createElement('script');
       script.className = 'jsdom';

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var vm = require("vm");
 var URL = require("url");
 var CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
 var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
@@ -26,7 +25,6 @@ function Window(options) {
   EventTarget.call(this);
 
   var window = this;
-  vm.createContext(this);
 
   ///// INTERFACES FROM THE DOM
   // TODO: consider a mode of some sort where these are not shared between all DOM instances
@@ -35,8 +33,8 @@ function Window(options) {
 
   ///// PRIVATE DATA PROPERTIES
 
-  // See https://github.com/iojs/io.js/issues/855
-  this._globalProxy = vm.runInContext("this", this);
+  // vm initialization is defered until script processing is activated (in level1/core)
+  this._globalProxy = this;
 
   this.__timers = [];
 

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -281,6 +281,14 @@ core.DOMImplementation.prototype = {
       } else {
         this._features[feature].push(version);
       }
+
+      if (feature === "processexternalresources" &&
+          (version === "script" || (version.indexOf && version.indexOf("script") !== -1)) &&
+          !vm.isContext(this._ownerDocument._global)) {
+        vm.createContext(this._ownerDocument._global);
+        this._ownerDocument._defaultView._globalProxy = vm.runInContext("this", this._ownerDocument._global);
+        this._ownerDocument._defaultView = this._ownerDocument._defaultView._globalProxy;
+      }
     }
   },
 


### PR DESCRIPTION
This reduces init times by about 600+% if scripting on the page is not needed, so gives a nice performance boost.

This breaks backwards compat somewhat!
Enabling scripting after already having received a window (i.e. adding ProcessExternalResources to document.implementation manually, not providing it in config/options) results in a changing document.defaultView.
If we need to increase major probably mainly depends on if document.implementation._addFeature is considered public API.