### PR TITLE
Fix error on new version of jsdom

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -51,10 +51,10 @@ exports.jsdom = function (html, options) {
     options.parsingMode = "html";
   }
 
-  if (options.parsingMode !== "html" && options.parsingMode !== "xml") {
+  /*if (options.parsingMode !== "html" && options.parsingMode !== "xml") {
     throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.parsingMode)}; must be either "html", ` +
       `"xml", "auto", or undefined`);
-  }
+  }*/
 
   // List options explicitly to be clear which are passed through
   var window = new Window({

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -235,11 +235,11 @@ core.HTMLDocument = function HTMLDocument(options) {
   this.implementation._addFeature('xml'   , '2.0');
 };
 
-var nonInheritedTags = new Set([
+/*var nonInheritedTags = new Set([
   'article', 'section', 'nav', 'aside', 'hgroup', 'header', 'footer', 'address', 'dt',
   'dd', 'figure', 'figcaption', 'main', 'em', 'strong', 'small', 's', 'cite', 'dfn', 'abbr',
   'ruby', 'rt', 'rp', 'code', 'var', 'samp', 'kbd', 'i', 'b', 'u', 'mark', 'bdi', 'bdo', 'wbr'
-]);
+]);*/
 
 inheritFrom(core.Document, core.HTMLDocument, {
   _defaultElementBuilder: function (document, tagName) {


### PR DESCRIPTION
Hi Team!
i got the problem on your new version. So i sent an PR to help you can check it easier! i already disabled that code to make my system run normally. they give me this error

/home/tuan/git/thedragoncode/node_modules/jsdom/lib/jsdom.js:55
    throw new RangeError(`Invalid parsingMode option ${JSON.stringify(options.
                         ^
SyntaxError: Unexpected token ILLEGAL
    at exports.runInThisContext (vm.js:69:16)
    at Module._compile (module.js:432:25)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
    at Module.require (module.js:357:17)
    at require (module.js:373:17)
    at Object.<anonymous> (/home/tuan/git/thedragoncode/test/config/application.js:22:12)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)


please have a look on it and  fix :), thanks