### PR TITLE
Bug in doctype parsing

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -158,7 +158,14 @@ function setChild(parent, node) {
         var data = node.data.slice(node.name.length + 1, -1);
         newNode = currentDocument.createProcessingInstruction(node.name.substring(1), data);
       } else if (node.name.toLowerCase() === '!doctype') {
-        newNode = parseDocType(currentDocument, '<' + node.data + '>');
+        if (node['x-name'] !== undefined) { // parse5 supports doctypes directly
+          newNode = currentDocument.implementation.createDocumentType(
+            node['x-name'] || '',
+            node['x-publicId'] || '',
+            node['x-systemId'] || '');
+        } else {
+          newNode = parseDocType(currentDocument, '<' + node.data + '>');
+        }
       }
     break;
 

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -324,3 +324,12 @@ exports["<template> with whitespace inside (GH-1004)"] = function (t) {
   t.equal(doc.documentElement.innerHTML, "<head><template>    <div></div>    </template></head><body></body>");
   t.done();
 };
+
+exports["doctype parsing should work for simple cases (GH-1066)"] = function (t) {
+  var doc = jsdom("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">");
+
+  t.strictEqual(doc.doctype.name, "html");
+  t.strictEqual(doc.doctype.systemId, "");
+  t.strictEqual(doc.doctype.publicId, "-//W3C//DTD HTML 4.01 Transitional//EN");
+  t.done();
+};


### PR DESCRIPTION
JSDOM 3.0 started implementing DocumentType as per the spec and return the correct type when queried using document.doctype. However, there's a bug in the parsing code and simple doctypes of the form '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">' aren't getting properly parsed.

As a result there's no way for application to implement their own doc type parsing (which I used to do for 2.0) or get correct values from JSDOM.