### PR TITLE
Implement NodeIterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ jsdom.env(config);
 - `config.features`: see Flexibility section below. **Note**: the default feature set for `jsdom.env` does _not_ include fetching remote JavaScript and executing it. This is something that you will need to _carefully_ enable yourself.
 - `config.resourceLoader`: a function that intercepts subresource requests and allows you to re-route them, modify, or outright replace them with your own content. More below.
 - `config.done`, `config.loaded`, `config.created`: see below.
+- `config.concurrentNodeIterators`: the maximum amount of `NodeIterator`s that you can use at the same time. The default is `10`; setting this to a high value will hurt performance.
 
 Note that at least one of the callbacks (`done`, `loaded`, or `created`) is required, as is one of `html`, `file`, or `url`.
 

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -66,7 +66,8 @@ exports.jsdom = function (html, options) {
     cookieJar: options.cookieJar,
     cookie: options.cookie,
     resourceLoader: options.resourceLoader,
-    deferClose: options.deferClose
+    deferClose: options.deferClose,
+    concurrentNodeIterators: options.concurrentNodeIterators
   });
 
   if (options.created) {
@@ -242,7 +243,8 @@ function processHTML(config) {
     parser: config.parser,
     parsingMode: config.parsingMode,
     created: config.created,
-    resourceLoader: config.resourceLoader
+    resourceLoader: config.resourceLoader,
+    concurrentNodeIterators: config.concurrentNodeIterators
   };
 
   if (config.document) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -53,6 +53,7 @@ function Window(options) {
     cookie: options.cookie,
     deferClose: options.deferClose,
     resourceLoader: options.resourceLoader,
+    concurrentNodeIterators: options.concurrentNodeIterators,
     defaultView: this._globalProxy,
     global: this
   });

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -693,11 +693,16 @@ core.Node.prototype = {
       throw new core.DOMException(core.DOMException.NOT_FOUND_ERR);
     }
 
+    var oldPreviousSibling = oldChild.previousSibling;
+
     this._childNodes.splice(oldChildIndex, 1);
     oldChild._parentNode = null;
     this._modified();
     oldChild._detach();
     this._descendantRemoved(this, oldChild);
+    if (this._ownerDocument) {
+      this._ownerDocument._runRemovingSteps(oldChild, this, oldPreviousSibling);
+    }
     return oldChild;
   }, // raises(DOMException);
 
@@ -1476,6 +1481,7 @@ core.Document = function Document(options) {
   }
 };
 
+core.Document._removingSteps = [];
 
 var tagRegEx = /[^\w:\d_\.-]+/i;
 var entRegEx = /[^\w\d_\-&;]+/;
@@ -1667,6 +1673,12 @@ inheritFrom(core.Node, core.Document, {
       setInnerHTML(this, node, text);
     } else if (text) {
       setInnerHTML(this, this, text);
+    }
+  },
+  _runRemovingSteps: function(oldNode, oldParent, oldPreviousSibling) {
+    var listeners = core.Document._removingSteps;
+    for (var i = 0; i < listeners.length; ++i) {
+      listeners[i](this, oldNode, oldParent, oldPreviousSibling);
     }
   }
 });

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1479,6 +1479,19 @@ core.Document = function Document(options) {
       document._cookieJar.setCookieSync(cookieStr, document._URL, { ignoreError : true });
     });
   }
+
+  this._activeNodeIterators = [];
+  this._activeNodeIteratorsMax = options.concurrentNodeIterators === undefined ?
+                                 10 :
+                                 Number(options.concurrentNodeIterators);
+
+  if (isNaN(this._activeNodeIteratorsMax)) {
+    throw new TypeError("The 'concurrentNodeIterators' option must be a Number");
+  }
+
+  if (this._activeNodeIteratorsMax < 0) {
+    throw new RangeError("The 'concurrentNodeIterators' option must be a non negative Number");
+  }
 };
 
 core.Document._removingSteps = [];

