### PR TITLE
Replace backticks with single ticks

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -52,8 +52,8 @@ exports.jsdom = function (html, options) {
   }
 
   if (options.parsingMode !== "html" && options.parsingMode !== "xml") {
-    throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ` +
-      `"xml", "auto", or undefined`);
+    throw new RangeError('Invalid parsingMode option ' + JSON.stringify(options.parsingMode) + ' must be either "html", ' +
+      '"xml", "auto", or undefined');
   }
 
   // List options explicitly to be clear which are passed through


### PR DESCRIPTION
The latest release is breaking the package on node v0.12.2:

    /.../jsdom/lib/jsdom.js:55
    throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.
                                         ^
    SyntaxError: Unexpected token ILLEGAL
   


