### PR TITLE
Support the eventInit parameter on core.Event

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -25,9 +25,6 @@ core.Event = function(eventType, eventInit) {
       this._cancelable = false;
       if(eventInit.bubbles) this._bubbles = eventInit.bubbles;
       if(eventInit.cancelable) this._cancelable = eventInit.cancelable;
-
-      console.log(this._cancelable);
-      console.log(this._bubbles);
     }
 };
 core.Event.prototype = {

--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -9,7 +9,7 @@ var core = require("../level1/core"),
     defineSetter = utils.defineSetter,
     inheritFrom = utils.inheritFrom;
 
-core.Event = function(eventType) {
+core.Event = function(eventType, eventInit) {
     this._type = eventType || null;
     this._bubbles = null;
     this._cancelable = null;
@@ -19,6 +19,11 @@ core.Event = function(eventType) {
     this._timeStamp = null;
     this._preventDefault = false;
     this._stopPropagation = false;
+
+    if(arguments.length > 1 && eventInit) {
+      this._bubbles = eventInit.bubbles;
+      this._cancelable = eventInit.cancelable;
+    }
 };
 core.Event.prototype = {
     initEvent: function(type, bubbles, cancelable) {

--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -21,8 +21,13 @@ core.Event = function(eventType, eventInit) {
     this._stopPropagation = false;
 
     if(arguments.length > 1 && eventInit) {
-      this._bubbles = eventInit.bubbles;
-      this._cancelable = eventInit.cancelable;
+      this._bubbles = false;
+      this._cancelable = false;
+      if(eventInit.bubbles) this._bubbles = eventInit.bubbles;
+      if(eventInit.cancelable) this._cancelable = eventInit.cancelable;
+
+      console.log(this._cancelable);
+      console.log(this._bubbles);
     }
 };
 core.Event.prototype = {

--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -11,22 +11,24 @@ var core = require("../level1/core"),
 
 core.Event = function(eventType, eventInit) {
     this._type = eventType || null;
-    this._bubbles = null;
-    this._cancelable = null;
+
+    if (eventInit === undefined || eventInit === null) {
+      eventInit = {};
+    }
+    if (typeof eventInit !== "object") {
+      throw new TypeError("cannot convert eventInit argument to a dictionary");
+    }
+    this._bubbles = Boolean(eventInit.bubbles);
+    this._cancelable = Boolean(eventInit.cancelable);
+
     this._target = null;
     this._currentTarget = null;
     this._eventPhase = 0;
     this._timeStamp = null;
     this._preventDefault = false;
     this._stopPropagation = false;
-
-    if(arguments.length > 1 && eventInit) {
-      this._bubbles = false;
-      this._cancelable = false;
-      if(eventInit.bubbles) this._bubbles = eventInit.bubbles;
-      if(eventInit.cancelable) this._cancelable = eventInit.cancelable;
-    }
 };
+
 core.Event.prototype = {
     initEvent: function(type, bubbles, cancelable) {
         this._type = type;

--- a/test/level2/events.js
+++ b/test/level2/events.js
@@ -82,9 +82,21 @@ exports['create event with each event type'] = function(test){
 // @see http://www.w3.org/TR/dom/#event
 exports['event interface eventInit parameter'] = function(test){
 
+    try{
+      var event = new events.Event('myevent', "exception");
+      test.fail("only a dictionary should be passed as the second parameter");
+    }
+    catch(e){
+      test.ok((e instanceof TypeError), "should be instanceof TypeError");
+    }
+
     var event = new events.Event('myevent');
-    test.equal(event.bubbles, null);
-    test.equal(event.cancelable, null);
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, false);
+
+    event = new events.Event('myevent', null);
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, false);
 
     event = new events.Event('myevent', {bubbles: true});
     test.equal(event.bubbles, true);
@@ -101,6 +113,39 @@ exports['event interface eventInit parameter'] = function(test){
     event = new events.Event('myevent', {});
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
+
+    event = new events.Event('myevent', {bubbles: null, cancelable: null});
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, false);
+
+    event = new events.Event('myevent', {bubbles: 0, cancelable: 0});
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, false);
+
+    // values > 0 are considered true;
+    event = new events.Event('myevent', {bubbles: 1, cancelable: 1});
+    test.equal(event.bubbles, true);
+    test.equal(event.cancelable, true);
+
+    // values > 0 are considered true;
+    event = new events.Event('myevent', {bubbles: 10, cancelable: 10});
+    test.equal(event.bubbles, true);
+    test.equal(event.cancelable, true);
+
+    // empty string is considered false;
+    event = new events.Event('myevent', {bubbles: "", cancelable: ""});
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, false);
+
+    // non empty string is considered true;
+    event = new events.Event('myevent', {bubbles: "false", cancelable: "false"});
+    test.equal(event.bubbles, true);
+    test.equal(event.cancelable, true);
+
+    // non empty string is considered true;
+    event = new events.Event('myevent', {bubbles: "true", cancelable: "true"});
+    test.equal(event.bubbles, true);
+    test.equal(event.cancelable, true);
 
     test.done();
 }

--- a/test/level2/events.js
+++ b/test/level2/events.js
@@ -79,6 +79,32 @@ exports['create event with each event type'] = function(test){
   test.done();
 }
 
+// @see http://www.w3.org/TR/dom/#event
+exports['event interface eventInit parameter'] = function(test){
+
+    var event = new events.Event('myevent');
+    test.equal(event.bubbles, null);
+    test.equal(event.cancelable, null);
+
+    event = new events.Event('myevent', {bubbles: true});
+    test.equal(event.bubbles, true);
+    test.equal(event.cancelable, false);
+
+    event = new events.Event('myevent', {cancelable: true});
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, true);
+
+    event = new events.Event('myevent', {bubbles: true, cancelable: true});
+    test.equal(event.bubbles, true);
+    test.equal(event.cancelable, true);
+
+    event = new events.Event('myevent', {});
+    test.equal(event.bubbles, false);
+    test.equal(event.cancelable, false);
+
+    test.done();
+}
+
 // @author Curt Arnold
 // @see http://www.w3.org/TR/DOM-Level-2-Events/events#Events-EventTarget-dispatchEvent
 // @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-17189187


### PR DESCRIPTION
support the eventInit parameter on core.Event according to the specification here.
https://developer.mozilla.org/en-US/docs/Web/API/Event/Event

event = new Event(typeArg, eventInit);

eventInit - Optional. Is an EventInit dictionary, having the following fields:
"bubbles", optional and defaulting to false, of type Boolean, indicating if the event bubbles or not.
"cancelable", optional and defaulting to false, of type Boolean, indicating if the event can be canceled or not.