### PR TITLE
Implement ParentNode interface

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -390,18 +390,6 @@ core.Node.prototype = {
   DOCUMENT_FRAGMENT_NODE      : DOCUMENT_FRAGMENT_NODE,
   NOTATION_NODE               : NOTATION_NODE,
 
-  get children() {
-    if (!this._childrenList) {
-      var self = this;
-      this._childrenList = new core.NodeList(this, function() {
-        return self._childNodes.filter(function(node) {
-          return node.tagName;
-        });
-      });
-    }
-    this._childrenList._update();
-    return this._childrenList;
-  },
   get nodeValue() {
     if (this.nodeType === core.Node.TEXT_NODE ||
         this.nodeType === core.Node.COMMENT_NODE ||

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -22,3 +22,4 @@ require("./node-filter")(core);
 require("./node-iterator")(core);
 require("./node")(core);
 require("./selectors")(core);
+require("./parent-node")(core);

--- a/lib/jsdom/living/parent-node.js
+++ b/lib/jsdom/living/parent-node.js
@@ -14,7 +14,7 @@ module.exports = function (core) {
 
       if (!this._childrenList) {
         const self = this;
-        this._childrenList = new core.NodeList(this, function () {
+        this._childrenList = new core.HTMLCollection(this, function () {
           return self._childNodes.filter(function (node) {
             return node.tagName;
           });

--- a/lib/jsdom/living/parent-node.js
+++ b/lib/jsdom/living/parent-node.js
@@ -48,5 +48,10 @@ module.exports = function (core) {
 
       return null;
     });
+
+    defineGetter(Interface.prototype, "childElementCount", function () {
+      return this.children.length;
+    });
+
   });
 };

--- a/lib/jsdom/living/parent-node.js
+++ b/lib/jsdom/living/parent-node.js
@@ -36,5 +36,17 @@ module.exports = function (core) {
 
       return null;
     });
+
+    defineGetter(Interface.prototype, "lastElementChild", function () {
+
+      for (let i = this._childNodes.length - 1; i >= 0; --i) {
+        const child = this._childNodes[i];
+        if (child.nodeType === ELEMENT_NODE) {
+          return child;
+        }
+      }
+
+      return null;
+    });
   });
 };

--- a/lib/jsdom/living/parent-node.js
+++ b/lib/jsdom/living/parent-node.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const defineGetter = require("../utils").defineGetter;
+
+module.exports = function (core) {
+  // https://dom.spec.whatwg.org/#interface-parentnode
+  // Note that ParentNode is a "NoInterfaceObject"
+
+  const implementors = [core.Document, core.DocumentFragment, core.Element];
+
+  implementors.forEach(function (Interface) {
+
+    defineGetter(Interface.prototype, "children", function () {
+
+      if (!this._childrenList) {
+        const self = this;
+        this._childrenList = new core.NodeList(this, function () {
+          return self._childNodes.filter(function (node) {
+            return node.tagName;
+          });
+        });
+      }
+      this._childrenList._update();
+      return this._childrenList;
+    });
+
+  });
+};

--- a/lib/jsdom/living/parent-node.js
+++ b/lib/jsdom/living/parent-node.js
@@ -7,6 +7,7 @@ module.exports = function (core) {
   // Note that ParentNode is a "NoInterfaceObject"
 
   const implementors = [core.Document, core.DocumentFragment, core.Element];
+  const ELEMENT_NODE = core.Node.ELEMENT_NODE;
 
   implementors.forEach(function (Interface) {
 
@@ -24,5 +25,16 @@ module.exports = function (core) {
       return this._childrenList;
     });
 
+    defineGetter(Interface.prototype, "firstElementChild", function () {
+
+      for (let i = 0; i < this._childNodes.length; ++i) {
+        const child = this._childNodes[i];
+        if (child.nodeType === ELEMENT_NODE) {
+          return child;
+        }
+      }
+
+      return null;
+    });
   });
 };

--- a/test/living-dom/files/parent-node.html
+++ b/test/living-dom/files/parent-node.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<?foo bar?>
+<html id="html_id">
+  <head>
+      <title>ParentNode</title>
+  </head>
+  <body>
+    <?foo bar?>
+    <a name="a_name"> hi </a>
+    <!-- comment -->
+    <div></div>
+  </body>
+</html>