--- a/lib/jsdom/living/helpers/traversal.js
+++ b/lib/jsdom/living/helpers/traversal.js
@@ -1,0 +1,100 @@
+"use strict";
+
+/**
+ * Find the preceding node (A) of the given node (B).
+ * An object A is preceding an object B if A and B are in the same tree
+ * and A comes before B in tree order.
+ * @param {!Node} node
+ * @param {?Node} root If set, `root` is always an inclusive ancestor
+ *        of the return value (or else null is returned). This check assumes
+ *        that `root` is also an inclusive ancestor of the given `node`
+ * @returns {?Node}
+ */
+exports.precedingNode = function (node, root) {
+  if (node === root) {
+    return null;
+  }
+
+  if (node.previousSibling) {
+    node = node.previousSibling;
+
+    while (node.lastChild) {
+      node = node.lastChild;
+    }
+    return node;
+  }
+
+  if (node.parentNode) {
+    return node.parentNode;
+  }
+
+  return null;
+};
+
+/**
+ * Find the following node (A) of the given node (B).
+ * An object A is following an object B if A and B are in the same tree
+ * and A comes after B in tree order.
+ * @param {!Node} node
+ * @param {?Node} root If set, root is always an inclusive ancestor
+ *        of the return value (or else null is returned). This check assumes
+ *        that `root` is also an inclusive ancestor of the given `node`
+ * @returns {?Node}
+ */
+exports.followingNode = function (node, root) {
+  if (node.firstChild) {
+    return node.firstChild;
+  }
+
+  do {
+    if (node === root) {
+      return null;
+    }
+
+    if (node.nextSibling) {
+      return node.nextSibling;
+    }
+
+    node = node.parentNode;
+  } while (node);
+
+  return null;
+};
+
+/**
+ * Find the following node (A) of the given node (B), but skip over any children of B.
+ * An object A is following an object B if A and B are in the same tree
+ * and A comes after B in tree order.
+ * @param {!Node} node
+ * @param {?Node} root If set, root is always an inclusive ancestor
+ *        of the return value (or else null is returned). This check assumes
+ *        that `root` is also an inclusive ancestor of the given `node`
+ * @returns {?Node}
+ */
+exports.followingNodeSkipChildren = function (node, root) {
+  do {
+    if (node === root) {
+      return null;
+    }
+
+    if (node.nextSibling) {
+      return node.nextSibling;
+    }
+
+    node = node.parentNode;
+  } while (node);
+
+  return null;
+};
+
+/** Find the last inclusive descendant in tree order of `node`
+ *
+ * @param {!Node} node
+ * @returns {?Node}
+ */
+exports.lastInclusiveDescendant = function (node) {
+  while (node.lastChild) {
+    node = node.lastChild;
+  }
+  return node;
+};

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -19,5 +19,6 @@ require("./text")(core);
 require("./dom-implementation")(core);
 require("./document")(core);
 require("./node-filter")(core);
+require("./node-iterator")(core);
 require("./node")(core);
 require("./selectors")(core);

