### PR TITLE
Add HTMLUnknownElement

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -402,7 +402,21 @@ core.HTMLDocument = function HTMLDocument(options) {
   this.implementation._addFeature('xml'   , '2.0');
 };
 
+var nonInheritedTags = new Set([
+  'article', 'section', 'nav', 'aside', 'hgroup', 'header', 'footer', 'address', 'dt',
+  'dd', 'figure', 'figcaption', 'main', 'em', 'strong', 'small', 's', 'cite', 'dfn', 'abbr',
+  'ruby', 'rt', 'rp', 'code', 'var', 'samp', 'kbd', 'i', 'b', 'u', 'mark', 'bdi', 'bdo', 'wbr'
+]);
+
 inheritFrom(core.Document, core.HTMLDocument, {
+  _defaultElementBuilder: function (document, tagName) {
+    if (nonInheritedTags.has(tagName.toLowerCase())) {
+      return new core.HTMLElement(document, tagName);
+    } else {
+      return new core.HTMLUnknownElement(document, tagName);
+    }
+  },
+
   _referrer : "",
   get referrer() {
     return this._referrer || '';
@@ -586,9 +600,9 @@ define('HTMLElement', {
   ]
 });
 
-core.Document.prototype._defaultElementBuilder = function(document, tagName) {
-  return new core.HTMLElement(document, tagName);
-};
+define('HTMLUnknownElement', {
+  // no additional properties & attributes
+});
 
 // http://www.whatwg.org/specs/web-apps/current-work/#category-listed
 var listedElements = /button|fieldset|input|keygen|object|select|textarea/i;

--- a/test/living-html/htmlelement.js
+++ b/test/living-html/htmlelement.js
@@ -1,0 +1,69 @@
+﻿"use strict";
+
+var jsdom = require("../..");
+
+var nonInheritedTags = [
+  "article", "section", "nav", "aside", "hgroup", "header", "footer", "address", "dt",
+  "dd", "figure", "figcaption", "main", "em", "strong", "small", "s", "cite", "abbr",
+  "code", "i", "b", "u"
+];
+
+exports["unknown elements should return HTMLUnknownElement"] = function (t) {
+  t.expect(4);
+
+  var doc = jsdom.jsdom();
+
+  var el = doc.createElement("foobar");
+  t.ok(el.constructor === doc.defaultView.HTMLUnknownElement,
+    "unknown element should inherit from HTMLUnknownElement (createElement)");
+  t.ok(el instanceof doc.defaultView.HTMLElement,
+    "unknown element should inherit from HTMLElement too (createElement)");
+
+  doc = jsdom.jsdom("<foobar>");
+  el = doc.body.firstChild;
+  t.ok(el.constructor === doc.defaultView.HTMLUnknownElement,
+    "unknown element should inherit from HTMLUnknownElement (parsing)");
+  t.ok(el instanceof doc.defaultView.HTMLElement,
+    "unknown element should inherit from HTMLElement too (parsing)");
+
+  t.done();
+};
+
+exports["other elements should have their respective types"] = function (t) {
+  t.expect(4);
+
+  var doc = jsdom.jsdom();
+
+  var el = doc.createElement("div");
+  t.ok(el.constructor === doc.defaultView.HTMLDivElement,
+    "div element should inherit from HTMLDivElement (createElement)");
+  t.ok(el instanceof doc.defaultView.HTMLElement,
+    "div element should inherit from HTMLElement too (createElement)");
+
+  doc = jsdom.jsdom("<div>");
+  el = doc.body.firstChild;
+  t.ok(el.constructor === doc.defaultView.HTMLDivElement,
+    "div element should inherit from HTMLDivElement (parsing)");
+  t.ok(el instanceof doc.defaultView.HTMLElement,
+    "div element should inherit from HTMLElement too (parsing)");
+
+  t.done();
+};
+
+exports["non-inherited elements should have the HTMLElement type"] = function (t) {
+  t.expect(2 * nonInheritedTags.length);
+
+  for (var i = 0; i < nonInheritedTags.length; ++i) {
+    var doc = jsdom.jsdom("<" + nonInheritedTags[i] + ">");
+    var el = doc.body.firstChild;
+    t.ok(el.constructor === doc.defaultView.HTMLElement,
+      nonInheritedTags[i] + " element should be a HTMLElement (parsing)");
+
+    el = doc.createElement(nonInheritedTags[i]);
+    t.ok(el.constructor === doc.defaultView.HTMLElement,
+      nonInheritedTags[i] + " element should be a HTMLElement (createElement)");
+
+  }
+
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -46,6 +46,7 @@ var files = [
   "living-dom/query-selector-all.js",
 
   "living-html/focus.js",
+  "living-html/htmlelement.js",
   "living-html/htmlinputelement.js",
   "living-html/htmloptionelement.js",
   "living-html/htmltextareaelement.js",

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -35,6 +35,8 @@ self.onmessage = function (e) {
     "living-dom/event-target.js": require("../test/living-dom/event-target.js"), // ok
     "living-dom/node-contains.js": require("../test/living-dom/node-contains.js"), // 0/20
     "living-dom/node-parent-element.js": require("../test/living-dom/node-parent-element.js"), // 0/11
+
+    "living-html/htmlelement.js": require("../test/living-html/htmlelement.js"), // ok
     "living-html/location.js": require("../test/living-html/location.js"), // ok
     "living-html/navigator.js": require("../test/living-html/navigator.js"), // ok
 


### PR DESCRIPTION
All elements with unrecognized tags are created with HTMLUnknownElement instead of HTMLElement.
Also changed this to only occur on HTMLDocument since we need to start to split these up properly.