### PR TITLE
Added defaultPrevented flag to the Event interface

### DIFF
--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -27,6 +27,8 @@ core.Event = function(eventType, eventInit) {
     this._timeStamp = null;
     this._preventDefault = false;
     this._stopPropagation = false;
+    this._defaultPrevented = false;
+    this._canceled = false;
 };
 
 core.Event.prototype = {
@@ -37,6 +39,7 @@ core.Event.prototype = {
     },
     preventDefault: function() {
         if (this._cancelable) {
+            this._canceled = true;
             this._preventDefault = true;
         }
     },
@@ -53,7 +56,8 @@ core.Event.prototype = {
     get target() { return this._target; },
     get currentTarget() { return this._currentTarget; },
     get eventPhase() { return this._eventPhase; },
-    get timeStamp() { return this._timeStamp; }
+    get timeStamp() { return this._timeStamp; },
+    get defaultPrevented() {return this._defaultPrevented; }
 };
 
 

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -565,11 +565,14 @@ define('HTMLElement', {
     dispatchEvent : function (event) {
       var outcome = core.Node.prototype.dispatchEvent.call(this, event)
 
-      if (!event._preventDefault     &&
+      if (!event._canceled &&
           event.target._eventDefaults[event.type] &&
           typeof event.target._eventDefaults[event.type] === 'function')
       {
         event.target._eventDefaults[event.type](event)
+      }
+      else if(event._canceled){
+        event._defaultPrevented = true;
       }
       return outcome;
     },
@@ -1163,11 +1166,16 @@ define('HTMLInputElement', {
       this.dispatchEvent(event);
     },
 
-    click: function() {
-      if (this.type === 'checkbox') {
-        this.checked = !this.checked;
+    _eventDefaults: {
+      click: function(event) {
+        if (event.target.type === 'checkbox') {
+          event.target.checked = !event.target.checked;
+        }
       }
-      else if (this.type === 'radio') {
+    },
+
+    click: function() {
+      if (this.type === 'radio') {
         this.checked = true;
       }
       else if (this.type === 'submit') {

--- a/test/level2/events.js
+++ b/test/level2/events.js
@@ -94,7 +94,7 @@ exports['event interface eventInit parameter'] = function (test) {
     }, TypeError);
 
     var event = new Constructor('myevent');
-    test.equal(event.bubbles, false);{}
+    test.equal(event.bubbles, false);
     test.equal(event.cancelable, false);
 
     event = new Constructor('myevent', null);
@@ -513,6 +513,20 @@ exports['prevent default'] = testcase({
   tearDown: function(cb){
     _tearDown.call(this);
     cb();
+  },
+
+  'the defaultPrevented flag is set when the event is prevented': function(test) {
+    this.title.addEventListener("foo", function(event) { event.preventDefault();}, false);
+    var return_val = this.title.dispatchEvent(this.event);
+    test.equal(this.event.defaultPrevented, true, 'the defaultPrevented flag should be true when the event is prevented');
+    test.done();
+  },
+
+  'the defaultPrevented flag is not set when the event is not prevented': function(test) {
+    this.title.addEventListener("foo", this.monitor.handleEvent, false);
+    var return_val = this.title.dispatchEvent(this.event);
+    test.equal(this.event.defaultPrevented, false, 'the defaultPrevented flag should be false when the event is not prevented');
+    test.done();
   },
 
   'a cancelable event can have its default event disabled': function(test) {

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -8956,6 +8956,31 @@ exports.tests = {
     test.done();
   },
 
+  HTMLInputElementCheckboxClickTogglesCheckedState: function(test) {
+    var doc = load("input");
+    var element = doc.querySelector("input[name='Check1']");
+    test.equal(element.checked, true);
+    element.click();
+    test.equal(element.checked, false);
+    element.click();
+    test.equal(element.checked, true);
+    test.done();
+  },
+
+  HTMLInputElementDefaultEventClickForCheckboxTogglesCheckedState: function(test) {
+    var doc = load("input");
+    var element = doc.querySelector("input[name='Check1']");
+    var clickevent = doc.createEvent("Event");
+    clickevent.initEvent("click", true, true);
+    element.dispatchEvent(clickevent);
+    test.equal(element.checked, false);
+    element.dispatchEvent(clickevent);
+    test.equal(element.checked, true);
+    element.dispatchEvent(clickevent);
+    test.equal(element.checked, false);
+    test.done();
+  },
+
   // <isindex> tests removed because it's replaced by <label> and <input> in the parser stage now
 
   /**


### PR DESCRIPTION
Support for feature defaultPrevented attribute on the Event interface was added as requested in issue https://github.com/tmpvar/jsdom/issues/989

This feature is supported by DOM living standard and can be referenced here. https://dom.spec.whatwg.org/#interface-event

Also added an event default for click on input elements of type checkbox.

Tests were added. Please code review and merge. Thank you.