--- a/test/living-dom/parent-node.js
+++ b/test/living-dom/parent-node.js
@@ -58,3 +58,29 @@ exports["DocumentFragment should implement ParentNode:children"] = function (t) 
   t.ok(parent.children instanceof doc.defaultView.HTMLCollection, "children should be a HTMLCollection");
   t.done();
 };
+exports["Document should implement ParentNode:firstElementChild"] = function (t) {
+  const doc = load("parent-node");
+  t.strictEqual(nodeName(doc.firstElementChild), "HTML");
+  t.done();
+};
+
+exports["Element should implement ParentNode:firstElementChild"] = function (t) {
+  const doc = load("parent-node");
+  t.strictEqual(nodeName(doc.body.firstElementChild), "A");
+  t.strictEqual(doc.createElement("div").firstElementChild, null);
+  t.done();
+};
+
+exports["DocumentFragment should implement ParentNode:firstElementChild"] = function (t) {
+  const doc = load("parent-node");
+  const fragment = doc.createDocumentFragment();
+
+  t.strictEqual(fragment.firstElementChild, null);
+
+  while (doc.body.firstChild) {
+    fragment.appendChild(doc.body.firstChild);
+  }
+
+  t.strictEqual(nodeName(fragment.firstElementChild), "A");
+  t.done();
+};

--- a/test/living-dom/parent-node.js
+++ b/test/living-dom/parent-node.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const load = require("../util").load(__dirname);
+
+function nodeName(node) {
+  return node && node.nodeName ? node.nodeName : node;
+}
+
+exports["Document should implement ParentNode:children"] = function (t) {
+  const doc = load("parent-node");
+
+  const parent = doc;
+  t.strictEqual(parent.children.length, 1);
+  t.strictEqual(nodeName(parent.children[0]), "HTML");
+  t.strictEqual(nodeName(parent.children.item(0)), "HTML");
+  t.strictEqual(nodeName(parent.children[1]), undefined);
+  t.strictEqual(nodeName(parent.children.item(1)), null);
+  t.done();
+};
+
+exports["Element should implement ParentNode:children"] = function (t) {
+  const doc = load("parent-node");
+
+  const parent = doc.body;
+  t.strictEqual(parent.children.length, 2);
+  t.strictEqual(nodeName(parent.children[0]), "A");
+  t.strictEqual(nodeName(parent.children.item(0)), "A");
+  t.strictEqual(nodeName(parent.children[1]), "DIV");
+  t.strictEqual(nodeName(parent.children.item(1)), "DIV");
+  t.strictEqual(nodeName(parent.children[2]), undefined);
+  t.strictEqual(nodeName(parent.children.item(2)), null);
+  t.done();
+};
+
+exports["DocumentFragment should implement ParentNode:children"] = function (t) {
+  const doc = load("parent-node");
+  const parent = doc.createDocumentFragment();
+
+  while (doc.body.firstChild) {
+    parent.appendChild(doc.body.firstChild);
+  }
+
+  t.strictEqual(parent.children.length, 2);
+  t.strictEqual(nodeName(parent.children[0]), "A");
+  t.strictEqual(nodeName(parent.children.item(0)), "A");
+  t.strictEqual(nodeName(parent.children[1]), "DIV");
+  t.strictEqual(nodeName(parent.children.item(1)), "DIV");
+  t.strictEqual(nodeName(parent.children[2]), undefined);
+  t.strictEqual(nodeName(parent.children.item(2)), null);
+  t.done();
+};

--- a/test/living-dom/parent-node.js
+++ b/test/living-dom/parent-node.js
@@ -15,6 +15,9 @@ exports["Document should implement ParentNode:children"] = function (t) {
   t.strictEqual(nodeName(parent.children.item(0)), "HTML");
   t.strictEqual(nodeName(parent.children[1]), undefined);
   t.strictEqual(nodeName(parent.children.item(1)), null);
+  t.strictEqual(nodeName(parent.children.namedItem("html_id")), "HTML");
+  t.strictEqual(nodeName(parent.children.namedItem("foo")), null);
+  t.ok(parent.children instanceof parent.defaultView.HTMLCollection, "children should be a HTMLCollection");
   t.done();
 };
 
