### PR TITLE
Properly implemented cookies, w3c tests fix and #1027 fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ jsdom.env(config);
 - `config.url`: sets the resulting window's `location.href`; if `config.html` and `config.file` are not provided, jsdom will load HTML from this URL.
 - `config.scripts`: see `scripts` above.
 - `config.src`: an array of JavaScript strings that will be evaluated against the resulting document. Similar to `scripts`, but it accepts JavaScript instead of paths/URLs.
-- `config.jar`: a custom cookie jar, if desired; see [mikeal/request](https://github.com/mikeal/request) documentation.
+- `config.cookieJar`: cookie jar which will be used by document and related resource requests. Can be created by `jsdom.createCookieJar()` method. Useful to share cookie state among different documents as browsers does.
 - `config.parsingMode`: either `"auto"`, `"html"`, or `"xml"`. The default is `"auto"`, which uses HTML behavior unless `config.url` responds with an XML `Content-Type`, or `config.file` contains a filename ending in `.xml` or `.xhtml`. Setting to `"xml"` will attempt to parse the document as an XHTML document. (jsdom is [currently only OK at doing that](https://github.com/tmpvar/jsdom/issues/885).)
 - `config.document`:
   - `referrer`: the new document will have this referrer.
-  - `cookie`: manually set a cookie value, e.g. `'key=value; expires=Wed, Sep 21 2011 12:00:00 GMT; path=/'`.
+  - `cookie`: manually set a cookie value, e.g. `'key=value; expires=Wed, Sep 21 2011 12:00:00 GMT; path=/'`. Accepts cookie string or array of cookie strings.
   - `cookieDomain`: a cookie domain for the manually set cookie; defaults to `127.0.0.1`.
 - `config.headers`: an object giving any headers that will be used while loading the HTML from `config.url`, if applicable
 - `config.features`: see Flexibility section below. **Note**: the default feature set for `jsdom.env` does _not_ include fetching remote JavaScript and executing it. This is something that you will need to _carefully_ enable yourself.
@@ -367,6 +367,29 @@ var doc = jsdom("<!DOCTYPE html>hello");
 
 serializeDocument(doc) === "<!DOCTYPE html><html><head></head><body>hello</body></html>";
 doc.documentElement.outerHTML === "<html><head></head><body>hello</body></html>";
+```
+
+### Sharing cookie state among pages
+
+```js
+var jsdom = require("jsdom");
+var cookieJar = jsdom.createCookieJar();
+
+jsdom.env({
+    url: 'http://google.com',
+    cookieJar: cookieJar,
+    done: function (err1, window1) {
+        //...
+
+        jsdom.env({
+            url: 'http://code.google.com',
+            cookieJar: cookieJar,
+            done: function (err2, window2) {
+                //...
+            }
+        });
+    }
+});
 ```
 
 ### Capturing Console Output

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -2,6 +2,7 @@
 var fs = require("fs");
 var path = require("path");
 var URL = require("url");
+var CookieJar = require('tough-cookie').CookieJar;
 
 var toFileUrl = require("./jsdom/utils").toFileUrl;
 var defineGetter = require("./jsdom/utils").defineGetter;
@@ -9,6 +10,8 @@ var defineSetter = require("./jsdom/utils").defineSetter;
 var features = require("./jsdom/browser/documentfeatures");
 var domToHtml = require("./jsdom/browser/domtohtml").domToHtml;
 var Window = require("./jsdom/browser/Window");
+
+require('./jsdom/living'); //Enable living standard features
 
 var canReadFilesFromFS = !!fs.readFile; // in a browserify environment, this isn"t present
 
@@ -21,6 +24,11 @@ function request() {
 exports.getVirtualConsole = function (window) {
   return window._virtualConsole;
 };
+
+exports.createCookieJar = function(){
+  return new CookieJar();
+};
+
 exports.debugMode = false;
 
 // Proxy feature functions to features module.
@@ -50,8 +58,8 @@ exports.jsdom = function (html, options) {
     parser: options.parser,
     url: options.url,
     referrer: options.referrer,
+    cookieJar: options.cookieJar,
     cookie: options.cookie,
-    cookieDomain: options.cookieDomain,
     resourceLoader: options.resourceLoader,
     deferClose: options.deferClose
   });
@@ -161,9 +169,11 @@ exports.env = exports.jsdom.env = function () {
       uri: config.url,
       encoding: config.encoding || "utf8",
       headers: config.headers || {},
-      proxy: config.proxy || null,
-      jar: config.jar !== undefined ? config.jar : true
+      proxy: config.proxy || null
     };
+
+    config.cookieJar = config.cookieJar || new CookieJar();
+    options.headers.cookie = options.headers.cookie || config.cookieJar.getCookieStringSync(config.url, { http: true });
 
     request(options, function (err, res, responseText) {
       if (err) {
@@ -181,11 +191,26 @@ exports.env = exports.jsdom.env = function () {
       config.html = responseText;
       config.url = res.request.uri.href;
 
+      var contentType = res.headers["content-type"];
+
       if (config.parsingMode === "auto" && (
-        res.headers["content-type"] === "application/xml" ||
-        res.headers["content-type"] === "text/xml" ||
-        res.headers["content-type"] === "application/xhtml+xml")) {
+        contentType === "application/xml" ||
+        contentType === "text/xml" ||
+        contentType === "application/xhtml+xml")) {
         config.parsingMode = "xml";
+      }
+
+      var cookies = res.headers["set-cookie"];
+
+      if (cookies) {
+        cookies = Array.isArray(cookies) ? cookies : [cookies];
+
+        cookies.forEach(function(cookieStr) {
+          config.cookieJar.setCookieSync(cookieStr, options.uri, {
+            http: true,
+            ignoreError: true
+          });
+        });
       }
 
       processHTML(config);
@@ -199,6 +224,7 @@ exports.serializeDocument = function (doc) {
 
 function processHTML(config) {
   var options = {
+    cookieJar: config.cookieJar,
     features: config.features,
     url: config.url,
     parser: config.parser,
@@ -210,7 +236,6 @@ function processHTML(config) {
   if (config.document) {
     options.referrer = config.document.referrer;
     options.cookie = config.document.cookie;
-    options.cookieDomain = config.document.cookieDomain;
   }
 
   var window = exports.jsdom(config.html, options).defaultView;

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -2,7 +2,7 @@
 var fs = require("fs");
 var path = require("path");
 var URL = require("url");
-var CookieJar = require('tough-cookie').CookieJar;
+var CookieJar = require("tough-cookie").CookieJar;
 
 var toFileUrl = require("./jsdom/utils").toFileUrl;
 var defineGetter = require("./jsdom/utils").defineGetter;
@@ -11,7 +11,7 @@ var features = require("./jsdom/browser/documentfeatures");
 var domToHtml = require("./jsdom/browser/domtohtml").domToHtml;
 var Window = require("./jsdom/browser/Window");
 
-require('./jsdom/living'); //Enable living standard features
+require("./jsdom/living"); //Enable living standard features
 
 var canReadFilesFromFS = !!fs.readFile; // in a browserify environment, this isn"t present
 
@@ -25,7 +25,7 @@ exports.getVirtualConsole = function (window) {
   return window._virtualConsole;
 };
 
-exports.createCookieJar = function(){
+exports.createCookieJar = function () {
   return new CookieJar();
 };
 
@@ -205,7 +205,7 @@ exports.env = exports.jsdom.env = function () {
       if (cookies) {
         cookies = Array.isArray(cookies) ? cookies : [cookies];
 
-        cookies.forEach(function(cookieStr) {
+        cookies.forEach(function (cookieStr) {
           config.cookieJar.setCookieSync(cookieStr, options.uri, {
             http: true,
             ignoreError: true

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -149,7 +149,7 @@ function Window(options) {
         xhr.setDisableHeaderCheck(false);
       }
 
-      var setReceivedCookies = function () {
+      function setReceivedCookies() {
         if (xhr.readyState === xhr.HEADERS_RECEIVED) {
           var receivedCookies = xhr.getResponseHeader("set-cookie");
 
@@ -166,7 +166,7 @@ function Window(options) {
 
           xhr.removeEventListener("readystatechange", setReceivedCookies);
         }
-      };
+      }
 
       xhr.addEventListener("readystatechange", setReceivedCookies);
       return xhr._send(data);

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -41,11 +41,11 @@ function Window(options) {
   this._document = new dom.HTMLDocument({
     parsingMode: options.parsingMode,
     contentType: options.contentType,
+    cookieJar: options.cookieJar,
     parser: options.parser,
     url: options.url,
     referrer: options.referrer,
     cookie: options.cookie,
-    cookieDomain: options.cookieDomain,
     deferClose: options.deferClose,
     resourceLoader: options.resourceLoader,
     defaultView: this._globalProxy,
@@ -140,16 +140,35 @@ function Window(options) {
     };
     xhr._send = xhr.send;
     xhr.send = function (data) {
-      if (window.document.cookie) {
-        var cookieDomain = window.document._cookieDomain;
-        var url = URL.parse(lastUrl);
-        var host = url.host.split(":")[0];
-        if (host.indexOf(cookieDomain, host.length - cookieDomain.length) !== -1) {
-          xhr.setDisableHeaderCheck(true);
-          xhr.setRequestHeader("cookie", window.document.cookie);
-          xhr.setDisableHeaderCheck(false);
-        }
+      var cookieJar = window.document._cookieJar;
+      var cookieStr = cookieJar.getCookieStringSync(lastUrl, {http: true});
+
+      if (cookieStr) {
+        xhr.setDisableHeaderCheck(true);
+        xhr.setRequestHeader("cookie", cookieStr);
+        xhr.setDisableHeaderCheck(false);
       }
+
+      var setReceivedCookies = function () {
+        if (xhr.readyState === xhr.HEADERS_RECEIVED) {
+          var receivedCookies = xhr.getResponseHeader("set-cookie");
+
+          if (receivedCookies) {
+            receivedCookies = Array.isArray(receivedCookies) ? receivedCookies : [receivedCookies];
+
+            receivedCookies.forEach(function (cookieStr) {
+              cookieJar.setCookieSync(cookieStr, lastUrl, {
+                http: true,
+                ignoreError: true
+              });
+            });
+          }
+
+          xhr.removeEventListener("readystatechange", setReceivedCookies);
+        }
+      };
+
+      xhr.addEventListener("readystatechange", setReceivedCookies);
       return xhr._send(data);
     };
     return xhr;

--- a/lib/jsdom/browser/resource-loader.js
+++ b/lib/jsdom/browser/resource-loader.js
@@ -1,0 +1,153 @@
+"use strict";
+
+var core = require("../level1/core");
+var resolveHref = require("../utils").resolveHref;
+var URL = require("url");
+var fs = require("fs");
+var request = require("request");
+
+var IS_BROWSER = Object.prototype.toString.call(process) !== "[object process]";
+
+function getDocumentBaseUrl(document) {
+  var baseElements = document.getElementsByTagName("base");
+  var baseUrl = document.URL;
+
+  if (baseElements.length > 0) {
+    var baseHref = baseElements.item(0).href;
+
+    if (baseHref) {
+      baseUrl = resolveHref(baseUrl, baseHref);
+    }
+  }
+
+  return baseUrl;
+}
+
+function createResourceLoadHandler(element, resourceUrl, document, loadCallback) {
+  return function (err, data) {
+    var ev = document.createEvent("HTMLEvents");
+
+    if (!err) {
+      try {
+        loadCallback.call(element, data, resourceUrl);
+        ev.initEvent("load", false, false);
+      }
+      catch (e) {
+        err = e;
+      }
+    }
+
+    if (err) {
+      ev.initEvent("error", false, false);
+      ev.error = err;
+    }
+
+    element.dispatchEvent(ev);
+  };
+}
+
+function readFile(url, callback) {
+  var filePath = url
+    .replace(/^file:\/\//, "")
+    .replace(/^\/([a-z]):\//i, "$1:/")
+    .replace(/%20/g, " ");
+
+  fs.readFile(filePath, "utf8", callback);
+}
+
+function download(urlObj, cookieJar, referrer, callback) {
+  var options = {
+    url: urlObj,
+    gzip: true,
+    headers: {
+      referer: referrer && !IS_BROWSER ? referrer : void 0,
+      cookie: cookieJar.getCookieStringSync(urlObj, {http: true})
+    }
+  };
+
+  request(options, function (error, response, body) {
+
+    if (!error) {
+      var cookies = response.headers["set-cookie"];
+
+      if (cookies) {
+        cookies = Array.isArray(cookies) ? cookies : [cookies];
+
+        cookies.forEach(function (cookieStr) {
+          cookieJar.setCookieSync(cookieStr, urlObj, {
+            http: true,
+            ignoreError: true
+          });
+        });
+      }
+    }
+
+    callback(error, body);
+  });
+}
+
+function fetch(urlObj, cookieJar, referrer, callback) {
+  if (urlObj.hostname) {
+    download(urlObj, cookieJar, referrer, callback);
+  } else {
+    readFile(urlObj.pathname, callback);
+  }
+}
+
+exports.enqueue = function (element, resourceUrl, callback) {
+  var document = element.nodeType === core.Node.DOCUMENT_NODE ? element : element._ownerDocument;
+
+  if (document._queue) {
+    var loadHandler = createResourceLoadHandler(element, resourceUrl || document.URL, document, callback);
+    return document._queue.push(loadHandler);
+  } else {
+    return function () { };
+  }
+};
+
+exports.resolveResourceUrl = function (document, url) {
+  // if getAttribute returns null, there is no href
+  // lets resolve to an empty string (nulls are not expected farther up)
+  if (url === null) {
+    return "";
+  }
+
+  var baseUrl = getDocumentBaseUrl(document);
+  return resolveHref(baseUrl, url);
+};
+
+exports.load = function (element, url, callback) {
+  var document = element._ownerDocument;
+  var documentImpl = document.implementation;
+
+  if (!documentImpl._hasFeature("FetchExternalResources", element.tagName.toLowerCase())) {
+    return;
+  }
+
+  // if getAttribute returns null, there is no href
+  // lets resolve to an empty string (nulls are not expected farther up)
+  var resourceUrl = exports.resolveResourceUrl(document, url);
+
+  if (documentImpl._hasFeature("SkipExternalResources", resourceUrl)) {
+    return false;
+  }
+
+  var urlObj = URL.parse(resourceUrl);
+  var baseUrl = getDocumentBaseUrl(document);
+  var cookieJar = document._cookieJar;
+  var enqueued = exports.enqueue(element, resourceUrl, callback);
+  var customLoader = document._customResourceLoader;
+
+  if (typeof customLoader === "function") {
+    customLoader.call(null, {
+      url: urlObj,
+      cookie: cookieJar.getCookieStringSync(urlObj, {http: true}),
+      baseUrl: baseUrl,
+      defaultFetch: function (callback) {
+        fetch(urlObj, cookieJar, baseUrl, callback);
+      }
+    }, enqueued);
+  } else {
+    fetch(urlObj, cookieJar, baseUrl, enqueued);
+  }
+};

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -9,6 +9,7 @@ var validateName = require('../living/helpers/validate-names').name;
 var HtmlToDom = require("../browser/htmltodom").HtmlToDom;
 var Location = require("../browser/location");
 var vm = require("vm");
+var CookieJar = require('tough-cookie').CookieJar;
 var EventTarget = require("../events/EventTarget");
 
 // utility functions
@@ -1447,6 +1448,7 @@ core.Document = function Document(options) {
   this._ids = Object.create(null);
   this._attached = true;
   this._readonly = false;
+  this._cookieJar = options.cookieJar || new CookieJar();
 
   this._contentType = options.contentType;
   if (this._contentType === undefined) {
@@ -1458,6 +1460,15 @@ core.Document = function Document(options) {
     this._URL = "about:blank";
   }
   this._location = new Location(this._URL, this);
+
+  if (options.cookie) {
+    var cookies = Array.isArray(options.cookie) ? options.cookie: [options.cookie];
+    var document = this;
+
+    cookies.forEach(function(cookieStr) {
+      document._cookieJar.setCookieSync(cookieStr, document._URL, { ignoreError : true });
+    });
+  }
 };
 
 

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1,139 +1,17 @@
-var core                  = require("../level1/core"),
+var resourceLoader        = require('../browser/resource-loader'),
+    core                  = require("../level1/core"),
     applyDocumentFeatures = require('../browser/documentfeatures').applyDocumentFeatures,
     defineGetter          = require('../utils').defineGetter,
     defineSetter          = require('../utils').defineSetter,
     inheritFrom           = require("../utils").inheritFrom,
-    resolveHref           = require("../utils").resolveHref,
     Window                = require("../browser/Window"),
     URL                   = require("url"),
-    Path                  = require('path'),
-    fs                    = require("fs"),
-    request               = require('request');
+    fs                    = require("fs");
 
-var isBrowser = Object.prototype.toString.call(process) !== "[object process]";
 
 // Setup the javascript language processor
 core.languageProcessors = {
   javascript : require("./languages/javascript").javascript
-};
-
-core.resourceLoader = {
-  load: function(element, href, callback) {
-    var ownerDoc = element._ownerDocument;
-    var ownerImplementation = ownerDoc.implementation;
-
-    if (ownerImplementation._hasFeature('FetchExternalResources', element.tagName.toLowerCase())) {
-      var full = this.resolve(ownerDoc, href);
-      var url = URL.parse(full);
-      if (ownerImplementation._hasFeature('SkipExternalResources', full)) {
-        return false;
-      }
-
-      var cookie = ownerDoc.cookie;
-      var cookieDomain = ownerDoc._cookieDomain;
-      var baseUrl = this.baseUrl(ownerDoc);
-      var enqueued = this.enqueue(element, callback, full);
-
-      if (typeof ownerDoc._resourceLoader == 'function') {
-        var fetch = this.fetch.bind(this);
-        ownerDoc._resourceLoader.call(null, {
-          url: url,
-          cookie: cookie,
-          cookieDomain: cookieDomain,
-          baseUrl: baseUrl,
-          defaultFetch: function(callback) {
-            fetch(this.url, this.cookie, this.cookieDomain, this.baseUrl, callback);
-          }
-        }, enqueued);
-      } else {
-        this.fetch(url, cookie, cookieDomain, baseUrl, enqueued);
-      }
-    }
-  },
-  enqueue: function(element, callback, filename) {
-    var loader = this,
-        doc    = element.nodeType === core.Node.DOCUMENT_NODE ?
-                 element                :
-                 element._ownerDocument;
-
-    if (!doc._queue) {
-      return function() {};
-    }
-
-    return doc._queue.push(function(err, data) {
-      var ev = doc.createEvent('HTMLEvents');
-
-      if (!err) {
-        try {
-          callback.call(element, data, filename || doc.URL);
-          ev.initEvent('load', false, false);
-        }
-        catch(e) {
-          err = e;
-        }
-      }
-
-      if (err) {
-        ev.initEvent('error', false, false);
-        ev.error = err;
-      }
-
-      element.dispatchEvent(ev);
-    });
-  },
-
-  baseUrl: function(document) {
-    var baseElements = document.getElementsByTagName('base');
-    var baseUrl = document.URL;
-
-    if (baseElements.length > 0) {
-      var baseHref = baseElements.item(0).href;
-      if (baseHref) {
-        baseUrl = resolveHref(baseUrl, baseHref);
-      }
-    }
-
-    return baseUrl;
-  },
-  resolve: function(document, href) {
-    // if getAttribute returns null, there is no href
-    // lets resolve to an empty string (nulls are not expected farther up)
-    if (href === null) {
-      return '';
-    }
-
-    var baseUrl = this.baseUrl(document);
-
-    return resolveHref(baseUrl, href);
-  },
-  fetch: function(url, cookie, cookieDomain, referrer, callback) {
-    if (url.hostname) {
-      this.download(url, cookie, cookieDomain, referrer, callback);
-    } else {
-      this.readFile(url.pathname, callback);
-    }
-  },
-  download: function(url, cookie, cookieDomain, referrer, callback) {
-    var headers = {};
-    // set header; accomodate browserify
-    if (referrer && !isBrowser) {
-        headers['Referer'] =  referrer;
-    }
-    if (cookie) {
-      var host = url.host.split(':')[0];
-      if (host.indexOf(cookieDomain, host.length - cookieDomain.length) !== -1) {
-        headers['cookie'] = cookie;
-      }
-    }
-
-    var options = {url: url, headers: headers, gzip: true};
-    request(options, function (error, response, body) {
-      callback(error, body);
-    });
-  },
-  readFile: function(url, callback) {
-    fs.readFile(url.replace(/^file:\/\//, "").replace(/^\/([a-z]):\//i, '$1:/').replace(/%20/g, ' '), 'utf8', callback);
-  }
 };
 
 function define(elementClass, def) {
@@ -346,10 +224,8 @@ ResourceQueue.prototype = {
 core.HTMLDocument = function HTMLDocument(options) {
   core.Document.call(this, options);
   this._referrer = options.referrer;
-  this._cookie = options.cookie;
-  this._cookieDomain = options.cookieDomain || '127.0.0.1';
   this._queue = new ResourceQueue(options.deferClose);
-  this._resourceLoader = options.resourceLoader;
+  this._customResourceLoader = options.resourceLoader;
   this.readyState = 'loading';
 
   // Add level2 features
@@ -423,7 +299,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
     this._queue.resume();
     // Set the readyState to 'complete' once all resources are loaded.
     // As a side-effect the document's load-event will be dispatched.
-    core.resourceLoader.enqueue(this, function() {
+    resourceLoader.enqueue(this, null, function() {
       this.readyState = 'complete';
       var ev = this.createEvent('HTMLEvents');
       ev.initEvent('DOMContentLoaded', false, false);
@@ -475,40 +351,6 @@ inheritFrom(core.Document, core.HTMLDocument, {
       body = firstChild(this.documentElement, 'FRAMESET');
     }
     return body;
-  },
-
-  _cookie : "",
-  get cookie() {
-    var cookies = Array.isArray(this._cookie) ?
-      this._cookie :
-      (this._cookie && this._cookie.length > 0 ? [this._cookie] : []);
-
-    return cookies.map(function (x) {
-      return x.split(';')[0];
-    }).join('; ');
-  },
-  set cookie(val) {
-    if (val == null) return val;
-    var key = val.split('=')[0];
-    var cookies = Array.isArray(this._cookie) ?
-      this._cookie :
-      (this._cookie && this._cookie.length > 0 ? [this._cookie] : []);
-    for (var i = 0; i < cookies.length; i++) {
-      if (cookies[i].lastIndexOf(key + '=', 0) === 0) {
-        cookies[i] = val;
-        key = null;
-        break;
-      }
-    }
-    if (key) {
-      cookies.push(val);
-    }
-    if (cookies.length === 1) {
-      this._cookie = cookies[0];
-    } else {
-      this._cookie = cookies;
-    }
-    return val;
   }
 });
 
@@ -638,7 +480,7 @@ define('HTMLLinkElement', {
   tagName: 'LINK',
   proto: {
     get href() {
-      return core.resourceLoader.resolve(this._ownerDocument, this.getAttribute('href'));
+      return resourceLoader.resolveResourceUrl(this._ownerDocument, this.getAttribute('href'));
     }
   },
   attributes: [
@@ -1431,7 +1273,7 @@ define('HTMLAnchorElement', {
 
   proto: {
     get href() {
-      return core.resourceLoader.resolve(this._ownerDocument, this.getAttribute('href'));
+      return resourceLoader.resolveResourceUrl(this._ownerDocument, this.getAttribute('href'));
     },
     get hostname() {
       return URL.parse(this.href).hostname || '';
@@ -1494,11 +1336,11 @@ define('HTMLImageElement', {
   proto: {
     _attrModified: function(name, value, oldVal) {
       if (name == 'src' && value !== oldVal) {
-        core.resourceLoader.enqueue(this, function() {})();
+        resourceLoader.enqueue(this, null, function () { })();
       }
     },
     get src() {
-      return core.resourceLoader.resolve(this._ownerDocument, this.getAttribute('src'));
+      return resourceLoader.resolveResourceUrl(this._ownerDocument, this.getAttribute('src'));
     }
   },
   attributes: [
@@ -1606,7 +1448,7 @@ define('HTMLScriptElement', {
   init: function() {
     this.addEventListener('DOMNodeInsertedIntoDocument', function() {
       if (this.src) {
-        core.resourceLoader.load(this, this.src, this._eval);
+        resourceLoader.load(this, this.src, this._eval);
       }
       else {
         var src = this.sourceLocation || {},
@@ -1617,7 +1459,7 @@ define('HTMLScriptElement', {
         }
         filename += '<script>';
 
-        core.resourceLoader.enqueue(this, this._eval, filename)(null, this.text);
+        resourceLoader.enqueue(this, filename, this._eval)(null, this.text);
       }
     });
   },
@@ -1986,10 +1828,11 @@ function loadFrame (frame) {
   // If the URL can't be resolved or the src attribute is missing / blank,
   // then url should be set to the string "about:blank".
   // (http://www.whatwg.org/specs/web-apps/current-work/#the-iframe-element)
-  var url = core.resourceLoader.resolve(parentDoc, src);
+  var url = resourceLoader.resolveResourceUrl(parentDoc, src);
   var wnd = new Window({
     parsingMode: 'html',
-    url: url
+    url: url,
+    cookieJar: parentDoc._cookieJar
   });
   var contentDoc = frame._contentDocument = wnd.document;
   applyDocumentFeatures(contentDoc, parentDoc.implementation._features);
@@ -2001,12 +1844,12 @@ function loadFrame (frame) {
 
   // Handle about:blank with a simulated load of an empty document.
   if(url === 'about:blank') {
-    core.resourceLoader.enqueue(frame, function() {
+    resourceLoader.enqueue(frame, null, function() {
       contentDoc.write();
       contentDoc.close();
     })();
   } else {
-    core.resourceLoader.load(frame, url, function(html, filename) {
+    resourceLoader.load(frame, url, function(html) {
       contentDoc.write(html);
       contentDoc.close();
     });

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -1,7 +1,7 @@
-var core = require("../level1/core"),
+var resourceLoader = require('../browser/resource-loader'),
+    core = require("../level1/core"),
     utils = require("../utils"),
     defineGetter = utils.defineGetter,
-    defineSetter = utils.defineSetter,
     inheritFrom = utils.inheritFrom,
     cssom = require("cssom"),
     cssstyle = require("cssstyle"),
@@ -95,10 +95,10 @@ defineGetter(core.Document.prototype, 'styleSheets', function() {
  * @see http://dev.w3.org/csswg/cssom/#requirements-on-user-agents-implementing0
  */
 function fetchStylesheet(url, sheet) {
-  core.resourceLoader.load(this, url, function(data, filename) {
+  resourceLoader.load(this, url, function(data) {
     // TODO: abort if the content-type is not text/css, and the document is
     // in strict mode
-    sheet.href = core.resourceLoader.resolve(this.ownerDocument, url);
+    sheet.href = resourceLoader.resolveResourceUrl(this.ownerDocument, url);
     evaluateStylesheet.call(this, data, sheet, url);
   });
 }

--- a/lib/jsdom/living/document.js
+++ b/lib/jsdom/living/document.js
@@ -1,5 +1,7 @@
 "use strict";
 var validateNames = require("./helpers/validate-names");
+var defineGetter = require("../utils").defineGetter;
+var defineSetter = require("../utils").defineSetter;
 
 module.exports = function (core) {
   core.Document.prototype.createProcessingInstruction = function (target, data) {
@@ -23,4 +25,26 @@ module.exports = function (core) {
   core.Document.prototype.createComment = function (data) {
     return new core.Comment(this, String(data));
   };
+
+  // https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie
+  defineGetter(core.Document.prototype, "cookie", function () {
+    return this._cookieJar.getCookieStringSync(this.URL, { http: false });
+  });
+
+  defineSetter(core.Document.prototype, "cookie", function (cookieStr) {
+    // NOTE: type casts follows logic that used by the Chromium: nulls are ignored,
+    // undefined is treated as the 'undefined' string, everything else - as a result of the toString() call.
+    if (cookieStr !== null) {
+      if (typeof cookieStr !== "string") {
+        cookieStr = String(cookieStr);
+      }
+
+      this._cookieJar.setCookieSync(cookieStr, this._URL, {
+        http: false,
+        ignoreError: true
+      });
+    }
+
+    return cookieStr;
+  });
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "nwmatcher": ">= 1.3.4 < 2.0.0",
     "parse5": "^1.4.2",
     "request": "^2.55.0",
+    "tough-cookie": "^0.12.1",
     "xml-name-validator": ">= 2.0.1 < 3.0.0",
     "xmlhttprequest": ">= 1.6.0 < 2.0.0"
   },

--- a/test/jsdom/env.js
+++ b/test/jsdom/env.js
@@ -489,7 +489,6 @@ exports["with configurable resource loader modifying routes and content"] = func
         t.ok(typeof resource === "object");
         t.ok(typeof resource.url === "object");
         t.equal(resource.cookie, "key=value");
-        t.equal(resource.cookieDomain, "127.0.0.1");
         t.equal(resource.baseUrl, "http://127.0.0.1:64001/html");
         t.ok(typeof resource.defaultFetch === "function");
         t.ok(typeof callback === "function");

--- a/test/jsdom/index.js
+++ b/test/jsdom/index.js
@@ -117,6 +117,7 @@ exports.tests = {
 
     // Mock response object
     var res = Object.create(EventEmitter.prototype);
+    res.setEncoding = function () {};
     res.headers = {};
 
     // Monkey patch https.request so it emits 'close' instead of 'end.

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -2471,17 +2471,20 @@ exports.tests = {
     future = new Date();
     future.setTime( future.getTime() + (24 * 60 * 60 * 1000) );
     cookie = 'key=value; expires='+future.toGMTString()+'; path=/';
-    doc = load("document", { cookie:cookie });
+    doc = load("document", {
+      url: "http://example.com",
+      cookie: cookie
+    });
     vcookie = doc.cookie;
     test.equal(vcookie, "key=value", "cookieLink");
 
-    doc = load("document");
+    doc = load("document", { url: 'http://example.com' });
     doc.cookie = "key1=value1";
     doc.cookie = "key2=value2";
     vcookie = doc.cookie;
     test.equal(vcookie, "key1=value1; key2=value2", "cookieLink");
 
-    doc = load("document");
+    doc = load("document", { url: 'http://example.com' });
     doc.cookie = "key3=value3; max-age=300";
     doc.cookie = "key4=value4; path=/";
     vcookie = doc.cookie;

--- a/test/living-html/cookie.js
+++ b/test/living-html/cookie.js
@@ -1,0 +1,309 @@
+"use strict";
+
+var http = require("http");
+var URL = require("url");
+var portfinder = require("portfinder");
+var jsdom = require("../..");
+
+var server = [];
+var testHost = null;
+
+var testCookies = [
+  "Test1=Basic; expires=Wed, 13-Jan-2051 22:23:01 GMT",
+  "Test2=PathMatch; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/TestPath",
+  "Test3=PathNotMatch; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/SomePath/",
+  "Test4=DomainMatchButPubSuffixRejected; expires=Wed, 13-Jan-2051 22:23:01 GMT; domain=127.0.0.1",
+  "Test5=DomainNotMatch; expires=Wed, 13-Jan-2051 22:23:01 GMT; domain=.example.com",
+  "Test6=HttpOnly; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/; HttpOnly",
+  "Test7=Secure; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/; Secure",
+  "Test8=Expired; expires=Wed, 13-Jan-1977 22:23:01 GMT; path=/",
+  "Test9=Duplicate; One=More; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/",
+  "Test10={\"prop1\":5,\"prop2\":\"value\"}; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/"
+];
+
+function assertCookies(t, actualCookieStr, expectedCookies) {
+  var actualCookies = actualCookieStr.split(/;\s*/);
+
+  t.strictEqual(actualCookies.length, expectedCookies.length);
+
+  expectedCookies.forEach(function (expected, i) {
+    t.strictEqual(actualCookies[i], expected);
+  });
+}
+
+exports.setUp = function (done) {
+  portfinder.getPort(function (err, port) {
+    server = http.createServer(function (req, res) {
+      switch (URL.parse(req.url).path) {
+        case "/TestPath/set-cookie-from-server":
+          res.writeHead(200, testCookies.map(function (cookieStr) {
+            return ["set-cookie", cookieStr];
+          }));
+          res.end("<body></body>");
+          break;
+
+        case "/TestPath/get-cookie-header":
+          res.end(req.headers.cookie);
+          break;
+
+        case "/TestPath/html-get-cookie-header":
+          res.end("<div class=\"cookie-header\">" + req.headers.cookie + "</div>");
+          break;
+
+        case "/TestPath/get-cookie-header-via-script":
+          res.end("window.scriptCallback('" + req.headers.cookie + "');");
+          break;
+
+        default:
+          res.end("<body></body>");
+      }
+    });
+
+    server.listen(port);
+    testHost = "http://127.0.0.1:" + port;
+    done();
+  });
+};
+
+exports.tearDown = function (done) {
+  server.close();
+  done();
+};
+
+exports["Set cookie by client"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/test-page",
+    done: function (err, window) {
+      testCookies.forEach(function (cookieStr) {
+        window.document.cookie = cookieStr;
+      });
+
+      assertCookies(t, window.document.cookie, [
+        "Test1=Basic",
+        "Test2=PathMatch",
+        "Test9=Duplicate",
+        "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+      ]);
+      t.done();
+    }
+  });
+};
+
+exports["Set cookie by page request"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/set-cookie-from-server",
+    done: function (err, window) {
+      assertCookies(t, window.document.cookie, [
+        "Test1=Basic",
+        "Test2=PathMatch",
+        "Test9=Duplicate",
+        "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+      ]);
+      t.done();
+    }
+  });
+};
+
+exports["Set cookie by resource request"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/test-page",
+    features: {
+      FetchExternalResources: ["script"]
+    },
+    done: function (err, window) {
+      var script = window.document.createElement("script");
+      script.src = testHost + "/TestPath/set-cookie-from-server";
+
+      script.onload = function () {
+        assertCookies(t, window.document.cookie, [
+          "Test1=Basic",
+          "Test2=PathMatch",
+          "Test9=Duplicate",
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        ]);
+        t.done();
+      };
+
+      window.document.documentElement.appendChild(script);
+    }
+  });
+};
+
+exports["Set cookie by XHR"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/test-page",
+    done: function (err, window) {
+      var xhr = new window.XMLHttpRequest();
+
+      xhr.onload = function () {
+        assertCookies(t, window.document.cookie, [
+          "Test1=Basic",
+          "Test2=PathMatch",
+          "Test9=Duplicate",
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        ]);
+        t.done();
+      };
+
+      xhr.open("GET", testHost + "/TestPath/set-cookie-from-server", true);
+      xhr.send();
+    }
+  });
+};
+
+exports["Send Cookies header via resource request"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/set-cookie-from-server",
+    features: {
+      FetchExternalResources: ["script"],
+      ProcessExternalResources: ["script"]
+    },
+    done: function (err, window) {
+      var script = window.document.createElement("script");
+      script.src = testHost + "/TestPath/get-cookie-header-via-script";
+
+      window.scriptCallback = function (cookiesHeader) {
+        assertCookies(t, cookiesHeader, [
+          "Test1=Basic",
+          "Test2=PathMatch",
+          "Test6=HttpOnly",
+          "Test9=Duplicate",
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        ]);
+        t.done();
+      };
+
+      window.document.documentElement.appendChild(script);
+    }
+  });
+};
+
+exports["Send Cookies header via XHR"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/set-cookie-from-server",
+    done: function (err, window) {
+      var xhr = new window.XMLHttpRequest();
+
+      xhr.onload = function () {
+        assertCookies(t, xhr.responseText, [
+          "Test1=Basic",
+          "Test2=PathMatch",
+          "Test6=HttpOnly",
+          "Test9=Duplicate",
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        ]);
+        t.done();
+      };
+
+      xhr.open("GET", testHost + "/TestPath/get-cookie-header", true);
+      xhr.send();
+    }
+  });
+};
+
+exports["Share cookies with <iframe>"] = function (t) {
+  jsdom.env({
+    url: testHost + "/TestPath/set-cookie-from-server",
+    features: {
+      FetchExternalResources: ["script", "iframe"],
+      ProcessExternalResources: ["script"]
+    },
+    done: function (err, window) {
+      var iframe = window.document.createElement("iframe");
+      iframe.src = testHost + "/TestPath/iframe-content";
+
+      iframe.onload = function () {
+        assertCookies(t, iframe.contentWindow.document.cookie, [
+          "Test1=Basic",
+          "Test2=PathMatch",
+          "Test9=Duplicate",
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        ]);
+        t.done();
+      };
+
+      window.document.documentElement.appendChild(iframe);
+    }
+  });
+};
+
+
+exports["options.document.cookie"] = function (t) {
+  jsdom.env({
+    html: "<body></body>",
+    url: "https://127.0.0.1/TestPath/set-cookie-from-server",
+    document: {
+      cookie: [
+        "OptionsTest=FooBar; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/TestPath; HttpOnly",
+        "SecureAliasUrlTest=Baz; Secure"
+      ]
+    },
+    done: function (err, window) {
+      assertCookies(t, window.document.cookie, ["SecureAliasUrlTest=Baz"]);
+
+      var xhr = new window.XMLHttpRequest();
+
+      xhr.onload = function () {
+        assertCookies(t, xhr.responseText, ["OptionsTest=FooBar"]);
+        t.done();
+      };
+
+      xhr.open("GET", testHost + "/TestPath/get-cookie-header", true);
+      xhr.send();
+    }
+  });
+};
+
+exports["options.cookieJar"] = function (t) {
+  var cookieJar = jsdom.createCookieJar();
+
+  jsdom.env({
+    url: testHost + "/TestPath/set-cookie-from-server",
+    cookieJar: cookieJar,
+    done: function () {
+      jsdom.env({
+        url: testHost + "/TestPath/html-get-cookie-header",
+        cookieJar: cookieJar,
+        done: function (err, window) {
+          var cookieHeader = window.document.querySelector(".cookie-header").innerHTML;
+
+          assertCookies(t, cookieHeader, [
+            "Test1=Basic",
+            "Test2=PathMatch",
+            "Test6=HttpOnly",
+            "Test9=Duplicate",
+            "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          ]);
+
+          assertCookies(t, window.document.cookie, [
+            "Test1=Basic",
+            "Test2=PathMatch",
+            "Test9=Duplicate",
+            "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          ]);
+
+          t.done();
+        }
+      });
+    }
+  });
+};
+
+exports["Regression: Expired cookie is still present in document.cookie(GH-1027)"] = function (t) {
+  jsdom.env({
+    html: "<body></body>",
+    done: function (err, window) {
+      var timeNow = new Date().getTime();
+
+      var expiredDate = new Date(timeNow - 24 * 60 * 60 * 1000);
+      window.document.cookie = "ExpiredCookie=FooBar; Expires=" + expiredDate.toGMTString();
+
+      var futureDate = new Date(timeNow + 24 * 60 * 60 * 1000);
+      window.document.cookie = "Test=FooBar; Expires=" + futureDate.toGMTString();
+
+      t.strictEqual(window.document.cookie, "Test=FooBar");
+      t.done();
+    }
+  });
+};
+

--- a/test/runner
+++ b/test/runner
@@ -44,7 +44,7 @@ var files = [
   "living-dom/node-parent-element.js",
   "living-dom/query-selector.js",
   "living-dom/query-selector-all.js",
-
+  "living-html/cookie.js",
   "living-html/focus.js",
   "living-html/htmlelement.js",
   "living-html/htmlinputelement.js",


### PR DESCRIPTION
BTW, it introduces breaking change: `config.resourceLoader` doesn't receive `cookieDomain` in the arguments anymore. Because, it doesn't make sense with the current implementation.