### PR TITLE
DOMImplementation fixes

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -233,16 +233,7 @@ Object.defineProperty(core.NodeList.prototype, 'constructor', {
 });
 
 core.DOMImplementation = function DOMImplementation(document, /* Object */ features) {
-  this._ownerDocument = document;
-  this._features = {};
-
-  if (features) {
-    for (var feature in features) {
-      if (features.hasOwnProperty(feature)) {
-        this._addFeature(feature.toLowerCase(), features[feature]);
-      }
-    }
-  }
+  throw new TypeError("Illegal constructor");
 };
 
 core.DOMImplementation.prototype = {
@@ -510,8 +501,8 @@ core.Node.prototype = {
       throw new core.DOMException(core.DOMException.NO_MODIFICATION_ALLOWED_ERR, 'Attempting to modify a read-only node');
     }
 
-    // Adopt unowned children, for weird nodes like DocumentType
-    if (!newChild._ownerDocument) newChild._ownerDocument = this._ownerDocument;
+    // DocumentType must be implicitly adopted
+    if (newChild.nodeType === DOCUMENT_TYPE_NODE) newChild._ownerDocument = this._ownerDocument;
 
     // TODO - if (!newChild) then?
     if (!(this instanceof core.Document) && newChild._ownerDocument !== this._ownerDocument) {
@@ -1450,8 +1441,11 @@ core.Document = function Document(options) {
   core.Node.call(this, this);
   this._parsingMode = options.parsingMode;
   this._htmlToDom = new HtmlToDom(options.parser, options.parsingMode);
-  this._implementation = new core.DOMImplementation(this);
-  this._defaultView = options.defaultView;
+
+  this._implementation = Object.create(core.DOMImplementation.prototype);
+  this._implementation._ownerDocument = this;
+  this._implementation._features = {};
+
   this._global = options.global;
   this._documentElement = null;
   this._ids = Object.create(null);

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1446,6 +1446,7 @@ core.Document = function Document(options) {
   this._implementation._ownerDocument = this;
   this._implementation._features = {};
 
+  this._defaultView = options.defaultView || null;
   this._global = options.global;
   this._documentElement = null;
   this._ids = Object.create(null);

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -1520,7 +1520,7 @@ inheritFrom(core.Node, core.Document, {
     return this._URL;
   },
   get location() {
-    return this._location;
+    return this._defaultView ? this._location : null;
   },
   get documentElement() {
     if (this._documentElement) {

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1862,6 +1862,11 @@ function loadFrame (frame) {
 
 function refreshAccessors(document) {
   var window = document._defaultView;
+
+  if (!window) {
+    return;
+  }
+
   var frames = document.querySelectorAll("iframe,frame");
 
   // delete accessors for all frames
@@ -1876,6 +1881,10 @@ function refreshAccessors(document) {
 }
 
 function refreshNameAccessor(frame) {
+  if (!frame._ownerDocument._defaultView) {
+    return;
+  }
+
   var name = frame.getAttribute("name");
   // https://html.spec.whatwg.org/multipage/browsers.html#named-access-on-the-window-object:supported-property-names
   if (name !== null && name !== "") {
@@ -1914,7 +1923,9 @@ define('HTMLFrameElement', {
         }
         refreshNameAccessor(this);
       } else if (name === 'src') {
-        if (isInDocument(this)) {
+        // iframe should never load in a document without a Window
+        // (e.g. implementation.createHTMLDocument)
+        if (isInDocument(this) && this._ownerDocument._defaultView) {
           loadFrame(this);
         }
       }
@@ -1934,20 +1945,19 @@ define('HTMLFrameElement', {
     _attach: function () {
       core.HTMLElement.prototype._attach.call(this);
 
-      loadFrame(this);
+      if (this._ownerDocument._defaultView) {
+        loadFrame(this);
+      }
       refreshAccessors(this._ownerDocument);
       refreshNameAccessor(this);
     },
 
     _contentDocument : null,
     get contentDocument() {
-      if (this._contentDocument == null) {
-        this._contentDocument = new core.HTMLDocument({ parsingMode: "html" });
-      }
       return this._contentDocument;
     },
     get contentWindow() {
-      return this.contentDocument.defaultView;
+      return this.contentDocument ? this.contentDocument.defaultView : null;
     }
   },
   attributes: [

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -576,10 +576,14 @@ define('HTMLBodyElement', {
      'onpagehide', 'onpageshow', 'onpopstate', 'onresize', 'onscroll',
      'onstorage', 'onunload'].forEach(function (name) {
       defineSetter(proto, name, function (handler) {
-        this._ownerDocument.defaultView[name] = handler;
+        const window = this._ownerDocument.defaultView;
+        if (window) {
+          window[name] = handler;
+        }
       });
       defineGetter(proto, name, function () {
-        return this._ownerDocument.defaultView[name];
+        const window = this._ownerDocument.defaultView;
+        return window ? window[name] : null;
       });
     });
     return proto;

--- a/test/living-dom/dom-implementation.js
+++ b/test/living-dom/dom-implementation.js
@@ -1,29 +1,29 @@
 "use strict";
-var jsdom = require("../..");
+const jsdom = require("../..");
 
 
 exports["create an empty document"] = function (t) {
-  var DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
-  var dom = new DOMImplementation();
-  var document = dom.createDocument(null, null, null);
+  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
+  const dom = new DOMImplementation();
+  const document = dom.createDocument(null, null, null);
   t.equal(document.childNodes.length, 0, "document should not contain any nodes");
   t.done();
 };
 
 exports["doctype ownerDocument"] = function (t) {
-  var DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
-  var dom = new DOMImplementation();
-  var doctype = dom.createDocumentType("bananas");
-  var document = dom.createDocument(null, null, doctype);
+  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
+  const dom = new DOMImplementation();
+  const doctype = dom.createDocumentType("bananas");
+  const document = dom.createDocument(null, null, doctype);
   t.equal(doctype.ownerDocument, document, "doctype should belong to the document");
   t.done();
 };
 
 exports["doctype child of ownerDocument"] = function (t) {
-  var DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
-  var dom = new DOMImplementation();
-  var doctype = dom.createDocumentType("hatstand");
-  var document = dom.createDocument(null, null, doctype);
+  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
+  const dom = new DOMImplementation();
+  const doctype = dom.createDocumentType("hatstand");
+  const document = dom.createDocument(null, null, doctype);
   t.equal(document.firstChild, doctype, "doctype should be a child of the document");
   t.done();
 };

--- a/test/living-dom/dom-implementation.js
+++ b/test/living-dom/dom-implementation.js
@@ -49,3 +49,17 @@ exports["location should be null"] = function (t) {
   t.strictEqual(newDocument.location, null, "location should be null");
   t.done();
 };
+
+exports["setting proxied event handlers on the body should have no effect"] = function (t) {
+  const document = jsdom.jsdom();
+  const newDocument = document.implementation.createHTMLDocument();
+
+  ["onafterprint", "onbeforeprint", "onbeforeunload", "onblur", "onerror",
+   "onfocus", "onhashchange", "onload", "onmessage", "onoffline", "ononline",
+   "onpagehide", "onpageshow", "onpopstate", "onresize", "onscroll",
+   "onstorage", "onunload"].forEach(function (name) {
+    newDocument.body[name] = "1 + 2";
+    t.strictEqual(newDocument.body[name], null, name + " should always be null because there is no window");
+  });
+  t.done();
+};

--- a/test/living-dom/dom-implementation.js
+++ b/test/living-dom/dom-implementation.js
@@ -63,3 +63,21 @@ exports["setting proxied event handlers on the body should have no effect"] = fu
   });
   t.done();
 };
+
+exports["iframe added to a created Document should not load"] = function (t) {
+  const document = jsdom.jsdom();
+  const newDocument = document.implementation.createHTMLDocument();
+
+  const iframe = newDocument.createElement("iframe");
+  // iframe's with a name are added as a property to the window, this line is added to see if things crash
+  iframe.setAttribute("name", "foobar");
+  newDocument.body.appendChild(iframe);
+  t.strictEqual(iframe.contentWindow, null, "contentWindow should be null, the iframe should never load");
+  t.strictEqual(iframe.contentDocument, null, "contentDocument should be null, the iframe should never load");
+
+  iframe.src = "http://example.com/"; // try to trigger a load action
+  t.strictEqual(iframe.contentWindow, null, "contentWindow should be null, the iframe should never load");
+  t.strictEqual(iframe.contentDocument, null, "contentDocument should be null, the iframe should never load");
+
+  t.done();
+};

--- a/test/living-dom/dom-implementation.js
+++ b/test/living-dom/dom-implementation.js
@@ -1,29 +1,39 @@
 "use strict";
 const jsdom = require("../..");
 
+exports["new DOMImplementation() is not allowed"] = function (t) {
+  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
+
+  let foo;
+  t.throws(function () {
+    foo = new DOMImplementation();
+  }, /Illegal constructor/i);
+
+  t.done();
+};
 
 exports["create an empty document"] = function (t) {
-  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
-  const dom = new DOMImplementation();
-  const document = dom.createDocument(null, null, null);
+  const implementation = jsdom.jsdom().implementation;
+  const document = implementation.createDocument(null, null, null);
   t.equal(document.childNodes.length, 0, "document should not contain any nodes");
   t.done();
 };
 
 exports["doctype ownerDocument"] = function (t) {
-  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
-  const dom = new DOMImplementation();
-  const doctype = dom.createDocumentType("bananas");
-  const document = dom.createDocument(null, null, doctype);
-  t.equal(doctype.ownerDocument, document, "doctype should belong to the document");
+  const document = jsdom.jsdom();
+  const doctype = document.implementation.createDocumentType("bananas");
+  t.ok(doctype.ownerDocument === document, "doctype should belong to the document the implementation belongs to");
+  const newDocument = document.implementation.createDocument(null, null, doctype);
+  t.ok(doctype.ownerDocument === newDocument, "doctype should belong to the new document");
   t.done();
 };
 
 exports["doctype child of ownerDocument"] = function (t) {
-  const DOMImplementation = jsdom.jsdom().defaultView.DOMImplementation;
-  const dom = new DOMImplementation();
-  const doctype = dom.createDocumentType("hatstand");
-  const document = dom.createDocument(null, null, doctype);
-  t.equal(document.firstChild, doctype, "doctype should be a child of the document");
+  const document = jsdom.jsdom();
+  const doctype = document.implementation.createDocumentType("hatstand");
+  const newDocument = document.implementation.createDocument(null, null, doctype);
+  t.ok(newDocument.firstChild === doctype, "doctype should be a child of the document");
+  t.done();
+};
   t.done();
 };

--- a/test/living-dom/dom-implementation.js
+++ b/test/living-dom/dom-implementation.js
@@ -35,5 +35,10 @@ exports["doctype child of ownerDocument"] = function (t) {
   t.ok(newDocument.firstChild === doctype, "doctype should be a child of the document");
   t.done();
 };
+
+exports["defaultView should be null"] = function (t) {
+  const document = jsdom.jsdom();
+  const newDocument = document.implementation.createDocument(null, null, null);
+  t.strictEqual(newDocument.defaultView, null, "defaultView should be null");
   t.done();
 };

--- a/test/living-dom/dom-implementation.js
+++ b/test/living-dom/dom-implementation.js
@@ -42,3 +42,10 @@ exports["defaultView should be null"] = function (t) {
   t.strictEqual(newDocument.defaultView, null, "defaultView should be null");
   t.done();
 };
+
+exports["location should be null"] = function (t) {
+  const document = jsdom.jsdom();
+  const newDocument = document.implementation.createHTMLDocument();
+  t.strictEqual(newDocument.location, null, "location should be null");
+  t.done();
+};


### PR DESCRIPTION
It is possible to create a `Document` without a `Window` (null `defaultView`) using `DOMImplementation`: `newDocument = document.implementation.createHTMLDocument()`.

There are various places in jsdom that blow up on such a Document. I've fixed these.

There were also a few bad test cases that violate the specifications & browsers.