### PR TITLE
Fix `` to '' for syntax error on line 55

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -52,8 +52,8 @@ exports.jsdom = function (html, options) {
   }
 
   if (options.parsingMode !== "html" && options.parsingMode !== "xml") {
-    throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ` +
-      `"xml", "auto", or undefined`);
+    throw new RangeError('Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ' +
+      '"xml", "auto", or undefined');
   }
 
   // List options explicitly to be clear which are passed through


### PR DESCRIPTION
I am currently using node, it has the following error
```
> require('jsdom')
/Users/DarwinSenior/Desktop/CS498/final_project/node_modules/jsdom/lib/jsdom.js:55
    throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.
                         ^
SyntaxError: Unexpected token ILLEGAL
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at repl:1:1
    at REPLServer.defaultEval (repl.js:132:27)
    at bound (domain.js:254:14)
```
So, I simply changed ` to ' so that it interperpates correctly. 
This is really a minor changes, and it is solely because I could not run the code under my computer. Sorry if I am not doing it correctly. This is the first time I am doing this.