### PR TITLE
Iframes are not cleaned up after the node DOMs are removed

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -7,7 +7,6 @@ var dom = require("../level1/core");
 var NOT_IMPLEMENTED = require("./utils").NOT_IMPLEMENTED;
 var History = require("./history");
 var VirtualConsole = require("../virtual-console");
-var defineGetter = require("../utils").defineGetter;
 var define = require("../utils").define;
 var inherits = require("../utils").inheritFrom;
 var EventTarget = require("../events/EventTarget");
@@ -230,14 +229,6 @@ function Window(options) {
     });
 
     return cs;
-  };
-
-  this._frame = function (name, frame) {
-    if (frame === undefined) {
-      delete window[name];
-    } else {
-      defineGetter(window, name, function () { return frame.contentWindow; });
-    }
   };
 
   ///// PUBLIC DATA PROPERTIES (TODO: should be getters)

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -555,11 +555,13 @@ core.Node.prototype = {
       }
 
       newChild._parentNode = this;
+
+      this._modified();
+
       if (this._attached && newChild._attach) {
         newChild._attach();
       }
 
-      this._modified();
       this._descendantAdded(this, newChild);
     }
 

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -2049,11 +2049,11 @@ function loadFrame (frame) {
 }
 
 function refreshAccessors(document) {
-  var window = document.defaultView;
+  var window = document._defaultView;
   var frames = document.querySelectorAll("iframe,frame");
 
   // delete accessors for all frames
-  for (var i = 0; i < window.length; ++i) {
+  for (var i = 0; i < window._length; ++i) {
     delete window[i];
   }
 
@@ -2063,81 +2063,47 @@ function refreshAccessors(document) {
   });
 }
 
