### PR TITLE
replaced grave accents with common single quotes

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -52,8 +52,8 @@ exports.jsdom = function (html, options) {
   }
 
   if (options.parsingMode !== "html" && options.parsingMode !== "xml") {
-    throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ` +
-      `"xml", "auto", or undefined`);
+    throw new RangeError('Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ' +
+      '"xml", "auto", or undefined');
   }
 
   // List options explicitly to be clear which are passed through

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -52,8 +52,8 @@ exports.jsdom = function (html, options) {
   }
 
   if (options.parsingMode !== "html" && options.parsingMode !== "xml") {
-    throw new RangeError('Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ' +
-      '"xml", "auto", or undefined');
+    throw new RangeError("Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either \"html\", " +
+      "\"xml\", \"auto\", or undefined");
   }
 
   // List options explicitly to be clear which are passed through


### PR DESCRIPTION
Replaced it with a "normal" quote and escaped the already existing quotes. (Imho it would be better to use single quotes for strings and double quotes for actual quotes in strings, but since all strings are declared using double quotes, I adapted the code style).