### PR TITLE
Add createVirtualConsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,9 @@ var virtualConsole = jsdom.createVirtualConsole();
 
 virtualConsole.sendTo(console);
 
-var window = jsdom.jsdom(null, {
+var document = jsdom.jsdom(undefined, {
   virtualConsole: virtualConsole
-}).defaultView;
+});
 ```
 
 #### Get an event emitter for a window's console
@@ -418,9 +418,9 @@ virtualConsole.on("log", function (message) {
   console.log("console.log called ->", message);
 });
 
-var window = jsdom.jsdom(null, {
+var document = jsdom.jsdom(undefined, {
   virtualConsole: virtualConsole
-}).defaultView;
+});
 ```
 
 ## What Standards Does jsdom Support, Exactly?

--- a/README.md
+++ b/README.md
@@ -397,8 +397,13 @@ jsdom.env({
 
 ```js
 var jsdom = require("jsdom");
+
+var virtualConsole = jsdom.createVirtualConsole();
+
+virtualConsole.sendTo(console);
+
 var window = jsdom.jsdom(null, {
-  sendConsoleTo: console
+  virtualConsole: virtualConsole
 }).defaultView;
 ```
 

--- a/README.md
+++ b/README.md
@@ -397,22 +397,25 @@ jsdom.env({
 
 ```js
 var jsdom = require("jsdom");
-var window = jsdom.jsdom().defaultView;
-
-jsdom.getVirtualConsole(window).sendTo(console);
+var window = jsdom.jsdom(null, {
+  sendConsoleTo: console
+}).defaultView;
 ```
 
 #### Get an event emitter for a window's console
 
 ```js
 var jsdom = require("jsdom");
-var window = jsdom.jsdom().defaultView;
 
-var virtualConsole = jsdom.getVirtualConsole(window);
+var virtualConsole = jsdom.createVirtualConsole();
 
 virtualConsole.on("log", function (message) {
   console.log("console.log called ->", message);
 });
+
+var window = jsdom.jsdom(null, {
+  virtualConsole: virtualConsole
+}).defaultView;
 ```
 
 ## What Standards Does jsdom Support, Exactly?

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -72,7 +72,8 @@ exports.jsdom = function (html, options) {
     resourceLoader: options.resourceLoader,
     deferClose: options.deferClose,
     concurrentNodeIterators: options.concurrentNodeIterators,
-    virtualConsole: options.virtualConsole 
+    virtualConsole: options.virtualConsole,
+    sendConsoleTo: options.sendConsoleTo
   });
 
   if (options.created) {

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -15,10 +15,15 @@ var features = require("./jsdom/browser/documentfeatures");
 var domToHtml = require("./jsdom/browser/domtohtml").domToHtml;
 var Window = require("./jsdom/browser/Window");
 var resourceLoader = require("./jsdom/browser/resource-loader");
+var VirtualConsole = require("./jsdom/virtual-console");
 
 require("./jsdom/living"); //Enable living standard features
 
 var canReadFilesFromFS = !!fs.readFile; // in a browserify environment, this isn"t present
+
+exports.createVirtualConsole = function () {
+  return new VirtualConsole();
+};
 
 exports.getVirtualConsole = function (window) {
   return window._virtualConsole;
@@ -66,7 +71,8 @@ exports.jsdom = function (html, options) {
     cookie: options.cookie,
     resourceLoader: options.resourceLoader,
     deferClose: options.deferClose,
-    concurrentNodeIterators: options.concurrentNodeIterators
+    concurrentNodeIterators: options.concurrentNodeIterators,
+    virtualConsole: options.virtualConsole 
   });
 
   if (options.created) {

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -72,8 +72,7 @@ exports.jsdom = function (html, options) {
     resourceLoader: options.resourceLoader,
     deferClose: options.deferClose,
     concurrentNodeIterators: options.concurrentNodeIterators,
-    virtualConsole: options.virtualConsole,
-    sendConsoleTo: options.sendConsoleTo
+    virtualConsole: options.virtualConsole
   });
 
   if (options.created) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -72,7 +72,7 @@ function Window(options) {
     if (options.virtualConsole instanceof VirtualConsole) {
       this._virtualConsole = options.virtualConsole;
     } else {
-      throw new Error(
+      throw new TypeError(
         "options.virtualConsole must be a VirtualConsole (from createVirtualConsole)");
     }
   } else {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -68,7 +68,16 @@ function Window(options) {
   // HTMLFrameElement init function (see: level2/html.js).
   this._length = 0;
 
-  this._virtualConsole = options.virtualConsole || new VirtualConsole();
+  if (options.virtualConsole) {
+    if (options.virtualConsole instanceof VirtualConsole) {
+      this._virtualConsole = options.virtualConsole;
+    } else {
+      throw new Error(
+        "options.virtualConsole must be a VirtualConsole (from createVirtualConsole)");
+    }
+  } else {
+    this._virtualConsole = new VirtualConsole();
+  }
 
   ///// GETTERS
 

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -68,7 +68,7 @@ function Window(options) {
   // HTMLFrameElement init function (see: level2/html.js).
   this._length = 0;
 
-  this._virtualConsole = new VirtualConsole();
+  this._virtualConsole = options.virtualConsole || new VirtualConsole();
 
   ///// GETTERS
 

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -70,10 +70,6 @@ function Window(options) {
 
   this._virtualConsole = options.virtualConsole || new VirtualConsole();
 
-  if (options.sendConsoleTo) {
-    this._virtualConsole.sendTo(options.sendConsoleTo);
-  }
-
   ///// GETTERS
 
   define(this, {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -70,6 +70,10 @@ function Window(options) {
 
   this._virtualConsole = options.virtualConsole || new VirtualConsole();
 
+  if (options.sendConsoleTo) {
+    this._virtualConsole.sendTo(options.sendConsoleTo);
+  }
+
   ///// GETTERS
 
   define(this, {

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -74,17 +74,16 @@ exports["virtualConsole separates output by window"] = function (t) {
 };
 
 exports["virtualConsole.sendTo proxies console methods"] = function (t) {
+  t.expect(consoleMethods.length);
+
   var window = jsdom.jsdom().defaultView;
   var virtualConsole = jsdom.getVirtualConsole(window);
   var fakeConsole = {};
 
-  var counter = 0;
-  function inc() {
-    ++counter;
-  }
-
   consoleMethods.forEach(function (method) {
-    fakeConsole[method] = inc;
+    fakeConsole[method] = function () {
+      t.ok(true, "sendTo works on all console methods");
+    };
   });
 
   virtualConsole.sendTo(fakeConsole);
@@ -92,8 +91,6 @@ exports["virtualConsole.sendTo proxies console methods"] = function (t) {
   consoleMethods.forEach(function (method) {
     window.console[method]();
   });
-
-  t.ok(counter === consoleMethods.length, "sendTo works on console methods");
 
   t.done();
 };

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -97,3 +97,29 @@ exports["virtualConsole.sendTo proxies console methods"] = function (t) {
 
   t.done();
 };
+
+exports["createVirtualConsole returns a new virtual console"] = function (t) {
+  var window = jsdom.jsdom().defaultView;
+  var virtualConsole = jsdom.createVirtualConsole();
+
+  t.ok(virtualConsole instanceof EventEmitter,
+    "createVirtualConsole returns an instance of EventEmitter");
+
+  t.done();
+};
+
+exports["jsdom setup accepts a virtual console"] = function (t) {
+  var initialVirtualConsole = jsdom.createVirtualConsole();
+
+  initialVirtualConsole.foo = "bar";
+
+  var window = jsdom.jsdom("", {
+    virtualConsole: initialVirtualConsole
+  }).defaultView;
+
+  var actualVirtualConsole = jsdom.getVirtualConsole(window); 
+  t.ok(initialVirtualConsole === actualVirtualConsole,
+    "getVirtualConsole returns the console given in options");
+
+  t.done();
+};

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -110,40 +110,18 @@ exports["jsdom setup accepts a virtual console"] = function (t) {
   var initialVirtualConsole = jsdom.createVirtualConsole();
 
   initialVirtualConsole.on("log", function (message) {
-    t.ok(message === "yes", 
+    t.ok(message === "yes",
       "supplied virtual console emits messages");
     t.done();
-  }); 
+  });
 
   var window = jsdom.jsdom("", {
     virtualConsole: initialVirtualConsole
   }).defaultView;
 
-  var actualVirtualConsole = jsdom.getVirtualConsole(window); 
+  var actualVirtualConsole = jsdom.getVirtualConsole(window);
   t.ok(initialVirtualConsole === actualVirtualConsole,
     "getVirtualConsole returns the console given in options");
 
   window.console.log("yes");
-};
-
-exports["sendConsoleTo in config proxies console methods"] = function (t) {
-  t.expect(consoleMethods.length);
-  var fakeConsole = {};
-
-  consoleMethods.forEach(function (method) {
-    fakeConsole[method] = function () {
-      t.ok(true,
-        "all console methods are passed through sendConsoleTo config");
-    };
-  });
-
-  var window = jsdom.jsdom(null, {
-    sendConsoleTo: fakeConsole
-  }).defaultView;
-
-  consoleMethods.forEach(function (method) {
-    window.console[method]();
-  });
-
-  t.done();
 };

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -109,9 +109,14 @@ exports["createVirtualConsole returns a new virtual console"] = function (t) {
 };
 
 exports["jsdom setup accepts a virtual console"] = function (t) {
+  t.expect(2);
   var initialVirtualConsole = jsdom.createVirtualConsole();
 
-  initialVirtualConsole.foo = "bar";
+  initialVirtualConsole.on("log", function (message) {
+    t.ok(message === "yes", 
+      "supplied virtual console emits messages");
+    t.done();
+  }); 
 
   var window = jsdom.jsdom("", {
     virtualConsole: initialVirtualConsole
@@ -121,5 +126,5 @@ exports["jsdom setup accepts a virtual console"] = function (t) {
   t.ok(initialVirtualConsole === actualVirtualConsole,
     "getVirtualConsole returns the console given in options");
 
-  t.done();
+  window.console.log("yes");
 };

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -96,7 +96,6 @@ exports["virtualConsole.sendTo proxies console methods"] = function (t) {
 };
 
 exports["createVirtualConsole returns a new virtual console"] = function (t) {
-  var window = jsdom.jsdom().defaultView;
   var virtualConsole = jsdom.createVirtualConsole();
 
   t.ok(virtualConsole instanceof EventEmitter,

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -128,3 +128,25 @@ exports["jsdom setup accepts a virtual console"] = function (t) {
 
   window.console.log("yes");
 };
+
+exports["sendConsoleTo in config proxies console methods"] = function (t) {
+  t.expect(consoleMethods.length);
+  var initialVirtualConsole = jsdom.createVirtualConsole();
+
+  consoleMethods.forEach(function (method) {
+    initialVirtualConsole[method] = function () {
+      t.ok(true,
+        "all console methods are passed through sendConsoleTo config");
+    };
+  });
+
+  var window = jsdom.jsdom(null, {
+    sendConsoleTo: initialVirtualConsole
+  }).defaultView;
+
+  consoleMethods.forEach(function (method) {
+    window.console[method]();
+  });
+
+  t.done();
+};

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -103,7 +103,6 @@ exports["virtualConsole.sendTo proxies console methods"] = function (t) {
 };
 
 exports["createVirtualConsole returns a new virtual console"] = function (t) {
-  var window = jsdom.jsdom().defaultView;
   var virtualConsole = jsdom.createVirtualConsole();
 
   t.ok(virtualConsole instanceof VirtualConsole,

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -128,17 +128,17 @@ exports["jsdom setup accepts a virtual console"] = function (t) {
 
 exports["sendConsoleTo in config proxies console methods"] = function (t) {
   t.expect(consoleMethods.length);
-  var initialVirtualConsole = jsdom.createVirtualConsole();
+  var fakeConsole = {};
 
   consoleMethods.forEach(function (method) {
-    initialVirtualConsole[method] = function () {
+    fakeConsole[method] = function () {
       t.ok(true,
         "all console methods are passed through sendConsoleTo config");
     };
   });
 
   var window = jsdom.jsdom(null, {
-    sendConsoleTo: initialVirtualConsole
+    sendConsoleTo: fakeConsole
   }).defaultView;
 
   consoleMethods.forEach(function (method) {

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -115,7 +115,7 @@ exports["jsdom setup accepts a virtual console"] = function (t) {
     t.done();
   });
 
-  var window = jsdom.jsdom("", {
+  var window = jsdom.jsdom(null, {
     virtualConsole: initialVirtualConsole
   }).defaultView;
 
@@ -124,4 +124,14 @@ exports["jsdom setup accepts a virtual console"] = function (t) {
     "getVirtualConsole returns the console given in options");
 
   window.console.log("yes");
+};
+
+exports["virtualConsole option throws on bad input"] = function (t) {
+  t.throws(function () {
+    jsdom.jsdom(null, {
+      virtualConsole: {}
+    });
+  });
+
+  t.done();
 };

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -2,6 +2,7 @@
 
 var jsdom = require("../..");
 var EventEmitter = require("events").EventEmitter;
+var VirtualConsole = require("../../lib/jsdom/virtual-console");
 
 var consoleMethods = [
   "assert",
@@ -21,10 +22,16 @@ var consoleMethods = [
   "warn"
 ];
 
-exports["jsdom.getVirtualConsole returns an instance of EventEmitter"] = function (t) {
+exports["VirtualConsole inherits from EventEmitter"] = function (t) {
+  var vc = new VirtualConsole();
+  t.ok(vc instanceof EventEmitter, "VirtualConsole inherits from EventEmitter");
+  t.done();
+};
+
+exports["jsdom.getVirtualConsole returns an instance of VirtualConsole"] = function (t) {
   var window = jsdom.jsdom().defaultView;
   var vc = jsdom.getVirtualConsole(window);
-  t.ok(vc instanceof EventEmitter, "getVirtualConsole returns an instance of EventEmitter");
+  t.ok(vc instanceof VirtualConsole, "getVirtualConsole returns an instance of VirtualConsole");
   t.done();
 };
 
@@ -99,8 +106,8 @@ exports["createVirtualConsole returns a new virtual console"] = function (t) {
   var window = jsdom.jsdom().defaultView;
   var virtualConsole = jsdom.createVirtualConsole();
 
-  t.ok(virtualConsole instanceof EventEmitter,
-    "createVirtualConsole returns an instance of EventEmitter");
+  t.ok(virtualConsole instanceof VirtualConsole,
+    "createVirtualConsole returns an instance of VirtualConsole");
 
   t.done();
 };

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -2,7 +2,6 @@
 
 var jsdom = require("../..");
 var EventEmitter = require("events").EventEmitter;
-var VirtualConsole = require("../../lib/jsdom/virtual-console");
 
 var consoleMethods = [
   "assert",
@@ -22,16 +21,10 @@ var consoleMethods = [
   "warn"
 ];
 
-exports["VirtualConsole inherits from EventEmitter"] = function (t) {
-  var vc = new VirtualConsole();
-  t.ok(vc instanceof EventEmitter, "VirtualConsole inherits from EventEmitter");
-  t.done();
-};
-
-exports["jsdom.getVirtualConsole returns an instance of VirtualConsole"] = function (t) {
+exports["jsdom.getVirtualConsole returns an instance of EventEmitter"] = function (t) {
   var window = jsdom.jsdom().defaultView;
   var vc = jsdom.getVirtualConsole(window);
-  t.ok(vc instanceof VirtualConsole, "getVirtualConsole returns an instance of VirtualConsole");
+  t.ok(vc instanceof EventEmitter, "getVirtualConsole returns an instance of EventEmitter");
   t.done();
 };
 
@@ -103,10 +96,11 @@ exports["virtualConsole.sendTo proxies console methods"] = function (t) {
 };
 
 exports["createVirtualConsole returns a new virtual console"] = function (t) {
+  var window = jsdom.jsdom().defaultView;
   var virtualConsole = jsdom.createVirtualConsole();
 
-  t.ok(virtualConsole instanceof VirtualConsole,
-    "createVirtualConsole returns an instance of VirtualConsole");
+  t.ok(virtualConsole instanceof EventEmitter,
+    "createVirtualConsole returns an instance of EventEmitter");
 
   t.done();
 };


### PR DESCRIPTION
As outlined in #1049, this to fix the problem that it is currently impossible to capture console events between the time jsdom is initialized and `getVirtualConsole` is called. 

```js
var window = jsdom.jsdom().defaultView;
// Any console events fired here will be lost
var virtualConsole = jsdom.getVirtualconsole(window);
virtualConsole.on('log', console.log);
```

This PR allows you to create a virtual console and pass it in as a config option.

```js
var virtualConsole = jsdom.createVirtualConsole();
virtualConsole.on('log', console.log);

var window = jsdom.jsdom(null, {
  virtualConsole: virtualConsole
}).defaultView;
```

I also updated the README for this to be the default way of capturing console output, so that there is less confusion in the future.