--- a/lib/jsdom/living/node-iterator.js
+++ b/lib/jsdom/living/node-iterator.js
@@ -1,0 +1,229 @@
+"use strict";
+
+const defineGetter = require("../utils").defineGetter;
+const precedingNode = require("./helpers/traversal").precedingNode;
+const followingNode = require("./helpers/traversal").followingNode;
+const followingNodeSkipChildren = require("./helpers/traversal").followingNodeSkipChildren;
+const lastInclusiveDescendant = require("./helpers/traversal").lastInclusiveDescendant;
+const INTERNAL = Symbol("NodeIterator internal");
+
+module.exports = function (core) {
+  // https://dom.spec.whatwg.org/#interface-nodeiterator
+
+  function NodeIteratorInternal(document, root, whatToShow, filter) {
+    this.active = true;
+    this.document = document;
+    this.root = root;
+    this.referenceNode = root;
+    this.pointerBeforeReferenceNode = true;
+    this.whatToShow = whatToShow;
+    this.filter = filter;
+  }
+
+  NodeIteratorInternal.prototype.throwIfNotActive = function () {
+    // (only thrown for getters/methods that are affected by removing steps)
+    if (!this.active) {
+      throw Error("This NodeIterator is no longer active. " +
+                  "More than " + this.document._activeNodeIteratorsMax +
+                  " iterators are being used concurrently. " +
+                  "You can increase the 'concurrentNodeIterators' option to " +
+                  "make this error go away."
+      );
+      // Alternatively, you can pester Ecma to add support for weak references,
+      // the DOM standard assumes the implementor has control over object life cycles.
+    }
+  };
+
+  NodeIteratorInternal.prototype.traverse = function (next) {
+    let node = this.referenceNode;
+    let beforeNode = this.pointerBeforeReferenceNode;
+
+    do {
+      if (next) {
+        if (!beforeNode) {
+          node = followingNode(node, this.root);
+
+          if (!node) {
+            return null;
+          }
+        }
+
+        beforeNode = false;
+      } else { // previous
+        if (beforeNode) {
+          node = precedingNode(node, this.root);
+
+          if (!node) {
+            return null;
+          }
+        }
+
+        beforeNode = true;
+      }
+    }
+    while (this.filterNode(node) !== core.NodeFilter.FILTER_ACCEPT);
+
+    this.pointerBeforeReferenceNode = beforeNode;
+    this.referenceNode = node;
+    return node;
+  };
+
+  NodeIteratorInternal.prototype.filterNode = function (node) {
+
+    let n = node.nodeType - 1;
+    if (!(this.whatToShow & (1 << n))) {
+      return core.NodeFilter.FILTER_SKIP;
+    }
+
+    let ret = core.NodeFilter.FILTER_ACCEPT;
+    let filter = this.filter;
+    if (typeof filter === "function") {
+      ret = filter(node);
+    } else if (filter && typeof filter.acceptNode === "function") {
+      ret = filter.acceptNode(node);
+    }
+
+    if (ret === true) {
+      return core.NodeFilter.FILTER_ACCEPT;
+    } else if (ret === false) {
+      return core.NodeFilter.FILTER_REJECT;
+    }
+
+    return ret;
+  };
+
+  NodeIteratorInternal.prototype.runRemovingSteps = function (oldNode, oldParent, oldPreviousSibling) {
+    if (oldNode.contains(this.root)) {
+      return;
+    }
+
+    // If oldNode is not an inclusive ancestor of the referenceNode
+    // attribute value, terminate these steps.
+    if (!oldNode.contains(this.referenceNode)) {
+      return;
+    }
+
+    if (this.pointerBeforeReferenceNode) {
+      // Let nextSibling be oldPreviousSibling’s next sibling, if oldPreviousSibling is non-null,
+      // and oldParent’s first child otherwise.
+      let nextSibling = oldPreviousSibling ?
+                        oldPreviousSibling.nextSibling :
+                        oldParent.firstChild;
+
+      // If nextSibling is non-null, set the referenceNode attribute to nextSibling
+      // and terminate these steps.
+      if (nextSibling) {
+        this.referenceNode = nextSibling;
+        return;
+      }
+
+      // Let next be the first node following oldParent (excluding any children of oldParent).
+      let next = followingNodeSkipChildren(oldParent);
+
+      // If root is an inclusive ancestor of next, set the referenceNode
+      // attribute to next and terminate these steps.
+      if (this.root.contains(next)) {
+        this.referenceNode = next;
+        return;
+      }
+
+      // Otherwise, set the pointerBeforeReferenceNode attribute to false.
+      this.pointerBeforeReferenceNode = false;
+
+      // Note: Steps are not terminated here.
+    }
+
+    // Set the referenceNode attribute to the last inclusive descendant in tree order of oldPreviousSibling,
+    // if oldPreviousSibling is non-null, and to oldParent otherwise.
+    this.referenceNode = oldPreviousSibling ?
+                             lastInclusiveDescendant(oldPreviousSibling) :
+                             oldParent;
+  };
+
+  core.Document._removingSteps.push(function (document, oldNode, oldParent, oldPreviousSibling) {
+    for (let i = 0; i < document._activeNodeIterators.length; ++i) {
+      let internal = document._activeNodeIterators[i];
+      internal.runRemovingSteps(oldNode, oldParent, oldPreviousSibling);
+    }
+  });
+
+  core.Document.prototype.createNodeIterator = function (root, whatToShow, filter) {
+    if (!root) {
+      throw new TypeError("Not enough arguments to Document.createNodeIterator.");
+    }
+
+    if (filter === undefined) {
+      filter = null;
+    }
+
+    if (filter !== null &&
+        typeof filter !== "function" &&
+        typeof filter.acceptNode !== "function") {
+      throw new TypeError("Argument 3 of Document.createNodeIterator should be a function or implement NodeFilter.");
+    }
+
+    let document = root._ownerDocument;
+
+    whatToShow = whatToShow === undefined ?
+      core.NodeFilter.SHOW_ALL :
+      (whatToShow & core.NodeFilter.SHOW_ALL) >>> 0; // >>> makes sure the result is unsigned
+
+    filter = filter || null;
+
+    let it = Object.create(core.NodeIterator.prototype);
+    let internal = new NodeIteratorInternal(document, root, whatToShow, filter);
+    it[INTERNAL] = internal;
+
+    document._activeNodeIterators.push(internal);
+    while (document._activeNodeIterators.length > document._activeNodeIteratorsMax) {
+      let internalOther = document._activeNodeIterators.shift();
+      internalOther.active = false;
+    }
+
+    return it;
+  };
+
+  core.NodeIterator = function NodeIterator() {
+    throw new TypeError("Illegal constructor");
+  };
+
+  defineGetter(core.NodeIterator.prototype, "root", function () {
+    return this[INTERNAL].root;
+  });
+
+  defineGetter(core.NodeIterator.prototype, "referenceNode", function () {
+    const internal = this[INTERNAL];
+    internal.throwIfNotActive();
+    return internal.referenceNode;
+  });
+
+  defineGetter(core.NodeIterator.prototype, "pointerBeforeReferenceNode", function () {
+    const internal = this[INTERNAL];
+    internal.throwIfNotActive();
+    return internal.pointerBeforeReferenceNode;
+  });
+
+  defineGetter(core.NodeIterator.prototype, "whatToShow", function () {
+    return this[INTERNAL].whatToShow;
+  });
+
+  defineGetter(core.NodeIterator.prototype, "filter", function () {
+    return this[INTERNAL].filter;
+  });
+
+  core.NodeIterator.prototype.previousNode = function () {
+    const internal = this[INTERNAL];
+    internal.throwIfNotActive();
+    return internal.traverse(false);
+  };
+
+  core.NodeIterator.prototype.nextNode = function () {
+    const internal = this[INTERNAL];
+    internal.throwIfNotActive();
+    return internal.traverse(true);
+  };
+
+  core.NodeIterator.prototype.detach = function () {
+    // noop
+  };
+};

