### PR TITLE
allow initEvent to be used with non-Event event constructors (#1077)

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -57,8 +57,8 @@ core.Event.prototype = {
 };
 
 
-core.UIEvent = function(eventType) {
-    core.Event.call(this, eventType);
+core.UIEvent = function(eventType, eventInit) {
+    core.Event.call(this, eventType, eventInit);
     this.view = null;
     this.detail = null;
 };
@@ -71,8 +71,8 @@ inheritFrom(core.Event, core.UIEvent, {
 });
 
 
-core.MouseEvent = function(eventType) {
-    core.UIEvent.call(this, eventType);
+core.MouseEvent = function(eventType, eventInit) {
+    core.UIEvent.call(this, eventType, eventInit);
     this.screenX = null;
     this.screenY = null;
     this.clientX = null;
@@ -115,8 +115,8 @@ inheritFrom(core.UIEvent, core.MouseEvent, {
 });
 
 
-core.MutationEvent = function(eventType) {
-    core.Event.call(this, eventType);
+core.MutationEvent = function(eventType, eventInit) {
+    core.Event.call(this, eventType, eventInit);
     this.relatedNode = null;
     this.prevValue = null;
     this.newValue = null;

--- a/test/level2/events.js
+++ b/test/level2/events.js
@@ -82,72 +82,79 @@ exports['create event with each event type'] = function(test){
 // @see https://dom.spec.whatwg.org/#interface-event
 exports['event interface eventInit parameter'] = function(test){
 
+  function testEventConstructor(Event) {
     try{
-      var event = new events.Event('myevent', "exception");
+      var event = new Event('myevent', "exception");
       test.fail("only a dictionary should be passed as the second parameter");
     }
     catch(e){
       test.ok((e instanceof TypeError), "should be instanceof TypeError");
     }
 
-    var event = new events.Event('myevent');
+    var event = new Event('myevent');
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
-    event = new events.Event('myevent', null);
+    event = new Event('myevent', null);
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
-    event = new events.Event('myevent', {bubbles: true});
+    event = new Event('myevent', {bubbles: true});
     test.equal(event.bubbles, true);
     test.equal(event.cancelable, false);
 
-    event = new events.Event('myevent', {cancelable: true});
+    event = new Event('myevent', {cancelable: true});
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, true);
 
-    event = new events.Event('myevent', {bubbles: true, cancelable: true});
+    event = new Event('myevent', {bubbles: true, cancelable: true});
     test.equal(event.bubbles, true);
     test.equal(event.cancelable, true);
 
-    event = new events.Event('myevent', {});
+    event = new Event('myevent', {});
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
-    event = new events.Event('myevent', {bubbles: null, cancelable: null});
+    event = new Event('myevent', {bubbles: null, cancelable: null});
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
-    event = new events.Event('myevent', {bubbles: 0, cancelable: 0});
+    event = new Event('myevent', {bubbles: 0, cancelable: 0});
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
     // values > 0 are considered true;
-    event = new events.Event('myevent', {bubbles: 1, cancelable: 1});
+    event = new Event('myevent', {bubbles: 1, cancelable: 1});
     test.equal(event.bubbles, true);
     test.equal(event.cancelable, true);
 
     // values > 0 are considered true;
-    event = new events.Event('myevent', {bubbles: 10, cancelable: 10});
+    event = new Event('myevent', {bubbles: 10, cancelable: 10});
     test.equal(event.bubbles, true);
     test.equal(event.cancelable, true);
 
     // empty string is considered false;
-    event = new events.Event('myevent', {bubbles: "", cancelable: ""});
+    event = new Event('myevent', {bubbles: "", cancelable: ""});
     test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
     // non empty string is considered true;
-    event = new events.Event('myevent', {bubbles: "false", cancelable: "false"});
+    event = new Event('myevent', {bubbles: "false", cancelable: "false"});
     test.equal(event.bubbles, true);
     test.equal(event.cancelable, true);
 
     // non empty string is considered true;
-    event = new events.Event('myevent', {bubbles: "true", cancelable: "true"});
+    event = new Event('myevent', {bubbles: "true", cancelable: "true"});
     test.equal(event.bubbles, true);
     test.equal(event.cancelable, true);
+  }
 
-    test.done();
+  testEventConstructor(events.Event);
+  testEventConstructor(events.UIEvent);
+  testEventConstructor(events.MouseEvent);
+  testEventConstructor(events.MutationEvent);
+
+  test.done();
 }
 
 // @author Curt Arnold


### PR DESCRIPTION
This addresses #1077, and adds tests for all the currently implemented interfaces to `Event`. First contribution to jsdom, let me know if I've missed anything, thanks!