### PR TITLE
Assure accurate childNodes state

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -567,6 +567,9 @@ core.Node.prototype = {
     if (this._childrenList) {
       this._childrenList._update();
     }
+    if (this._childNodesList) {
+      this._childNodesList._update();
+    }
     this._clearMemoizedQueries()
   },
 

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -17079,6 +17079,15 @@ exports.tests = {
     test.done();
   },
 
+  child_nodes_state: function(test) {
+    var doc = jsdom.jsdom();
+    var element = doc.createElement('div');
+    var childNodes = element.childNodes;
+    var newElement = element.appendChild(doc.createElement('div'));
+    test.equal(childNodes[0], newElement);
+    test.done();
+  },
+
   hc_docclonenodetrue: function(test) {
     var doc;
     var docClone;


### PR DESCRIPTION
`childNodes` properties reflect inaccurate state in some scenarios. This update fixes that

This bug caused [replaceContent](https://github.com/medikoo/dom-ext/blob/master/node/%23/_replace-content.js) module logic not working properly. While it works without issues in all major browsers
