### PR TITLE
Add engines advisory for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
     "test-browser": "iojs ./test/browser-runner",
     "lint": "jshint lib/ && jshint test/"
   },
+  "engines": { 
+    "node": "^1.2.0"
+  },
   "main": "./lib/jsdom",
   "files": [
     "lib/"


### PR DESCRIPTION
This is so npm outputs at least a warning when installing jsdom on nodejs instead of iojs.

@domenic I know I said I wouldn't, but it's so small, it's okaaaaay :S