### PR TITLE
Pathname of anchor tag with relative `href`

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var URL = require("url");
 var CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
 var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 var notImplemented = require("./not-implemented");
@@ -8,6 +7,7 @@ var History = require("./history");
 var VirtualConsole = require("../virtual-console");
 var define = require("../utils").define;
 var inherits = require("../utils").inheritFrom;
+var resolveHref = require("../utils").resolveHref;
 var EventTarget = require("../events/EventTarget");
 var namedPropertiesWindow = require("../living/named-properties-window");
 var cssom = require("cssom");
@@ -151,7 +151,7 @@ function Window(options) {
     var lastUrl = "";
     xhr._open = xhr.open;
     xhr.open = function (method, url, async, user, password) {
-      url = URL.resolve(window.document.URL, url);
+      url = resolveHref(window.document.URL, url);
       lastUrl = url;
       return xhr._open(method, url, async, user, password);
     };

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -188,6 +188,19 @@ function Window(options) {
       xhr.addEventListener("readystatechange", setReceivedCookies);
       return xhr._send(data);
     };
+    Object.defineProperty(xhr, "response", {
+      get: function () {
+        if (this.responseType === "text") {
+          return this.responseText;
+        } else if (this.responseType === "json") {
+          return JSON.parse(this.responseText);
+        } else {
+          return null; // emulate failed requeest
+        }
+      },
+      enumerable: true,
+      configurable: true
+    });
     return xhr;
   };
 

--- a/lib/jsdom/browser/resource-loader.js
+++ b/lib/jsdom/browser/resource-loader.js
@@ -8,7 +8,7 @@ const NODE_TYPE = require("../living/node-type");
 
 var IS_BROWSER = Object.prototype.toString.call(process) !== "[object process]";
 
-function getDocumentBaseUrl(document) {
+var getDocumentBaseUrl = exports.getDocumentBaseUrl = function getDocumentBaseUrl(document) {
   var baseElements = document.getElementsByTagName("base");
   var baseUrl = document.URL;
 
@@ -21,7 +21,7 @@ function getDocumentBaseUrl(document) {
   }
 
   return baseUrl;
-}
+};
 
 function createResourceLoadHandler(element, resourceUrl, document, loadCallback) {
   return function (err, data) {

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -9,7 +9,8 @@ var resourceLoader        = require('../browser/resource-loader'),
     URL                   = require("url"),
     fs                    = require("fs"),
     mapper                = require("../utils").mapper,
-    mixinURLUtils         = require("whatwg-url-compat").mixinURLUtils;
+    URL                   = require("whatwg-url-compat"),
+    mixinURLUtils         = URL.mixinURLUtils;
 
 const proxiedWindowEventHandlers = require("../living/helpers/proxied-window-event-handlers");
 const domSymbolTree = require("../living/helpers/internal-constants").domSymbolTree;
@@ -568,12 +569,38 @@ define('HTMLTitleElement', {
   }
 });
 
+function reparseAnchors(doc) {
+  var anchors = doc.getElementsByTagName("a");
+  for (var i = 0; i < anchors.length; ++i) {
+    URL.reparse(anchors[i]);
+  }
+}
 define('HTMLBaseElement', {
   tagName: 'BASE',
   attributes: [
     'href',
     'target'
-  ]
+  ],
+  proto: {
+    _attrModified: function (name, value, oldVal) {
+      core.HTMLElement.prototype._attrModified.call(this, name, value, oldVal);
+      if (name === 'href') {
+        reparseAnchors(this._ownerDocument);
+      }
+    },
+
+    _detach: function () {
+      core.HTMLElement.prototype._detach.call(this);
+
+      reparseAnchors(this._ownerDocument);
+    },
+
+    _attach: function () {
+      core.HTMLElement.prototype._attach.call(this);
+
+      reparseAnchors(this._ownerDocument);
+    }
+  }
 });
 
 

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -8,7 +8,8 @@ var resourceLoader        = require('../browser/resource-loader'),
     Window                = require("../browser/Window"),
     URL                   = require("url"),
     fs                    = require("fs"),