@@ -29,6 +32,9 @@ exports["Element should implement ParentNode:children"] = function (t) {
   t.strictEqual(nodeName(parent.children.item(1)), "DIV");
   t.strictEqual(nodeName(parent.children[2]), undefined);
   t.strictEqual(nodeName(parent.children.item(2)), null);
+  t.strictEqual(nodeName(parent.children.namedItem("a_name")), "A");
+  t.strictEqual(nodeName(parent.children.namedItem("foo")), null);
+  t.ok(parent.children instanceof doc.defaultView.HTMLCollection, "children should be a HTMLCollection");
   t.done();
 };
 
@@ -47,5 +53,8 @@ exports["DocumentFragment should implement ParentNode:children"] = function (t) 
   t.strictEqual(nodeName(parent.children.item(1)), "DIV");
   t.strictEqual(nodeName(parent.children[2]), undefined);
   t.strictEqual(nodeName(parent.children.item(2)), null);
+  t.strictEqual(nodeName(parent.children.namedItem("a_name")), "A");
+  t.strictEqual(nodeName(parent.children.namedItem("foo")), null);
+  t.ok(parent.children instanceof doc.defaultView.HTMLCollection, "children should be a HTMLCollection");
   t.done();
 };

--- a/test/living-dom/parent-node.js
+++ b/test/living-dom/parent-node.js
@@ -112,3 +112,27 @@ exports["DocumentFragment should implement ParentNode:lastElementChild"] = funct
   t.strictEqual(nodeName(fragment.lastElementChild), "DIV");
   t.done();
 };
+
+exports["Document should implement ParentNode:childElementCount"] = function (t) {
+  const doc = load("parent-node");
+  t.strictEqual(doc.childElementCount, 1);
+  t.done();
+};
+
+exports["Element should implement ParentNode:childElementCount"] = function (t) {
+  const doc = load("parent-node");
+  t.strictEqual(doc.body.childElementCount, 2);
+  t.done();
+};
+
+exports["DocumentFragment should implement ParentNode:childElementCount"] = function (t) {
+  const doc = load("parent-node");
+  const fragment = doc.createDocumentFragment();
+
+  while (doc.body.firstChild) {
+    fragment.appendChild(doc.body.firstChild);
+  }
+
+  t.strictEqual(fragment.childElementCount, 2);
+  t.done();
+};

--- a/test/living-dom/parent-node.js
+++ b/test/living-dom/parent-node.js
@@ -84,3 +84,31 @@ exports["DocumentFragment should implement ParentNode:firstElementChild"] = func
   t.strictEqual(nodeName(fragment.firstElementChild), "A");
   t.done();
 };
+
+
+exports["Document should implement ParentNode:lastElementChild"] = function (t) {
+  const doc = load("parent-node");
+  t.strictEqual(nodeName(doc.lastElementChild), "HTML");
+  t.done();
+};
+
+exports["Element should implement ParentNode:lastElementChild"] = function (t) {
+  const doc = load("parent-node");
+  t.strictEqual(nodeName(doc.body.lastElementChild), "DIV");
+  t.strictEqual(doc.createElement("div").lastElementChild, null);
+  t.done();
+};
+
+exports["DocumentFragment should implement ParentNode:lastElementChild"] = function (t) {
+  const doc = load("parent-node");
+  const fragment = doc.createDocumentFragment();
+
+  t.strictEqual(fragment.lastElementChild, null);
+
+  while (doc.body.firstChild) {
+    fragment.appendChild(doc.body.firstChild);
+  }
+
+  t.strictEqual(nodeName(fragment.lastElementChild), "DIV");
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -45,6 +45,7 @@ var files = [
   "living-dom/query-selector.js",
   "living-dom/query-selector-all.js",
   "living-dom/node-iterator.js",
+  "living-dom/parent-node.js",
   "living-html/cookie.js",
   "living-html/current-script.js",
   "living-html/focus.js",


### PR DESCRIPTION
https://dom.spec.whatwg.org/#interface-parentnode
Fixes #519

* `children` should only be defined on `Document`, `Element` and `DocumentFragment`
* `children` should be a HTMLColleciton
* Implement firstElementChild
* Implement lastElementChild
* Implement childElementCount

There's more stuff in ParentNode, but as far as I can tell there is not yet a single browser which implements those. So I would rather wait (perhaps the api is not yet stable)