--- a/test/living-dom/files/test.html
+++ b/test/living-dom/files/test.html
@@ -4,7 +4,7 @@
     <title>Minimal</title>
 </head>
 <body>
-<span>Hello!<strong>Goodbye!</strong><strong>Hello Again</strong></span>
+<span>Hello!<strong>Goodbye!</strong><strong>Hello <!-- A Comment! --> Again</strong></span>
 <p>This is an <em>Important</em> paragraph</p>
 </body>
 </html>

--- a/test/living-dom/node-iterator.js
+++ b/test/living-dom/node-iterator.js
@@ -1,0 +1,708 @@
+"use strict";
+
+const jsdom = require("../../");
+const load = require("../util").load(__dirname);
+
+function descendants(root) {
+  let ret = [];
+
+  for (let i = 0; i < root.childNodes.length; ++i) {
+
+    let child = root.childNodes[i];
+    ret.push(child);
+    ret = ret.concat(descendants(child));
+  }
+
+  return ret;
+}
+
+function forwardIterator(it, nodeOrName) {
+  for (let c = 0; c < 1000; ++c) {
+    let node = it.nextNode();
+
+    if (typeof nodeOrName === "string" &&
+        node.nodeName === nodeOrName) {
+      return node;
+    }
+
+    if (nodeOrName === node) {
+      return node;
+    }
+
+    if (node === null) {
+      throw Error("Unable to find node in forwardIterator() because nextNode() returned null");
+    }
+  }
+
+  throw Error("Unable to find node in forwardIterator() after a lot of tries");
+}
+
+function removeAndReinsert(node) {
+  let parent = node.parentNode;
+  let nextSibling = node.nextSibling;
+
+  // Remove it and re insert in the same location
+  // the DOM tree will be identical, however it should have
+  // affected the state of the node iterator because of the "removing steps"
+  parent.removeChild(node);
+  parent.insertBefore(node, nextSibling);
+}
+
+exports["createNodeIterator(): should throw if the first argument is missing"] = function (t) {
+  let doc = load("test");
+  t.throws(function () {
+    doc.createNodeIterator();
+  }, /not enough arguments/i);
+  t.done();
+};
+
+exports["createNodeIterator(): should throw if the filter argument is not a function or NodeFilter"] = function (t) {
+  let doc = load("test");
+
+  t.throws(function () {
+    doc.createNodeIterator(doc, -1, {});
+  }, /Argument.*NodeFilter/i);
+  t.done();
+};
+
+exports["createNodeIterator(): should set defaults for missing arguments"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  t.ok(it.root, "root should be set");
+  t.strictEqual(it.root.nodeName, "BODY", "root was set to the <body>");
+  t.ok(it.referenceNode ===  it.root, "referenceNode should be set to root right after creation");
+  t.strictEqual(it.pointerBeforeReferenceNode, true, "pointerBeforeReferenceNode should be true right after creation");
+  t.strictEqual(it.whatToShow, 0xFFFFFFFF, "whatToShow is NodeFilter.SHOW_ALL by default");
+  t.strictEqual(it.filter, null, "filter is null by default");
+  t.done();
+};
+
+exports["createNodeIterator(): whatToShow should unset high bits"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body, 0xFFFFFFFFFF); // (two extra F's)
+  t.strictEqual(it.whatToShow, 0xFFFFFFFF, "whatToShow should unset high bits");
+  t.done();
+};
+
+exports["createNodeIterator(): should create an instanceof NodeIterator"] = function (t) {
+  let doc = load("test");
+
+  let foo;
+  t.throws(function () {
+    foo = new doc.defaultView.NodeIterator();
+  }, /Illegal constructor/i);
+
+  t.done();
+};
+
+exports["new NodeIterator() is not allowed"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc);
+  t.strictEqual(Object.getPrototypeOf(it).constructor.name, "NodeIterator");
+  t.done();
+};
+
+exports["too many concurrent iterators should throw when accessing the iterator"] = function (t) {
+  let doc = jsdom.jsdom("<html/>", {concurrentNodeIterators: 3});
+
+  let iterators = [
+    doc.createNodeIterator(doc),
+    doc.createNodeIterator(doc),
+    doc.createNodeIterator(doc),
+    doc.createNodeIterator(doc)
+  ];
+
+  let foo;
+  t.throws(function () {
+    foo = iterators[0].referenceNode;
+  }, /no longer active/i);
+
+  t.throws(function () {
+    foo = iterators[0].pointerBeforeReferenceNode;
+  }, /no longer active/i);
+
+  t.throws(function () {
+    iterators[0].nextNode();
+  }, /no longer active/i);
+
+  t.throws(function () {
+    iterators[0].previousNode();
+  }, /no longer active/i);
+
+  // Other getters / method should not fail because they
+  // are not affected by removing steps
+
+  foo = iterators[0].root;
+  foo = iterators[0].whatToShow;
+  foo = iterators[0].filter;
+  iterators[0].detach(); // (noop)
+
+  // The 3 newer iterators should not fail
+  for (var i = 1; i < iterators.length; ++i) {
+    foo = iterators[i].referenceNode;
+    foo = iterators[i].pointerBeforeReferenceNode;
+    iterators[i].nextNode();
+    iterators[i].previousNode();
+    foo = iterators[i].root;
+    foo = iterators[i].whatToShow;
+    foo = iterators[i].filter;
+    iterators[i].detach(); // (noop)
+  }
+
+  t.done();
+};
+
+exports["detach() should be a no-op"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc);
+  it.detach();
+  it.detach();
+  t.done();
+};
+
+exports["filter exceptions should be propagated"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc, 0xFFFFFFFF, function () { throw Error("Foo Bar!"); });
+
+  t.throws(function () {
+    it.nextNode();
+  }, /^Foo Bar!$/);
+
+  t.done();
+};
+
+exports["NodeIterator instances should not expose any extra properties"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc);
+
+  for (let key in it) {
+    switch (key) {
+      case "nextNode":
+      case "previousNode":
+      case "detach":
+      case "root":
+      case "referenceNode":
+      case "pointerBeforeReferenceNode":
+      case "whatToShow":
+      case "filter":
+        t.ok(!it.hasOwnProperty(key), key + " should not be an 'own' property");
+        break;
+      default:
+        t.ok(false, key + " is not a valid NodeIterator property");
+    }
+  }
+
+  t.done();
+};
+
+exports["The first nextNode() call should return the root"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  let node = it.nextNode();
+  t.ok(node             ===  it.root);
+  t.ok(it.referenceNode ===  it.root);
+  t.strictEqual(it.pointerBeforeReferenceNode, false, "pointerBeforeReferenceNode should be false after nextNode()");
+
+  t.done();
+};
+
+exports["nextNode() should iterate over each descendant of root (in tree order)"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode(); // skip the root node
+
+  let nodes = descendants(it.root);
+  nodes.forEach(function (node) {
+    let itNode = it.nextNode();
+    t.ok(node             ===  itNode);
+    t.ok(it.referenceNode ===  itNode);
+    t.strictEqual(it.pointerBeforeReferenceNode, false, "pointerBeforeReferenceNode should be false after nextNode()");
+  });
+
+  let node = it.nextNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.ok(it.referenceNode ===  nodes[nodes.length - 1],
+       "referenceNode should reference the last node even though nextNode() returns null");
+  t.strictEqual(it.pointerBeforeReferenceNode, false, "pointerBeforeReferenceNode should be false after nextNode()");
+  t.done();
+};
+
+exports["iterating over nodes of a foreign document should be allowed"] = function (t) {
+  let doc = jsdom.jsdom("<html/>");
+  let foreignDoc = load("test");
+  let it = doc.createNodeIterator(foreignDoc.body);
+
+  it.nextNode(); // skip the root node
+
+  let nodes = descendants(it.root);
+  nodes.forEach(function (node) {
+    let itNode = it.nextNode();
+    t.ok(node             ===  itNode);
+    t.ok(it.referenceNode ===  itNode);
+    t.strictEqual(it.pointerBeforeReferenceNode, false, "pointerBeforeReferenceNode should be false after nextNode()");
+  });
+
+  let node = it.nextNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.ok(it.referenceNode ===  nodes[nodes.length - 1],
+       "referenceNode should reference the last node even though nextNode() returns null");
+  t.strictEqual(it.pointerBeforeReferenceNode, false, "pointerBeforeReferenceNode should be false after nextNode()");
+  t.done();
+};
+
+exports["previousNode() should have no effect on a newly created iterator"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  let node = it.previousNode();
+  t.ok(node ===  null);
+  t.ok(it.referenceNode ===  it.root);
+  t.strictEqual(it.pointerBeforeReferenceNode, true);
+
+  t.done();
+};
+
+exports["The root should be the last node that previousNode() will return"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode();
+  let node = it.previousNode();
+  t.ok(node             ===  it.root);
+  t.ok(it.referenceNode ===  it.root);
+  t.strictEqual(it.pointerBeforeReferenceNode, true, "pointerBeforeReferenceNode should be true after previousNode()");
+
+  t.done();
+};
+
+exports["previousNode() should return the same node that nextNode() just returned"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode(); // skip the root, this is tested in a different case
+  let wasNext = it.nextNode();
+  let node = it.previousNode();
+
+  t.ok(node ===  wasNext);
+  t.done();
+};
+
+exports["previousNode() should iterate over each descendant of root (in reverse tree order)"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  forwardIterator(it, null); // skip to the end
+
+  let nodes = descendants(it.root).reverse();
+  nodes.forEach(function (node) {
+    let itNode = it.previousNode();
+    t.ok(node             ===  itNode);
+    t.ok(it.referenceNode ===  itNode);
+    t.strictEqual(it.pointerBeforeReferenceNode, true,
+                  "pointerBeforeReferenceNode should be true after previousNode()");
+  });
+
+  let node = it.previousNode();
+  t.ok(node             ===  it.root);
+  t.ok(it.referenceNode ===  it.root);
+  t.strictEqual(it.pointerBeforeReferenceNode, true, "pointerBeforeReferenceNode should be true after previousNode()");
+
+  node = it.previousNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.ok(it.referenceNode ===  it.root,
+       "referenceNode should reference root node even though previousNode() returns null");
+  t.strictEqual(it.pointerBeforeReferenceNode, true, "pointerBeforeReferenceNode should be true after previousNode()");
+  t.done();
+};
+
+exports["whatToShow should skip nodes of types not present in the bitset"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body, 0x00000001 | 0x00000080); // SHOW_ELEMENT | SHOW_COMMENT
+
+  it.nextNode(); // skip the root node
+
+  let hasElement = false;
+  let hasComment = false;
+  let hasOther = false;
+
+  let nodes = descendants(it.root).filter(function (node) {
+    if (node.nodeType === 1) {
+      hasElement = true;
+      return true;
+    }
+
+    if (node.nodeType === 8) {
+      hasComment = true;
+      return true;
+    }
+
+    hasOther = true;
+    return false;
+  });
+
+  // If these node types are not encountered,
+  // the test case is not very useful:
+  t.ok(hasElement);
+  t.ok(hasComment);
+  t.ok(hasOther);
+
+
+  nodes.forEach(function (node) {
+    let itNode = it.nextNode();
+    t.ok(node ===  itNode);
+  });
+
+  let node = it.nextNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.done();
+};
+
+exports["should skip nodes using a filter function"] = function (t) {
+  let doc = load("test");
+
+  function acceptNode(node) {
+    t.strictEqual(node.nodeType, 1, "whatToShow should have filtered non element nodes before acceptNode() is called");
+
+    if (node.nodeName === "STRONG") {
+      return 1; // FILTER_ACCEPT
+    }
+
+    return 3; // FILTER_REJECT
+  }
+
+  let it = doc.createNodeIterator(doc.body, 0x00000001, acceptNode); // SHOW_ELEMENT
+
+  let nodes = descendants(it.root).filter(function (node) {
+    return node.nodeName === "STRONG";
+  });
+
+  t.ok(nodes.length, "Test case prerequisite");
+
+  nodes.forEach(function (node) {
+    let itNode = it.nextNode();
+    t.ok(node ===  itNode);
+  });
+
+  let node = it.nextNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.done();
+};
+
+exports["should skip nodes using a NodeFilter as a filter"] = function (t) {
+  let doc = load("test");
+
+  function acceptNode(node) {
+    t.strictEqual(node.nodeType, 1, "whatToShow should have filtered non element nodes before acceptNode() is called");
+
+    if (node.nodeName === "STRONG") {
+      return 1; // FILTER_ACCEPT
+    }
+
+    return 3; // FILTER_REJECT
+  }
+
+  let it = doc.createNodeIterator(doc.body, 0x00000001, {acceptNode: acceptNode}); // SHOW_ELEMENT
+
+  let nodes = descendants(it.root).filter(function (node) {
+    return node.nodeName === "STRONG";
+  });
+
+  t.ok(nodes.length, "Test case prerequisite");
+
+  nodes.forEach(function (node) {
+    let itNode = it.nextNode();
+    t.ok(node ===  itNode);
+  });
+
+  let node = it.nextNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.done();
+};
+
+exports["filter function should also accept booleans as a return value"] = function (t) {
+  let doc = load("test");
+
+  function acceptNode(node) {
+    return node.nodeName === "STRONG";
+  }
+
+  let it = doc.createNodeIterator(doc.body, 0x00000001, acceptNode); // SHOW_ELEMENT
+
+  let nodes = descendants(it.root).filter(function (node) {
+    return node.nodeName === "STRONG";
+  });
+
+  t.ok(nodes.length, "Test case prerequisite");
+
+  nodes.forEach(function (node) {
+    let itNode = it.nextNode();
+    t.ok(node ===  itNode);
+  });
+
+  let node = it.nextNode();
+  t.ok(node ===  null, "nextNode should return null after having iterated through all the nodes");
+  t.done();
+};
+
+exports["Removing the root node should not affect the iterator state"] = function (t) {
+  // This behaviour is not noted explicitly in the spec, however this how all the browsers behave
+  // (and it makes sense)
+
+  let doc = load("test");
+
+  let node = doc.body.childNodes[1];
+  let it = doc.createNodeIterator(node);
+  doc.body.removeChild(node);
+
+  t.ok(it.root ===  node);
+  t.ok(it.referenceNode ===  node, "referenceNode should be set to root right after creation");
+  t.strictEqual(it.pointerBeforeReferenceNode, true, "pointerBeforeReferenceNode should be true right after creation");
+  t.ok(it.referenceNode.parentNode ===  null);
+  t.done();
+};
+
+exports["Removing a node that is not an inclusive ancestor " +
+        "of the referenceNode should not affect the state"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+  t.ok(it.root.childNodes.length >= 2, "Test case prerequisite");
+
+  it.nextNode(); // skip the root
+  it.nextNode();
+  it.nextNode(); // referenceNode is now the second child of the root
+  removeAndReinsert(it.root.firstChild);
+
+  t.ok(it.root ===  doc.body);
+  t.ok(it.referenceNode ===  it.root.childNodes[1]);
+  t.strictEqual(it.pointerBeforeReferenceNode, false);
+  t.done();
+};
+
+exports["Removing the referenceNode after nextNode() should " +
+        "update the state properly (null oldPreviousSibling)"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode(); // skip the root
+
+  let removed = it.nextNode(); // referenceNode is now the first child of <body>
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  it.root, "referenceNode should be root again");
+  t.ok(it.pointerBeforeReferenceNode ===  false, "should be false so that nextNode() will return the firstChild again");
+
+  let next = it.nextNode();
+  t.ok(next === it.root.firstChild,
+                "nextNode() should return the first child again after the previous one was removed");
+
+  t.done();
+};
+
+exports["Removing the referenceNode after nextNode() should " +
+        "update the state properly (non-null oldPreviousSibling)"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body.children[0]);
+  t.ok(it.root.childNodes.length >= 3, "Test case prerequisite");
+
+  it.nextNode(); // skip the root
+
+  let removed = it.root.childNodes[1];
+  forwardIterator(it, removed); // referenceNode is now the second child of root
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  it.root.firstChild,
+       "referenceNode should be set the the oldPreviousSibling of the removed node");
+  t.strictEqual(it.pointerBeforeReferenceNode, false);
+
+  let next = it.nextNode();
+  t.ok(next ===  it.root.childNodes[1], "nextNode() should return the second child again");
+
+  t.done();
+};
+
+exports["Removing and reinserting the referenceNode after nextNode() should iterate it again"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode(); // skip the root
+
+  let removed = it.nextNode();
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  it.root, "referenceNode should be root again");
+  t.strictEqual(it.pointerBeforeReferenceNode, false,
+                "should be false so that nextNode() will return the firstChild again");
+
+  let next = it.nextNode();
+  t.ok(next ===  removed);
+
+  t.done();
+};
+
+exports["Removing and reinserting the referenceNode after previousNode() should iterate it again"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode(); // skip the root
+  it.nextNode();
+
+  let removed = it.previousNode();
+  let nextSibling = removed.nextSibling;
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  nextSibling, "referenceNode should be the nextSibling of the removed node");
+  t.strictEqual(it.pointerBeforeReferenceNode, true,
+                "should be true so that previousNode() will return the same node again");
+
+  let previous = it.previousNode();
+  t.ok(previous ===  removed);
+
+  t.done();
+};
+
+exports["Removing a parent of the referenceNode should update the state properly"] = function (t) {
+  let doc = load("test");
+
+  let parent = doc.body.children[1];
+  let previousSibling = parent.previousSibling;
+  t.ok(previousSibling, "Test case prerequisite");
+  parent.innerHTML = "<a></a><b></b><i></i>";
+
+  let it = doc.createNodeIterator(doc.body);
+  forwardIterator(it, parent);
+  it.nextNode();
+  t.strictEqual(it.nextNode().nodeName, "B");
+
+  removeAndReinsert(parent);
+
+  t.ok(it.referenceNode ===  previousSibling);
+  t.strictEqual(it.pointerBeforeReferenceNode, false);
+  t.done();
+};
+
+exports["Removing referenceNode after previousNode(): " +
+        "oldPreviousSibling == null && oldParent.firstChild != null"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  it.nextNode(); // skip the root
+  it.nextNode();
+
+  let removed = it.previousNode();
+  t.ok(!removed.previousSibling, "Test case prerequisite");
+  t.ok(removed.nextSibling, "Test case prerequisite");
+  let nextSibling = removed.nextSibling;
+  removeAndReinsert(removed);
+
+  // (nextSibling is the new firstChild)
+  t.ok(it.referenceNode ===  nextSibling, "referenceNode should be the nextSibling of the removed node");
+  t.strictEqual(it.pointerBeforeReferenceNode, true);
+
+  let next = it.nextNode();
+  t.ok(next !== removed);
+  t.ok(next ===  nextSibling);
+
+  t.done();
+};
+
+exports["Removing referenceNode after previousNode(): " +
+        "oldPreviousSibling != null && oldPreviousSibling.nextSibling != null"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body.children[0]);
+
+  it.nextNode(); // skip root
+  it.nextNode();
+  it.nextNode(); // second child
+  let removed = it.previousNode(); // second child, pointerBeforeReferenceNode is now true
+
+  t.ok(removed.previousSibling, "Test case prerequisite");
+  t.ok(removed.nextSibling, "Test case prerequisite");
+  let nextSibling = removed.nextSibling;
+
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  nextSibling, "referenceNode should be the nextSibling of the removed node");
+  t.strictEqual(it.pointerBeforeReferenceNode, true);
+
+  t.done();
+};
+
+exports["Removing referenceNode after previousNode(): " +
+        "oldPreviousSibling == null && oldParent.firstChild == null"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  forwardIterator(it, "STRONG");
+
+  let parent = it.referenceNode;
+  t.ok(parent.childNodes.length === 1, "Test case prerequisite");
+  t.ok(parent.nextSibling, "Test case prerequisite");
+
+  it.nextNode();
+  let removed = it.previousNode();
+
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  parent.nextSibling, "referenceNode should be the following node of the oldParent");
+  t.strictEqual(it.pointerBeforeReferenceNode, true);
+
+  t.done();
+};
+
+exports["Removing referenceNode after previousNode(): " +
+        "oldPreviousSibling != null && oldPreviousSibling.nextSibling == null"] = function (t) {
+  let doc = load("test");
+  let it = doc.createNodeIterator(doc.body);
+
+  forwardIterator(it, it.root.children[0].lastChild);
+  let removed = it.previousNode();
+
+  t.ok(removed.previousSibling, "Test case prerequisite");
+  t.ok(!removed.nextSibling, "Test case prerequisite");
+  let parent = removed.parentNode;
+  t.ok(parent.nextSibling, "Test case prerequisite");
+
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode === parent.nextSibling, "referenceNode should be the following node of the oldParent");
+  t.strictEqual(it.pointerBeforeReferenceNode, true);
+
+  t.done();
+};
+
+exports["Removing referenceNode after previousNode(): " +
+        "node following oldParent is outside of root"] = function (t) {
+  let doc = load("test");
+  doc.body.innerHTML = "<p><a><em></em></a></p><div></div>";
+  let it = doc.createNodeIterator(doc.body.firstChild);
+
+  forwardIterator(it, "EM");
+  let removed = it.previousNode();
+
+  removeAndReinsert(removed);
+
+  t.ok(it.referenceNode ===  it.root.firstChild, "referenceNode should be the oldParent");
+  t.strictEqual(it.pointerBeforeReferenceNode, false);
+
+  t.done();
+};
+
+exports["Removing referenceNode after nextNode(): " +
+  "oldPreviousSibling != null"] = function (t) {
+  let doc = load("test");
+  doc.body.innerHTML = "<p>Efghijkl</p><p>Mnopqrst</p>";
+
+  let it = doc.createNodeIterator(doc);
+
+  forwardIterator(it, null);
+
+  var removed = doc.body.children[1];
+  removed.parentNode.removeChild(removed);
+
+  t.ok(it.referenceNode === doc.body.children[0].lastChild);
+  t.strictEqual(it.pointerBeforeReferenceNode, false);
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -44,6 +44,7 @@ var files = [
   "living-dom/node-parent-element.js",
   "living-dom/query-selector.js",
   "living-dom/query-selector-all.js",
+  "living-dom/node-iterator.js",
   "living-html/cookie.js",
   "living-html/current-script.js",
   "living-html/focus.js",


### PR DESCRIPTION
Using https://dom.spec.whatwg.org/#interface-nodeiterator
Related to #317

I wrote my own test cases, I used istanbul to verify coverage (line and branch coverage is 100%).

The most tricky part about `NodeIterator` is its behavior when you remove nodes it iterates over. Each active `NodeIterator` must be notified about every node that is removed ("[removing steps](https://dom.spec.whatwg.org/#concept-node-remove-ext)").

The DOM specification assumes implementations have control over object lifecycles (destructors, weak references, etc). To implement it properly, without leaks, you would need to use weak references between the `Document` and `NodeIterator`s. We can not use such things in javascript (WeakMap and WeakSet are not adequate in this case) unless we would add a dependency on a compiled module (again :P). It looks like Ecma added this limitation on purpose to prevent side channel attacks.

Instead, I added an option that specifies the maximum number of `NodeIterator`s that removing steps will occur for. If this limit is reached, the oldest `NodeIterator` will no longer be tracked and it will start to throw whenever you try to access its state.

I tried to work out an alternative by asynchronously resolving the state of `NodeIterator`s. jsdom would store a lot of data about removals & insertions applied on nodes and the NodeIterator would use that data the next time you access it. This is pretty complex, but more importantly it would be  performance heavy because you would have to store a lot of state. Also the combination of iterating + modification would probably become something like `O(n^2)` instead of `O(n)`.