-    mapper                = require("../utils").mapper;
+    mapper                = require("../utils").mapper,
+    mixinURLUtils         = require("whatwg-url-compat").mixinURLUtils;
 
 const proxiedWindowEventHandlers = require("../living/helpers/proxied-window-event-handlers");
 const domSymbolTree = require("../living/helpers/internal-constants").domSymbolTree;
@@ -1341,55 +1342,28 @@ define('HTMLModElement', {
 define('HTMLAnchorElement', {
   tagName: 'A',
 
-  proto: {
-    get href() {
-      return resourceLoader.resolveResourceUrl(this._ownerDocument, this.getAttribute('href'));
-    },
-    get hostname() {
-      return URL.parse(this.href).hostname || '';
-    },
-    get host() {
-      return URL.parse(this.href).host || '';
-    },
-    get origin() {
-      var proto = URL.parse(this.href).protocol;
+  init: function () {
+    mixinURLUtils(this, function getTheBase() {
+      return resourceLoader.getDocumentBaseUrl(this._ownerDocument);
+    }, function updateSteps(value) {
+      this.setAttribute("href", value);
+    });
+  },
 
-      if (proto !== undefined && proto !== null) {
-        proto += '//';
+  proto: {
+    _attrModified: function(name, value, oldVal) {
+      if (name === 'href') {
+        URL.setTheInput(this, value);
       }
 
-      return proto + URL.parse(this.href).host || '';
+      core.HTMLElement.prototype._attrModified.call(this, name, value, oldVal);
     },
-    get port() {
-      return URL.parse(this.href).port || '';
-    },
-    get protocol() {
-      var protocol = URL.parse(this.href).protocol;
-      return (protocol == null) ? ':' : protocol;
-    },
-    get password() {
-      var auth = URL.parse(this.href).auth;
-      return auth.substr(auth.indexOf(':') + 1);
-    },
-    get pathname() {
-      return URL.parse(this.href).pathname || '';
-    },
-    get username() {
-      var auth = URL.parse(this.href).auth;
-      return auth.substr(0, auth.indexOf(':'));
-    },
-    get search() {
-      return URL.parse(this.href).search || '';
-    },
-    get hash() {
-      return URL.parse(this.href).hash || '';
-    }
   },
+
   attributes: [
     'accessKey',
     'charset',
     'coords',
-    {prop: 'href', type: 'string', read: false},
     'hreflang',
     'name',
     'rel',

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -97,7 +97,7 @@ function fetchStylesheet(url, sheet) {
   resourceLoader.load(this, url, function(data) {
     // TODO: abort if the content-type is not text/css, and the document is
     // in strict mode
-    sheet.href = resourceLoader.resolveResourceUrl(this.ownerDocument, url);
+    url = sheet.href = resourceLoader.resolveResourceUrl(this.ownerDocument, url);
     evaluateStylesheet.call(this, data, sheet, url);
   });
 }

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -25,3 +25,4 @@ require("./node")(core);
 require("./selectors")(core);
 require("./parent-node")(core);
 require("./non-document-type-child-node")(core);
+require("./url")(core);

--- a/lib/jsdom/living/url.js
+++ b/lib/jsdom/living/url.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const URL = require("whatwg-url-compat");
+
+module.exports = function (core) {
+  core.URL = URL.createURLConstructor();
+};

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -1,6 +1,8 @@
 "use strict";
 var path = require("path");
-var url = require("url");
+
+const URL = require("whatwg-url-compat").createURLConstructor();
+
 const domSymbolTree = require("./living/helpers/internal-constants").domSymbolTree;
 const SYMBOL_TREE_POSITION = require("symbol-tree").TreePosition;
 
@@ -174,69 +176,15 @@ exports.memoizeQuery = function memoizeQuery(fn) {
   };
 };
 
-/**
-* A slightly-more-compliant version of `url.resolve`, taking care of a few Node bugs.
-*/
 exports.resolveHref = function resolveHref(baseUrl, href) {
-  var about = "about:blank";
-
-  // if we're redirecting to another site on about:blank, just let it through
-  if (href.substring(0, about.length) === about) {
+  try {
+    return new URL(href, baseUrl).href;
+  } catch (e) {
+    // can't throw since this utility is basically used everywhere
+    // do what the spec says regarding anchor tags: just don't parse it
+    // https://url.spec.whatwg.org/#dom-urlutils-href
     return href;
   }
-
-  // if we have to resolve from about:blank we need a bit of special logic
-  if (baseUrl.substring(0, about.length) === about) {
-    if (href.search(/^([A-Za-z0-9]+):/) === 0) { // we have an absolute url
-      baseUrl = href;
-      href = "";
-    } else if (href[0] === "#") { // we have a location hash on about:blank
-      return baseUrl.split(/#/)[0] + href;
-    } else if (!href) { // we just have some base url
-      return baseUrl;
-    } else { // must be a file url
-      baseUrl = "file://" + href;
-      href = "";
-    }
-  }
-
-  if (baseUrl === resolveHref.memoizedUrl && resolveHref.cache && resolveHref.cache[href]) {
-    return resolveHref.cache[href];
-  }
-
-  // When switching protocols, the path doesn't get canonicalized (i.e. .s and ..s are still left):
-  // https://github.com/joyent/node/issues/5453
-  var intermediate = url.resolve(baseUrl, href);
-
-  // This canonicalizes the path, at the cost of overwriting the hash.
-  var nextStep = url.resolve(intermediate, "#");
-
-  // But it breaks file URLs by removing their colon O_o, so put that back.
-  nextStep = nextStep.replace(/^file:\/\/([a-z])\//i, "file:///$1:/");
-
-  // So, insert the hash back in, if there was one.
-  var parsed = url.parse(intermediate);
-  var fixed = nextStep.slice(0, -1) + (parsed.hash || "");
-
-  // Finally, fix file:/// URLs on Windows, where Node removes their drive letters:
-  // https://github.com/joyent/node/issues/5452
-  if (/^file\:\/\/\/[a-z]\:\//i.test(baseUrl) && /^file\:\/\/\//.test(fixed) &&
-      !/^file\:\/\/\/[a-z]\:\//i.test(fixed)) {
-    fixed = fixed.replace(/^file\:\/\/\//, baseUrl.substring(0, 11));
-  }
-
-  // HORRIBLE HACK: encode \u00E4 correctly just so that we pass
-  // https://github.com/w3c/web-platform-tests/blob/e75f01a689a3481f5c773315c2c2527712cf8c2c/dom/nodes/DOMImplementation-createHTMLDocument.html#L71-L72
-  // Eventually we should replace this with a real URL parser based on the URL standard.
-  fixed = fixed.replace(/\u00E4/, "%C3%A4");
-
-  if (baseUrl !== resolveHref.memoizedUrl) {
-    resolveHref.memoizedUrl = baseUrl;
-    resolveHref.cache = {};
-  }
-  resolveHref.cache[href] = fixed;
-
-  return fixed;
 };
 
 exports.mapper = function (parent, filter, recursive) {
@@ -252,14 +200,14 @@ exports.mapper = function (parent, filter, recursive) {
   };
 };
 
-// TODO URL: be more rigorous (update when whatwg-url is merged)
 function isValidAbsoluteURL(str) {
-  var parsedURL = url.parse(str);
-  return (
-    parsedURL.protocol !== null &&
-    parsedURL.host !== null &&
-    parsedURL.path !== null
-  );
+  try {
+    new URL(str); // jshint ignore:line
+    // if we can parse it, it's a valid absolute URL
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 exports.isValidTargetOrigin = function (str) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "request": "^2.55.0",
     "symbol-tree": ">= 3.1.0 < 4.0.0",
     "tough-cookie": "^1.1.0",
+    "whatwg-url-compat": "~0.6.0",
     "xml-name-validator": ">= 2.0.1 < 3.0.0",
     "xmlhttprequest": ">= 1.6.0 < 2.0.0",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "portfinder": "0.4.0",
     "q": "^1.2.0",
     "selenium-standalone": "^4.4.0",
-    "urlmaster": "0.2.15",
     "wd": "0.3.11"
   },
   "browser": {

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -60,7 +60,7 @@ exports.tests = {
     var jQueryFile = path.resolve(__dirname, '../jquery-fixtures/jquery-1.4.4.js');
 
     test.expect(6);
-    jsdom.jQueryify(tmpWindow(), jQueryFile, function(window, jQuery) {
+    jsdom.jQueryify(tmpWindow(), 'file:' + jQueryFile, function(window, jQuery) {
       testFunction(test, window, jQuery, true);
       test.done();
     });
@@ -88,7 +88,7 @@ exports.tests = {
   jquerify_attribute_selector_gh_400: function(test) {
     var window = jsdom.jsdom().defaultView;
 
-    jsdom.jQueryify(window, path.resolve(__dirname, '../jquery-fixtures/jquery-1.11.0.js'), function () {
+    jsdom.jQueryify(window, 'file:' + path.resolve(__dirname, '../jquery-fixtures/jquery-1.11.0.js'), function () {
       try {
           window.$("body").append('<html><body><div data-foo="bar"/><div data-baz="foo"/></body></html>');
 
@@ -846,7 +846,7 @@ exports.tests = {
 
   fix_for_issue_172 : function(test) {
     jsdom.env("<html><body><script type='text/javascript'></script></body></html>", [
-      path.resolve(__dirname, '../jquery-fixtures/jquery-1.6.2.js')
+      'file:' + path.resolve(__dirname, '../jquery-fixtures/jquery-1.6.2.js')
     ], function () {
       // ensure the callback gets called!
       test.done();
@@ -977,7 +977,7 @@ exports.tests = {
   },
 
   allow_ender_to_run : function(test) {
-    jsdom.env('<a />', [__dirname + '/files/ender-qwery.js'], function(e, w) {
+    jsdom.env('<a />', ['file:' + __dirname + '/files/ender-qwery.js'], function(e, w) {
       test.ok(!e, 'no errors');
       test.ok(w.ender, 'ender exists');
       test.ok(w.$, 'window contains $');
@@ -1382,7 +1382,7 @@ exports.tests = {
   jquery_val_on_selects : function(test) {
     var window = jsdom.jsdom().defaultView;
 
-    jsdom.jQueryify(window, path.resolve(__dirname, '../jquery-fixtures/jquery-1.11.0.js'), function () {
+    jsdom.jQueryify(window, 'file:' + path.resolve(__dirname, '../jquery-fixtures/jquery-1.11.0.js'), function () {
       window.$("body").append('<html><body><select id="foo"><option value="first">f</option><option value="last">l</option></select></body></html>');
 
       test.equal(window.document.querySelector("[value='first']").selected, true, "`selected` property should be `true` for first");
@@ -1406,7 +1406,7 @@ exports.tests = {
   jquery_attr_mixed_case : function(test) {
     var window = jsdom.jsdom().defaultView;
 
-    jsdom.jQueryify(window, path.resolve(__dirname, '../jquery-fixtures/jquery-1.11.0.js'), function () {
+    jsdom.jQueryify(window, 'file:' + path.resolve(__dirname, '../jquery-fixtures/jquery-1.11.0.js'), function () {
       var $el = window.$('<div mixedcase="blah"></div>');
 
       test.equal($el.attr('mixedCase'), 'blah');
@@ -1418,7 +1418,7 @@ exports.tests = {
   "Calling show() method in jQuery 1.11.0 (GH-709)": function (t) {
     var window = jsdom.jsdom("<!DOCTYPE html><html><head></head><body></body></html>").defaultView;
 
-    jsdom.jQueryify(window, path.resolve(__dirname, "../jquery-fixtures/jquery-1.11.0.js"), function () {
+    jsdom.jQueryify(window, 'file:' + path.resolve(__dirname, "../jquery-fixtures/jquery-1.11.0.js"), function () {
       var $el = window.$("<div></div>");
 
       t.doesNotThrow(function () {
@@ -1432,7 +1432,7 @@ exports.tests = {
   "Calling show() method in jQuery 1.11.0, second case (GH-709)": function (t) {
     var window = jsdom.jsdom("<!DOCTYPE html><html><head></head><body></body></html>").defaultView;
 
-    jsdom.jQueryify(window, path.resolve(__dirname, "../jquery-fixtures/jquery-1.11.0.js"), function () {
+    jsdom.jQueryify(window, 'file:' + path.resolve(__dirname, "../jquery-fixtures/jquery-1.11.0.js"), function () {
       var $el1 = window.$("<div></div>");
       var $el2 = window.$("<span></span>");
 

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -78,7 +78,7 @@ exports.tests = {
 
   jquerify_invalid: function (test) {
     test.expect(2);
-    jsdom.jQueryify(tmpWindow(), 1, function (window, jQuery) {
+    jsdom.jQueryify(jsdom.jsdom("", { url: "http://www.example.org" }).defaultView, 1, function (window, jQuery) {
       test.strictEqual(window.jQuery, undefined);
       test.strictEqual(jQuery, undefined);
       test.done();
@@ -564,13 +564,13 @@ exports.tests = {
   </html>';
 
     function testLocal() {
-      var url = '/path/to/docroot/index.html';
+      var url = 'file:///path/to/docroot/index.html';
       var doc = jsdom.jsdom(html, {url: url});
       test.equal(um.addPathEmpty(doc.getElementById("link1").href), 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
-      test.equal(doc.getElementById("link2").href, '/local.html', 'Relative URL should be resolved');
-      test.equal(doc.getElementById("link3").href, '/path/to/docroot/local.html', 'Relative URL should be resolved');
-      test.equal(doc.getElementById("link4").href, '/path/local.html', 'Relative URL should be resolved');
-      test.equal(doc.getElementById("link5").href, '/path/to/docroot/index.html#here', 'Relative URL should be resolved');
+      test.equal(doc.getElementById("link2").href, 'file:///local.html', 'Relative URL should be resolved');
+      test.equal(doc.getElementById("link3").href, 'file:///path/to/docroot/local.html', 'Relative URL should be resolved');
+      test.equal(doc.getElementById("link4").href, 'file:///path/local.html', 'Relative URL should be resolved');
+      test.equal(doc.getElementById("link5").href, 'file:///path/to/docroot/index.html#here', 'Relative URL should be resolved');
       //test.equal(doc.getElementById("link6").href, '//prototol/avoidance.html', 'Protocol-less URL should be resolved');
     }
 
@@ -586,7 +586,7 @@ exports.tests = {
     }
 
     function testBase() {
-      var url  = 'blahblahblah-invalid',
+      var url  = 'about:blank',
       doc  = jsdom.jsdom(html, {url: url}),
       base = doc.createElement("base");
       base.href = 'http://example.com/path/to/docroot/index.html';

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -5,7 +5,6 @@ var inheritFrom = require("../../lib/jsdom/utils").inheritFrom;
 var toFileUrl = require('../util').toFileUrl(__dirname);
 var http = require("http");
 var URL = require('url');
-var um = require('urlmaster');
 
 var serializeDocument = require('../../lib/jsdom').serializeDocument;
 
@@ -566,7 +565,7 @@ exports.tests = {
     function testLocal() {
       var url = 'file:///path/to/docroot/index.html';
       var doc = jsdom.jsdom(html, {url: url});
-      test.equal(um.addPathEmpty(doc.getElementById("link1").href), 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
+      test.equal(doc.getElementById("link1").href, 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
       test.equal(doc.getElementById("link2").href, 'file:///local.html', 'Relative URL should be resolved');
       test.equal(doc.getElementById("link3").href, 'file:///path/to/docroot/local.html', 'Relative URL should be resolved');
       test.equal(doc.getElementById("link4").href, 'file:///path/local.html', 'Relative URL should be resolved');
@@ -577,7 +576,7 @@ exports.tests = {
     function testRemote() {
       var url = 'http://example.com/path/to/docroot/index.html';
       var doc = jsdom.jsdom(html, {url: url});
-      test.equal(um.addPathEmpty(doc.getElementById("link1").href), 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
+      test.equal(doc.getElementById("link1").href, 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
       test.equal(doc.getElementById("link2").href, 'http://example.com/local.html', 'Relative URL should be resolved');
       test.equal(doc.getElementById("link3").href, 'http://example.com/path/to/docroot/local.html', 'Relative URL should be resolved');
       test.equal(doc.getElementById("link4").href, 'http://example.com/path/local.html', 'Relative URL should be resolved');
@@ -591,7 +590,7 @@ exports.tests = {
       base = doc.createElement("base");
       base.href = 'http://example.com/path/to/docroot/index.html';
       doc.getElementsByTagName("head").item(0).appendChild(base);
-      test.equal(um.addPathEmpty(doc.getElementById("link1").href), 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
+      test.equal(doc.getElementById("link1").href, 'http://example.com/', 'Absolute URL should be left alone except for possible trailing slash');
       test.equal(doc.getElementById("link2").href, 'http://example.com/local.html', 'Relative URL should be resolved');
       test.equal(doc.getElementById("link3").href, 'http://example.com/path/to/docroot/local.html', 'Relative URL should be resolved');
       test.equal(doc.getElementById("link4").href, 'http://example.com/path/local.html', 'Relative URL should be resolved');
@@ -599,48 +598,9 @@ exports.tests = {
       test.equal(doc.getElementById("link6").href, 'http://example.com/protocol/avoidance.html', 'Relative URL should be resolved');
     }
 
-    function testAutomated() {
-      //  RFC resolution cases from http://tools.ietf.org/html/rfc3986#section-5.2
-      // urlmaster builds them all for us
-
-      // create a doc with all of the possible bases and all of the possible refs
-      bases = um.generateAll({ scheme: 'http', auth: 'www.why.com', path:'/a/b', query:'?foo=bar', frag:'#abc' }, true),
-      refs = um.generateAll({ scheme: 'https', auth: 'www.not.com', path:'/q/r', uery:'?when=now', frag:'#xyz' }, true);
-
-      // build html with every possible link
-      var html = '<html><head><base href=""></base></head><body>';
-      refs.forEach(function (ref, i) {
-        html += '<a href="' + ref + '" id="link' + i + '">link' + i + '</a>\n';
-      });
-      html += '</body></html>';
-      var locn = toFileUrl(__filename);
-
-      // now check each base case
-      bases.forEach(function (base, i) {
-       var doc = jsdom.jsdom(html, { url: locn });
-       var expected = um.resolveTrack(locn, base, refs);
-
-      // set up the base
-       doc.getElementsByTagName("base")[0].setAttribute("href",base);
-       refs.forEach(function (ref, j){
-          var href = doc.getElementById("link" + j).href;
-          var result = expected[j][3];
-
-          // empty path must accept href with or without a slash; see http://tools.ietf.org/html/rfc3986#section-3.3
-          // so we consistently push them towards having
-          test.equal(um.addPathEmpty(href), um.addPathEmpty(result),
-                     'locn \'' + locn + '\' base \'' + base + '\' with ref \'' +
-                     ref + '\' should resolve to \'' + result + '\' (' +
-                     um.addPathEmpty(result) + ') instead of \'' + href +
-                     '\' (' + um.addPathEmpty(href) + ')');
-        });
-      });
-    }
-
     testLocal();
     testRemote();
     testBase();
-    testAutomated();
     test.done();
   },
 

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -588,10 +588,6 @@ exports.tests = {
     var nodeList = doc.getElementsByTagName("a");
     test.equal(nodeList.length, 1, 'A size');
     test.equal(nodeList.item(0).origin, 'http://www.github.com:3020', 'a.origin');
-    var doc = load("anchor6");
-    var nodeList = doc.getElementsByTagName("a");
-    test.equal(nodeList.length, 1, 'A size');
-    test.equal(nodeList.item(0).origin, 'special://www.github.com', 'a.origin');
     var doc = load("anchor7");
     var nodeList = doc.getElementsByTagName("a");
     test.equal(nodeList.length, 1, 'A size');

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19762,6 +19762,7 @@ exports.tests = {
   },
 
   normalize_method_defined_on_string_prototype_should_not_affect_getting_attribute_properties: function (test) {
+    var oldNormalize = String.prototype.normalize;
     String.prototype.normalize = function () {
       return "masked alt";
     };
@@ -19771,12 +19772,13 @@ exports.tests = {
     test.strictEqual(img.alt, "alt", "<img> elements should not have their attribute properties masked by defining " +
       "a normalize method on string instances");
 
-    delete String.prototype.normalize;
+    String.prototype.normalize = oldNormalize;
     test.done();
   },
 
 
   normalize_method_defined_on_string_prototype_should_not_affect_setting_attribute_properties: function (test) {
+    var oldNormalize = String.prototype.normalize;
     String.prototype.normalize = function () {
       return "masked action";
     };
@@ -19787,7 +19789,7 @@ exports.tests = {
     test.strictEqual(form.action, "test.html", "<form> elements should not have their attribute properties masked " +
       "by defining a normalize method on string instances when removing empty attributes");
 
-    delete String.prototype.normalize;
+    String.prototype.normalize = oldNormalize;
     test.done();
   },
 

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19796,7 +19796,7 @@ exports.tests = {
   filename_with_spaces_in_script_tag_can_be_read: function(test) {
     jsdom.env(
       '<html><head></head><body></body></html>',
-      [path.resolve(__dirname, './html/files/js/script with spaces.js')],
+      ['file:' + path.resolve(__dirname, './html/files/js/script with spaces.js')],
       function(err, window){
         test.strictEqual(err, null, "There should be no errors when using scripts with spaces in their filenames");
         test.done();

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -135,7 +135,7 @@ exports.tests = {
     var doc = jsdom.jsdom("<html><head><style>div{display:none}</style></head>" +
                           "<body><div></div></body></html>");
     var win = doc.defaultView;
-    jsdom.jQueryify(win, path.resolve(__dirname, "../jquery-fixtures/jquery-1.11.0.js"),
+    jsdom.jQueryify(win, "file:" + path.resolve(__dirname, "../jquery-fixtures/jquery-1.11.0.js"),
                     function (window, jQuery) {
       var div = jQuery("div");
       var cs = win.getComputedStyle(div.get(0));

--- a/test/misc/url.js
+++ b/test/misc/url.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var jsdom = require("../..");
+
+exports["URL should exist and work in initialized Window"] = function (t) {
+  var window = jsdom.jsdom().defaultView;
+  t.ok(window.URL, "URL exists");
+
+  var url = new window.URL("http://example.com");
+  t.strictEqual(url.hostname, "example.com");
+
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -65,6 +65,8 @@ var files = [
   "living-html/on-error.js",
   "living-html/post-message.js",
 
+  "misc/url.js",
+
   "window/history.js",
   "window/script.js",
   "window/console.js",

--- a/test/sizzle/index.js
+++ b/test/sizzle/index.js
@@ -10,8 +10,8 @@ function test(fn) {
     jsdom.env({
       html: testFile,
       scripts: [
-        path.resolve(__dirname, '../jquery-fixtures/jquery-1.8.3.js'),
-        path.resolve(__dirname, 'files/sizzle.js')
+        'file:' + path.resolve(__dirname, '../jquery-fixtures/jquery-1.8.3.js'),
+        'file:' + path.resolve(__dirname, 'files/sizzle.js')
       ],
       done: function(e, window) {
 

--- a/test/w3c/w3ctest.js
+++ b/test/w3c/w3ctest.js
@@ -4,10 +4,10 @@ var fs = require("fs");
 var path = require("path");
 var request = require("request");
 var jsdom = require("../..");
-var resolveHref = require("../../lib/jsdom/utils").resolveHref;
+var toFileUrl = require("../../lib/jsdom/utils").toFileUrl;
 
 function createJsdom(source, url, t) {
-  const reporterHref = resolveHref(__dirname, "w3c/tests/resources/testharnessreport.js");
+  const reporterHref = toFileUrl(__dirname + "/tests/resources/testharnessreport.js");
 
   jsdom.env({
     html: source,
@@ -74,7 +74,7 @@ function testUrl(url, t) {
       });
     } else {
       file = file.replace(/\/resources\//gi, __dirname + "/tests/resources/");
-      createJsdom(file, path.resolve(__dirname, "tests", url), t);
+      createJsdom(file, "file:" + path.resolve(__dirname, "tests", url), t);
     }
   });
 }

--- a/test/window/history.js
+++ b/test/window/history.js
@@ -13,9 +13,7 @@ exports["a default window should have a history object with correct default valu
 };
 
 exports["the history object should update correctly when calling pushState/replaceState"] = function (t) {
-  var window = jsdom("", {
-    url: "http://www.example.org/"
-  }).defaultView;
+  var window = jsdom("", { url: "http://www.example.org/" }).defaultView;
 
   window.addEventListener("popstate", function () {
     t.fail("popstate should not fire as a result of a pushState() or replaceState() call");
@@ -50,7 +48,7 @@ exports["the history object should update correctly when calling pushState/repla
 };
 
 exports["the history object should update correctly when calling forward/back/go"] = function (t) {
-  var window = jsdom().defaultView;
+  var window = jsdom("", { url: "http://www.example.org/" }).defaultView;
   var initialPath = window.location.pathname;
 
   [
@@ -102,7 +100,7 @@ exports["the history object should update correctly when calling forward/back/go
 };
 
 exports["the history object should update correctly when calling pushState with index behind length"] = function (t) {
-  var window = jsdom().defaultView;
+  var window = jsdom("", { url: "http://www.example.org/" }).defaultView;
 
   [
     [{ foo: "bar" }, "title 1", "/bar"],
@@ -133,7 +131,7 @@ exports["the history object should update correctly when calling pushState with 
 };
 
 exports["the history object should fire popstate on the window while navigating the history"] = function (t) {
-  var window = jsdom().defaultView;
+  var window = jsdom("", { url: "http://www.example.org/" }).defaultView;
 
   var eventFired = false;
   var state = { foo: "bar" };

--- a/test/window/script.js
+++ b/test/window/script.js
@@ -2,7 +2,7 @@ var jsdom = require('../../lib/jsdom'),
     path = require('path'),
     fs = require('fs'),
     http = require('http'),
-    jQueryPath = path.resolve(__dirname, '../jquery-fixtures/jquery-1.4.2.js');
+    jQueryPath = 'file:' + path.resolve(__dirname, '../jquery-fixtures/jquery-1.4.2.js');
 
 exports.tests = {
   scripts_share_a_global_context: function(test) {
@@ -120,7 +120,7 @@ exports.tests = {
 
   // see: https://github.com/tmpvar/jsdom/issues/163
   issue_163 : function(test) {
-    jsdom.env('<a />', [__dirname + '/files/163.js'], function(errors, window) {
+    jsdom.env('<a />', ['file:' + __dirname + '/files/163.js'], function(errors, window) {
       test.ok(!errors, 'no errors');
       test.ok(window.hasNativeObjects === true, 'window has the expected properties');
       test.done();
@@ -129,7 +129,7 @@ exports.tests = {
 
   // see: https://github.com/tmpvar/jsdom/issues/179
   issue_179 : function(test) {
-    jsdom.env('<a />', [__dirname + '/files/179.js'], function(errors, window) {
+    jsdom.env('<a />', ['file:' + __dirname + '/files/179.js'], function(errors, window) {
       test.ok(!errors, 'no errors');
       test.ok(window.b === 42, 'local var gets hung off of the window');
       test.ok(window.exposed === 42, 'read local var from window and exposed it');
@@ -185,7 +185,7 @@ exports.tests = {
   },
 
   timer_executes_in_context : function (test) {
-    jsdom.env('<a />', [__dirname + '/files/timer_in_context.js'], function (errors, window) {
+    jsdom.env('<a />', ['file:' + __dirname + '/files/timer_in_context.js'], function (errors, window) {
       setTimeout(function () {
         test.ok(window.x == 1);
         test.done();

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -46,6 +46,7 @@ self.onmessage = function (e) {
     "living-html/post-message.js": require("../test/living-html/post-message.js"), // ok
     "living-html/on-error.js": require("../test/living-html/on-error.js"), // ok
     "living-html/navigator.js": require("../test/living-html/navigator.js"), // ok
+    "misc/url.js": require("../test/misc/url.js"), // ok
 
     "window/history": require("../test/window/history"), // ok
     "window/script": require("../test/window/script"), // 0/10
@@ -92,6 +93,8 @@ self.onmessage = function (e) {
     "living-html/navigator.js",
     "living-html/on-error.js",
     "living-html/post-message.js",
+
+    "misc/url.js",
 
     "window/history",
     "window/console",


### PR DESCRIPTION
I was working with JSDom and ran into some behavior with `myAnchorTag.pathname` that I thought was unexpected. Let me show an example:

```js
global.jsdom = require('jsdom').jsdom;
global.document = jsdom('<html><head><script></script></head><body></body></html>');
global.window = global.document.parentWindow;
global.navigator = window.navigator = { userAgent: 'JSDom', appVersion: '' };

var a = document.createElement('a');

a.href = "uri/what/pls";
a.pathname;
// /what/pls

a.href = "/uri/what/pls";
a.pathname;
// /uri/what/pls
```

Is it unexpected that the pathname always strips the first part of the path when it is relative + no leading slash? Or am I missing something obvious here? :open_mouth: 