+function refreshNameAccessor(frame) {
+  var name = frame.getAttribute("name");
+  // https://html.spec.whatwg.org/multipage/browsers.html#named-access-on-the-window-object:supported-property-names
+  if (name !== null && name !== "") {
+    // I do not know why this only works with _global and not with _defaultView :(
+    var window = frame._ownerDocument._global;
+    delete window[name];
+
+    if (isInDocument(frame)) {
+      defineGetter(window, name, function () { return frame.contentWindow; });
+    }
+  }
+}
+
+function isInDocument(el) {
+  var document = el._ownerDocument;
+
+  var current = el;
+  while ((current = current._parentNode)) {
+    if (current === document) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 define('HTMLFrameElement', {
   tagName: 'FRAME',
-  init : function () {
-    // Set up the frames array.  window.frames really just returns a reference
-    // to the window object, so the frames array is just implemented as indexes
-    // on the window.
-    var parent = this._ownerDocument.defaultView;
-    var self = this;
-
-    // The contentDocument/contentWindow shouldn't be created until the frame
-    // is inserted:
-    // "When an iframe element is first inserted into a document, the user
-    //  agent must create a nested browsing context, and then process the
-    //  iframe attributes for the first time."
-    //  (http://www.whatwg.org/specs/web-apps/current-work/#the-iframe-element)
-    this._initInsertListener = function () {
-      loadFrame(self);
-
-      refreshAccessors(self._ownerDocument);
-
-      var name = self.getAttribute("name");
-      if (name) {
-        defineGetter(parent, name, function () {
-          return self.contentWindow;
-        });
-      }
-    };
-
-    this.addEventListener('DOMNodeInsertedIntoDocument', this._initInsertListener, false);
-  },
   proto: {
-    _attrModified: function(name, value, oldVal) {
+    _attrModified: function (name, value, oldVal) {
       core.HTMLElement.prototype._attrModified.call(this, name, value, oldVal);
-      var self = this;
-      var parent = this._ownerDocument.defaultView;
       if (name === 'name') {
-        // Remove named frame access.
         if (oldVal) {
-          parent._frame(oldVal);
+          // I do not know why this only works with _global and not with _defaultView :(
+          delete this._ownerDocument._global[oldVal];
         }
-        // Set up named frame access.
-        if (value) {
-          parent._frame(value, this);
-        }
+        refreshNameAccessor(this);
       } else if (name === 'src') {
-        // Page we don't fetch the page until the node is inserted. This at
-        // least seems to be the way Chrome does it.
-        if (!this._attachedToDocument) {
-          if (!this._waitingOnInsert) {
-            // First, remove the listener added in 'init'.
-            this.removeEventListener('DOMNodeInsertedIntoDocument',
-                                     this._initInsertListener, false)
-
-            // If we aren't already waiting on an insert, add a listener.
-            // This guards against src being set multiple times before the frame
-            // is inserted into the document - we don't want to register multiple
-            // callbacks.
-            this.addEventListener('DOMNodeInsertedIntoDocument', function loader () {
-              self.removeEventListener('DOMNodeInsertedIntoDocument', loader, false);
-              this._waitingOnInsert = false;
-              loadFrame(self);
-
-              refreshAccessors(self._ownerDocument);
-
-              var name = self.getAttribute("name");
-              if (name) {
-                defineGetter(parent, name, function () {
-                  return self.contentWindow;
-                });
-              }
-            }, false);
-            this._waitingOnInsert = true;
-          }
-        } else {
-          loadFrame(self);
+        if (isInDocument(this)) {
+          loadFrame(this);
         }
       }
     },
@@ -2145,19 +2111,20 @@ define('HTMLFrameElement', {
     _detach: function () {
       core.HTMLElement.prototype._detach.call(this);
 
-      var self = this;
-      var parent = this._ownerDocument.defaultView;
-
-      if (self.contentWindow) {
-        self.contentWindow.close();
+      if (this.contentWindow) {
+        this.contentWindow.close();
       }
 
-      // delete frame reference
-      if (self.getAttribute("name")) {
-        parent._frame(self.getAttribute("name"));
-      }
+      refreshAccessors(this._ownerDocument);
+      refreshNameAccessor(this);
+    },
 
-      refreshAccessors(self._ownerDocument);
+    _attach: function () {
+      core.HTMLElement.prototype._attach.call(this);
+
+      loadFrame(this);
+      refreshAccessors(this._ownerDocument);
+      refreshNameAccessor(this);
     },
 
     _contentDocument : null,

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -2048,6 +2048,21 @@ function loadFrame (frame) {
   }
 }
 
+function refreshAccessors(document) {
+  var window = document.defaultView;
+  var frames = document.querySelectorAll("iframe,frame");
+
+  // delete accessors for all frames
+  for (var i = 0; i < window.length; ++i) {
+    delete window[i];
+  }
+
+  window._length = frames.length;
+  Array.prototype.forEach.call(frames, function (frame, i) {
+    defineGetter(window, i, function () { return frame.contentWindow; });
+  });
+}
+
 define('HTMLFrameElement', {
   tagName: 'FRAME',
   init : function () {
@@ -2055,11 +2070,7 @@ define('HTMLFrameElement', {
     // to the window object, so the frames array is just implemented as indexes
     // on the window.
     var parent = this._ownerDocument.defaultView;
-    var frameID = parent._length++;
     var self = this;
-    defineGetter(parent, frameID, function () {
-      return self.contentWindow;
-    });
 
     // The contentDocument/contentWindow shouldn't be created until the frame
     // is inserted:
@@ -2069,21 +2080,32 @@ define('HTMLFrameElement', {
     //  (http://www.whatwg.org/specs/web-apps/current-work/#the-iframe-element)
     this._initInsertListener = function () {
       loadFrame(self);
+
+      refreshAccessors(self._ownerDocument);
+
+      var name = self.getAttribute("name");
+      if (name) {
+        defineGetter(parent, name, function () {
+          return self.contentWindow;
+        });
+      }
     };
+
     this.addEventListener('DOMNodeInsertedIntoDocument', this._initInsertListener, false);
   },
   proto: {
     _attrModified: function(name, value, oldVal) {
       core.HTMLElement.prototype._attrModified.call(this, name, value, oldVal);
       var self = this;
+      var parent = this._ownerDocument.defaultView;
       if (name === 'name') {
         // Remove named frame access.
         if (oldVal) {
-          this._ownerDocument.defaultView._frame(oldVal);
+          parent._frame(oldVal);
         }
         // Set up named frame access.
         if (value) {
-          this._ownerDocument.defaultView._frame(value, this);
+          parent._frame(value, this);
         }
       } else if (name === 'src') {
         // Page we don't fetch the page until the node is inserted. This at
@@ -2102,6 +2124,15 @@ define('HTMLFrameElement', {
               self.removeEventListener('DOMNodeInsertedIntoDocument', loader, false);
               this._waitingOnInsert = false;
               loadFrame(self);
+
+              refreshAccessors(self._ownerDocument);
+
+              var name = self.getAttribute("name");
+              if (name) {
+                defineGetter(parent, name, function () {
+                  return self.contentWindow;
+                });
+              }
             }, false);
             this._waitingOnInsert = true;
           }
@@ -2110,6 +2141,25 @@ define('HTMLFrameElement', {
         }
       }
     },
+
+    _detach: function () {
+      core.HTMLElement.prototype._detach.call(this);
+
+      var self = this;
+      var parent = this._ownerDocument.defaultView;
+
+      if (self.contentWindow) {
+        self.contentWindow.close();
+      }
+
+      // delete frame reference
+      if (self.getAttribute("name")) {
+        parent._frame(self.getAttribute("name"));
+      }
+
+      refreshAccessors(self._ownerDocument);
+    },
+
     _contentDocument : null,
     get contentDocument() {
       if (this._contentDocument == null) {

--- a/test/window/frame.js
+++ b/test/window/frame.js
@@ -499,5 +499,28 @@ exports.tests = {
     test.strictEqual(window.foo, window[1], "foo should be second frame");
 
     test.done();
+  },
+
+  'frame should not be loaded and accessor should not exist until in document, even with a parent node': function (t) {
+    var document = jsdom.jsdom("<!doctype html>", { url: toFileUrl(__filename) });
+    var window = document.defaultView;
+
+    var frame = document.createElement("iframe");
+    frame.onload = function () {
+      t.ok(false, "onload should not be called");
+    };
+    var parentNode = document.createElement("div");
+    parentNode.appendChild(frame);
+
+    frame.src = "files/simple_iframe.html";
+    frame.setAttribute("name", "foo");
+
+    t.strictEqual(window.length, 0, "window length should be zero (no frames)");
+    t.strictEqual(window[0], undefined, "window should not have a 0 property");
+    t.strictEqual(window.foo, undefined, "window should not have a property for the iframe name");
+
+    setTimeout(function () {
+      t.done();
+    }, 1000);
   }
 };


### PR DESCRIPTION
Whenever an frame/iframe node element is created, there is a associated getter created for the parent window. However, the getter is not cleaned up when the node is removed. Also, `window.frames.length` or `window.length` doesn't change after iframes are removed.

The issue can be reproduced [here](https://gist.github.com/sylnp0201/1922dc0304998363a20d) with jsdom v3.1.2 and a simple Backbone view.