### PR TITLE
Improve named properties

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -9,6 +9,7 @@ var VirtualConsole = require("../virtual-console");
 var define = require("../utils").define;
 var inherits = require("../utils").inheritFrom;
 var EventTarget = require("../events/EventTarget");
+var namedPropertiesWindow = require("../living/named-properties-window");
 
 // NB: the require() must be after assigning `module.export` because this require() is circular
 module.exports = Window;
@@ -104,6 +105,8 @@ function Window(options) {
       return window._document._location;
     }
   });
+
+  namedPropertiesWindow.initializeWindow(this, dom.HTMLCollection);
 
   ///// METHODS for [ImplicitThis] hack
   // See https://lists.w3.org/Archives/Public/public-script-coord/2015JanMar/0109.html

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -10,15 +10,12 @@ var define = require("../utils").define;
 var inherits = require("../utils").inheritFrom;
 var EventTarget = require("../events/EventTarget");
 
-// NB: this is requiring level 1 to break the circular dependency chain that would otherwise arise.
-// A better structure would be to use the style from living/, where we export a function which takes a dom object
-// and use/augment that. Or maybe we should use the style from EventTarget, where we export the constructor? But
-// I don't see a way to avoid circular references in that situation.
-var dom = require("../level1/core");
+// NB: the require() must be after assigning `module.export` because this require() is circular
+module.exports = Window;
+var dom = require("../living");
 
 var cssSelectorSplitRE = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
 
-module.exports = Window;
 dom.Window = Window;
 
 // NOTE: per https://heycam.github.io/webidl/#Global, all properties on the Window object must be own-properties.

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -11,6 +11,7 @@ var Location = require("../browser/location");
 var vm = require("vm");
 var CookieJar = require('tough-cookie').CookieJar;
 var EventTarget = require("../events/EventTarget");
+var mapper = require("../utils").mapper;
 
 // utility functions
 var attachId = function(id,elm,doc) {
@@ -55,70 +56,7 @@ function setInnerHTML(document, node, html) {
   }
 }
 
-// TODO: move all of these to utils.js. Right now they are exposed on window, which is bizarre.
-var core = module.exports = {
-  mapper: function(parent, filter, recursive) {
-    return function() {
-      return core.mapDOMNodes(parent, recursive !== false, filter);
-    };
-  },
-
-  // Returns Array
-  mapDOMNodes : function(parent, recursive, callback) {
-    function visit(parent, result) {
-      return parent._childNodes.reduce(reducer, result);
-    }
-
-    function reducer(array, child) {
-      if (callback(child)) {
-        array.push(child);
-      }
-      if (recursive && child._childNodes) {
-        visit(child, array);
-      }
-      return array;
-    }
-
-    return visit(parent, []);
-  },
-
-  visitTree: function(root, callback) {
-    var cur = root; // TODO: Unroll this.
-
-    function visit(el) {
-      if (el) {
-        callback(el);
-        if (el._childNodes) {
-          var i        = 0,
-              children = el._childNodes,
-              l        = children.length;
-
-          for (i; i<l; i++) {
-            visit(children[i]);
-          }
-        }
-      }
-    }
-    visit(root);
-  },
-
-  markTreeReadonly: function(node) {
-    function markLevel(el) {
-      el._readonly = true;
-      // also mark attributes and their children read-only
-      if (el.attributes) {
-        var attributes = el.attributes, l = attributes.length, i=0;
-        attributes._readonly = true;
-
-        for (i; i<l; i++) {
-          core.visitTree(attributes[i], markLevel);
-        }
-      }
-    }
-
-    core.visitTree(node, markLevel);
-  }
-};
+var core = exports;
 
 core.DOMException = require("../web-idl/DOMException");
 
@@ -1421,7 +1359,7 @@ inheritFrom(core.Node, core.Element, {
 
       return false;
     }
-    return new core.NodeList(this._ownerDocument || this, core.mapper(this, filterByTagName, true));
+    return new core.NodeList(this._ownerDocument || this, mapper(this, filterByTagName, true));
   }),
 
   getElementsByClassName: function (className) {
@@ -1443,7 +1381,7 @@ inheritFrom(core.Node, core.Element, {
       return false;
     }
 
-    return new core.NodeList(this.ownerDocument || this, core.mapper(this, filterByClassName));
+    return new core.NodeList(this.ownerDocument || this, mapper(this, filterByClassName));
   }
 });
 
@@ -1641,7 +1579,7 @@ inheritFrom(core.Node, core.Document, {
       }
       return false;
     }
-    return new core.NodeList(this.documentElement || this, core.mapper(this, filterByTagName, true));
+    return new core.NodeList(this.documentElement || this, mapper(this, filterByTagName, true));
   }),
 
   getElementsByClassName: function (className) {
@@ -1663,7 +1601,7 @@ inheritFrom(core.Node, core.Document, {
       return false;
     }
 
-    return new core.NodeList(this.ownerDocument || this, core.mapper(this, filterByClassName));
+    return new core.NodeList(this.ownerDocument || this, mapper(this, filterByClassName));
   },
 
   write: function () {

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -12,6 +12,8 @@ var vm = require("vm");
 var CookieJar = require('tough-cookie').CookieJar;
 var EventTarget = require("../events/EventTarget");
 var mapper = require("../utils").mapper;
+var namedPropertiesWindow = require("../living/named-properties-window");
+var Window = require('../browser/Window');
 
 // utility functions
 var attachId = function(id,elm,doc) {
@@ -521,6 +523,8 @@ core.Node.prototype = {
   },
 
   _attrModified: function(name, value, oldValue) {
+    namedPropertiesWindow.elementAttributeModified(this, name, value, oldValue);
+
     if (name == 'id' && this._attached) {
       var doc = this._ownerDocument;
       detachId(oldValue,this,doc);
@@ -573,6 +577,8 @@ core.Node.prototype = {
   /* returns void */
   _attach : function() {
     this._attached = true;
+    namedPropertiesWindow.nodeAttachedToDocument(this);
+
     if (this.id) {
       attachId(this.id,this,this._ownerDocument);
     }
@@ -584,8 +590,10 @@ core.Node.prototype = {
   },
   /* returns void */
   _detach : function() {
-    var i, elms;
     this._attached = false;
+
+    namedPropertiesWindow.nodeDetachedFromDocument(this);
+
     if (this.id) {
       detachId(this.id,this,this._ownerDocument);
     }

--- a/lib/jsdom/level2/core.js
+++ b/lib/jsdom/level2/core.js
@@ -4,6 +4,8 @@ var defineSetter = require('../utils').defineSetter;
 var memoizeQuery = require('../utils').memoizeQuery;
 var validateQname = require('../living/helpers/validate-names').qname;
 var validateAndExtract = require('../living/helpers/validate-names').validateAndExtract;
+var mapper = require("../utils").mapper;
+var visitTree = require("../utils").visitTree;
 
 core.NamedNodeMap.prototype.getNamedItemNS = function(/* string */ namespaceURI,
                                                       /* string */ localName)
@@ -187,7 +189,7 @@ core.Element.prototype.getElementsByTagNameNS = memoizeQuery(function(/* String 
   }
 
   return new core.NodeList(this.ownerDocument || this,
-                           core.mapper(this, filterByTagName));
+                           mapper(this, filterByTagName));
 });
 
 core.Element.prototype.hasAttribute = function(/* string */name)
@@ -256,7 +258,7 @@ core.Document.prototype.importNode = function(/* Node */ importedNode,
   }
 
   if (deep) {
-    core.visitTree(newNode, lastChance);
+    visitTree(newNode, lastChance);
   }
   else {
     lastChance(newNode);

--- a/lib/jsdom/level2/events.js
+++ b/lib/jsdom/level2/events.js
@@ -7,7 +7,8 @@ var core = require("../level1/core"),
     utils = require("../utils"),
     defineGetter = utils.defineGetter,
     defineSetter = utils.defineSetter,
-    inheritFrom = utils.inheritFrom;
+    inheritFrom = utils.inheritFrom,
+    visitTree = require("../utils").visitTree;
 
 core.Event = function(eventType, eventInit) {
     this._type = eventType || null;
@@ -178,7 +179,7 @@ core.Node.prototype.insertBefore = function(newChild, refChild) {
     if (this.nodeType == core.Node.DOCUMENT_NODE || this._attachedToDocument) {
       ev = doc.createEvent("MutationEvents");
       ev.initMutationEvent("DOMNodeInsertedIntoDocument", false, false, null, null, null, null, null);
-      core.visitTree(newChild, function(el) {
+      visitTree(newChild, function(el) {
         if (el.nodeType == core.Node.ELEMENT_NODE) {
           el.dispatchEvent(ev);
           el._attachedToDocument = true;
@@ -200,7 +201,7 @@ core.Node.prototype.removeChild = function (oldChild) {
 
     ev = doc.createEvent("MutationEvents");
     ev.initMutationEvent("DOMNodeRemovedFromDocument", false, false, null, null, null, null, null);
-    core.visitTree(oldChild, function(el) {
+    visitTree(oldChild, function(el) {
       if (el.nodeType == core.Node.ELEMENT_NODE) {
         el.dispatchEvent(ev);
         el._attachedToDocument = false;

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -6,7 +6,10 @@ var resourceLoader        = require('../browser/resource-loader'),
     inheritFrom           = require("../utils").inheritFrom,
     Window                = require("../browser/Window"),
     URL                   = require("url"),
-    fs                    = require("fs");
+    fs                    = require("fs"),
+    visitTree             = require("../utils").visitTree,
+    mapper                = require("../utils").mapper,
+    mapDOMNodes           = require("../utils").mapDOMNodes;
 
 
 // Setup the javascript language processor
@@ -162,7 +165,7 @@ function closest(e, tagName) {
 
 function descendants(e, tagName, recursive) {
   var owner = recursive ? e._ownerDocument || e : e;
-  return new core.HTMLCollection(owner, core.mapper(e, function(n) {
+  return new core.HTMLCollection(owner, mapper(e, function(n) {
     return n.tagName === tagName;
   }, recursive));
 }
@@ -261,7 +264,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
     return this.getElementsByTagName('IMG');
   },
   get applets() {
-    return new core.HTMLCollection(this, core.mapper(this, function(el) {
+    return new core.HTMLCollection(this, mapper(this, function(el) {
       if (el && el.tagName) {
         var upper = el.tagName.toUpperCase();
         if (upper === "APPLET") {
@@ -275,7 +278,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
     }));
   },
   get links() {
-    return new core.HTMLCollection(this, core.mapper(this, function(el) {
+    return new core.HTMLCollection(this, mapper(this, function(el) {
       if (el && el.tagName) {
         var upper = el.tagName.toUpperCase();
         if (upper === "AREA" || (upper === "A" && el.href)) {
@@ -314,7 +317,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
   },
 
   getElementsByName : function(elementName) {
-    return new core.HTMLCollection(this, core.mapper(this, function(el) {
+    return new core.HTMLCollection(this, mapper(this, function(el) {
       return (el.getAttribute && el.getAttribute("name") === elementName);
     }));
   },
@@ -424,7 +427,7 @@ define('HTMLFormElement', {
   proto: {
     _descendantAdded: function(parent, child) {
       var form = this;
-      core.visitTree(child, function(el) {
+      visitTree(child, function(el) {
         if (typeof el._changedFormOwner === 'function') {
           el._changedFormOwner(form);
         }
@@ -433,7 +436,7 @@ define('HTMLFormElement', {
       core.HTMLElement.prototype._descendantAdded.apply(this, arguments);
     },
     _descendantRemoved: function(parent, child) {
-      core.visitTree(child, function(el) {
+      visitTree(child, function(el) {
         if (typeof el._changedFormOwner === 'function') {
           el._changedFormOwner(null);
         }
@@ -442,7 +445,7 @@ define('HTMLFormElement', {
       core.HTMLElement.prototype._descendantRemoved.apply(this, arguments);
     },
     get elements() {
-      return new core.HTMLCollection(this._ownerDocument, core.mapper(this, function(e) {
+      return new core.HTMLCollection(this._ownerDocument, mapper(this, function(e) {
         return listedElements.test(e.nodeName) ; // TODO exclude <input type="image">
       }));
     },
@@ -665,7 +668,7 @@ define('HTMLSelectElement', {
       core.HTMLElement.prototype._attrModified.apply(this, arguments);
     },
     get options() {
-      return new core.HTMLOptionsCollection(this, core.mapper(this, function(n) {
+      return new core.HTMLOptionsCollection(this, mapper(this, function(n) {
         return n.nodeName === 'OPTION';
       }));
     },
@@ -893,7 +896,7 @@ define('HTMLInputElement', {
       }
 
       var name = this.name.toLowerCase();
-      var radios = new core.HTMLCollection(this, core.mapper(root, function(el) {
+      var radios = new core.HTMLCollection(this, mapper(root, function(el) {
         return el.type === 'radio' &&
                el.name &&
                el.name.toLowerCase() === name &&
@@ -1529,7 +1532,7 @@ define('HTMLTableElement', {
           var sections = [table.tHead].concat(table.tBodies._toArray(), table.tFoot).filter(function(s) { return !!s });
 
           if (sections.length === 0) {
-            return core.mapDOMNodes(table, false, function(el) {
+            return mapDOMNodes(table, false, function(el) {
               return el.tagName === 'TR';
             });
           }
@@ -1707,7 +1710,7 @@ define('HTMLTableRowElement', {
   proto: {
     get cells() {
       if (!this._cells) {
-        this._cells = new core.HTMLCollection(this, core.mapper(this, function(n) {
+        this._cells = new core.HTMLCollection(this, mapper(this, function(n) {
           return n.nodeName === 'TD' || n.nodeName === 'TH';
         }, false));
       }

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1885,52 +1885,15 @@ function refreshAccessors(document) {
   });
 }
 
-function refreshNameAccessor(frame) {
-  if (!frame._ownerDocument._defaultView) {
-    return;
-  }
-
-  var name = frame.getAttribute("name");
-  // https://html.spec.whatwg.org/multipage/browsers.html#named-access-on-the-window-object:supported-property-names
-  if (name !== null && name !== "") {
-    // I do not know why this only works with _global and not with _defaultView :(
-    var window = frame._ownerDocument._global;
-    delete window[name];
-
-    if (isInDocument(frame)) {
-      defineGetter(window, name, function () { return frame.contentWindow; });
-    }
-  }
-}
-
-function isInDocument(el) {
-  var document = el._ownerDocument;
-
-  var current = el;
-  while ((current = current._parentNode)) {
-    if (current === document) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 define('HTMLFrameElement', {
   tagName: 'FRAME',
   proto: {
     _attrModified: function (name, value, oldVal) {
       core.HTMLElement.prototype._attrModified.call(this, name, value, oldVal);
-      if (name === 'name') {
-        if (oldVal) {
-          // I do not know why this only works with _global and not with _defaultView :(
-          delete this._ownerDocument._global[oldVal];
-        }
-        refreshNameAccessor(this);
-      } else if (name === 'src') {
+      if (name === 'src') {
         // iframe should never load in a document without a Window
         // (e.g. implementation.createHTMLDocument)
-        if (isInDocument(this) && this._ownerDocument._defaultView) {
+        if (this._attached && this._ownerDocument._defaultView) {
           loadFrame(this);
         }
       }
@@ -1944,7 +1907,6 @@ define('HTMLFrameElement', {
       }
 
       refreshAccessors(this._ownerDocument);
-      refreshNameAccessor(this);
     },
 
     _attach: function () {
@@ -1954,7 +1916,6 @@ define('HTMLFrameElement', {
         loadFrame(this);
       }
       refreshAccessors(this._ownerDocument);
-      refreshNameAccessor(this);
     },
 
     _contentDocument : null,

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -1342,6 +1342,8 @@ define('HTMLImageElement', {
       if (name == 'src' && value !== oldVal) {
         resourceLoader.enqueue(this, null, function () { })();
       }
+
+      core.HTMLElement.prototype._attrModified.call(this, name, value, oldVal);
     },
     get src() {
       return resourceLoader.resolveResourceUrl(this._ownerDocument, this.getAttribute('src'));

--- a/lib/jsdom/living/named-properties-window.js
+++ b/lib/jsdom/living/named-properties-window.js
@@ -1,0 +1,126 @@
+"use strict";
+const mapper = require("../utils").mapper;
+const hasOwnProp = Object.prototype.hasOwnProperty;
+const namedPropertiesTracker = require("../named-properties-tracker");
+const ELEMENT_NODE = 1;
+
+function isNamedPropertyElement(element) {
+  // (for the name attribute)
+
+  // use hasOwnProperty to make sure contentWindow comes from the prototype,
+  // and is not set directly on the node by a script.
+  if ("contentWindow" in element && !hasOwnProp.call(element, "contentWindow")) {
+    return true;
+  }
+
+  switch (element.nodeName) {
+    case "A":
+    case "APPLET":
+    case "AREA":
+    case "EMBED":
+    case "FORM":
+    case "FRAMESET":
+    case "IMG":
+    case "OBJECT":
+      return true;
+  }
+
+  return false;
+}
+
+function namedPropertyResolver(HTMLCollection, window, name) {
+  function filter(node) {
+    if (node.nodeType !== ELEMENT_NODE) {
+      return false;
+    }
+
+    if (node.getAttribute("id") === name) {
+      return true;
+    }
+
+    if (isNamedPropertyElement(node)) {
+      return node.getAttribute("name") === name;
+    }
+
+    return false;
+  }
+
+  const document = window._document;
+  const objects = new HTMLCollection(
+    document.documentElement,
+    mapper(document, filter, true)
+  );
+
+  const length = objects.length;
+  for (let i = 0; i < length; ++i) {
+    const node = objects[i];
+
+    if ("contentWindow" in node && !hasOwnProp.call(node, "contentWindow")) {
+      return node.contentWindow;
+    }
+  }
+
+  if (length === 0) {
+    return undefined;
+  }
+
+  if (length === 1) {
+    return objects[0];
+  }
+
+  return objects;
+}
+
+exports.initializeWindow = function (window, HTMLCollection) {
+  namedPropertiesTracker.create(window, namedPropertyResolver.bind(null, HTMLCollection));
+};
+
+exports.elementAttributeModified = function (element, name, value, oldValue) {
+  if (!element._attached) {
+    return;
+  }
+
+  if (name === "id" || (name === "name" && isNamedPropertyElement(element))) {
+    const tracker = namedPropertiesTracker.get(element._ownerDocument._global);
+
+    // (tracker will be null if the document has no Window)
+    if (tracker) {
+      tracker.maybeUntrack(oldValue);
+      tracker.track(value);
+    }
+  }
+};
+
+exports.nodeAttachedToDocument = function (node) {
+  if (node.nodeType !== ELEMENT_NODE) {
+    return;
+  }
+
+  const tracker = namedPropertiesTracker.get(node._ownerDocument._global);
+  if (!tracker) {
+    return;
+  }
+
+  tracker.track(node.getAttribute("id"));
+
+  if (isNamedPropertyElement(node)) {
+    tracker.track(node.getAttribute("name"));
+  }
+};
+
+exports.nodeDetachedFromDocument = function (node) {
+  if (node.nodeType !== ELEMENT_NODE) {
+    return;
+  }
+
+  const tracker = namedPropertiesTracker.get(node._ownerDocument._global);
+  if (!tracker) {
+    return;
+  }
+
+  tracker.maybeUntrack(node.getAttribute("id"));
+
+  if (isNamedPropertyElement(node)) {
+    tracker.maybeUntrack(node.getAttribute("name"));
+  }
+};

--- a/lib/jsdom/named-properties-tracker.js
+++ b/lib/jsdom/named-properties-tracker.js
@@ -1,0 +1,88 @@
+"use strict";
+// https://heycam.github.io/webidl/#idl-named-properties
+
+const IS_NAMED_PROPERTY = Symbol();
+const TRACKER = Symbol();
+
+exports.create = function (object, resolverFunc) {
+  if (object[TRACKER]) {
+    throw Error("A NamedPropertiesTracker has already been created for this object");
+  }
+
+  const tracker = new NamedPropertiesTracker(object, resolverFunc);
+  object[TRACKER] = tracker;
+  return tracker;
+};
+
+exports.get = function (object) {
+  if (!object) {
+    return null;
+  }
+
+  return object[TRACKER] || null;
+};
+
+function NamedPropertiesTracker(object, resolverFunc) {
+  this.object = object;
+  this.resolverFunc = resolverFunc;
+}
+
+function newPropertyDescriptor(object, resolverFunc, name) {
+  const descriptor = {
+    enumerable: true,
+    configurable: true,
+    get: function () {
+      return resolverFunc(object, name);
+    },
+    set: function (value) {
+      Object.defineProperty(object, name, {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value: value
+      });
+    }
+  };
+
+  descriptor.get[IS_NAMED_PROPERTY] = true;
+  descriptor.set[IS_NAMED_PROPERTY] = true;
+  return descriptor;
+}
+
+NamedPropertiesTracker.prototype.track = function (name) {
+  if (name === undefined || name === null || name === "") {
+    return;
+  }
+
+  if (name in this.object) {
+    // already tracked or it is not a named property (e.g. "addEventListener")
+    return;
+  }
+
+  const descriptor = newPropertyDescriptor(this.object, this.resolverFunc, name);
+  Object.defineProperty(this.object, name, descriptor);
+};
+
+NamedPropertiesTracker.prototype.maybeUntrack = function (name) {
+  if (name === undefined || name === null || name === "") {
+    return;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(this.object, name);
+
+  if (!descriptor || !descriptor.get || descriptor.get[IS_NAMED_PROPERTY] !== true) {
+    // Not defined by NamedPropertyTracker
+    return;
+  }
+
+  const value = this.object[name];
+  if (value !== undefined) {
+    // still associated with a value
+    return;
+  }
+
+  // note: delete puts the object in dictionary mode.
+  // if this turns out to be a performance issue, maybe add:
+  // https://github.com/petkaantonov/bluebird/blob/3e36fc861ac5795193ba37935333eb6ef3716390/src/util.js#L177
+  delete this.object[name];
+};

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -235,3 +235,64 @@ exports.resolveHref = function resolveHref(baseUrl, href) {
 
   return fixed;
 };
+
+exports.mapper = function (parent, filter, recursive) {
+  return function () {
+    return exports.mapDOMNodes(parent, recursive !== false, filter);
+  };
+};
+
+// Returns Array
+exports.mapDOMNodes = function (parent, recursive, callback) {
+  function visit(parent, result) {
+    return parent._childNodes.reduce(reducer, result);
+  }
+
+  function reducer(array, child) {
+    if (callback(child)) {
+      array.push(child);
+    }
+    if (recursive && child._childNodes) {
+      visit(child, array);
+    }
+    return array;
+  }
+
+  return visit(parent, []);
+};
+
+exports.visitTree = function (root, callback) {
+  function visit(el) {
+    if (el) {
+      callback(el);
+      if (el._childNodes) {
+        const children = el._childNodes;
+        const length = children.length;
+
+        for (let i = 0; i < length; i++) {
+          visit(children[i]);
+        }
+      }
+    }
+  }
+  visit(root);
+};
+
+/* UNUSED:
+exports.markTreeReadonly = function (node) {
+  function markLevel(el) {
+    el._readonly = true;
+    // also mark attributes and their children read-only
+    if (el.attributes) {
+      var attributes = el.attributes, l = attributes.length, i=0;
+      attributes._readonly = true;
+
+      for (i; i<l; i++) {
+        exports.visitTree(attributes[i], markLevel);
+      }
+    }
+  }
+
+  exports.visitTree(node, markLevel);
+};
+*/

--- a/test/jsdom/named-properties-tracker.js
+++ b/test/jsdom/named-properties-tracker.js
@@ -1,0 +1,166 @@
+"use strict";
+const NamedPropertiesTracker = require("../../lib/jsdom/named-properties-tracker");
+
+exports["get() should return the tracker previously created by create()"] = function (t) {
+  const obj = {};
+
+  t.ok(NamedPropertiesTracker.get(obj) === null);
+  const tracker = NamedPropertiesTracker.create(obj, function () {});
+  t.ok(NamedPropertiesTracker.get(obj) === tracker);
+  t.done();
+};
+
+exports["track() and maybeUntrack() should do nothing for empty names"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () {});
+
+  tracker.track(undefined);
+  tracker.track(null);
+  tracker.track("");
+  tracker.maybeUntrack(undefined);
+  tracker.maybeUntrack(null);
+  tracker.maybeUntrack("");
+  t.done();
+};
+
+exports["should define a getter which calls the resolver each time"] = function (t) {
+  let state = "bar";
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function (object, name) {
+    t.ok(object === obj);
+    return "hello " + name + " " + state;
+  });
+
+  tracker.track("foo");
+  t.strictEqual(obj.foo, "hello foo bar");
+  state = "baz";
+  t.strictEqual(obj.foo, "hello foo baz");
+
+  t.done();
+};
+
+exports["named properties should be enumerable"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+
+  tracker.track("foo");
+  let found = false;
+  for (let key in obj) {
+    if (key === "foo") {
+      found = true;
+    }
+  }
+  t.ok(found);
+
+  t.done();
+};
+
+exports["named properties should be configurable"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+
+  tracker.track("foo");
+  tracker.track("dog");
+
+  Object.defineProperty(obj, "foo", {
+    value: "baz"
+  });
+
+  delete obj.dog;
+
+  t.strictEqual(obj.foo, "baz");
+  t.ok(!("dog" in obj));
+  t.done();
+};
+
+exports["named properties should be settable"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+
+  tracker.track("foo");
+  obj.foo = 10;
+
+  t.strictEqual(obj.foo, 10);
+  t.done();
+};
+
+exports["a named property should not override an existing property"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+
+  obj.foo = 10;
+  tracker.track("foo");
+  t.strictEqual(obj.foo, 10);
+
+  tracker.maybeUntrack("foo");
+  t.strictEqual(obj.foo, 10);
+
+  t.done();
+};
+
+
+exports["a named property should not override an existing property, even if undefined"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+
+  obj.foo = undefined;
+  tracker.track("foo");
+  t.strictEqual(obj.foo, undefined);
+  t.ok("foo" in obj);
+  t.strictEqual(obj.foo, undefined);
+
+  tracker.maybeUntrack("foo");
+  t.ok("foo" in obj);
+  t.strictEqual(obj.foo, undefined);
+
+  t.done();
+};
+
+exports["a named property should not override properties from the prototype"] = function (t) {
+  function Abc() {}
+  Abc.prototype.foo = 12345;
+  const obj = new Abc();
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+
+  tracker.track("foo");
+  t.strictEqual(obj.foo, 12345);
+
+  tracker.maybeUntrack("foo");
+  t.strictEqual(obj.foo, 12345);
+
+  t.done();
+};
+
+exports["a named property should not override Object properties"] = function (t) {
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return "bar"; });
+  const props = ["__proto__", "toString", "constructor", "hasOwnProperty", "isPrototypeOf"];
+
+  props.forEach(function (prop) {
+    const value = obj[prop];
+    tracker.track(prop);
+    t.strictEqual(obj[prop], value, prop + " should not have been overridden");
+  });
+
+  t.done();
+};
+
+exports["a named property without any result should not be 'in' the object"] = function (t) {
+  let state = "bar";
+  const obj = {};
+  const tracker = NamedPropertiesTracker.create(obj, function () { return state; });
+
+  tracker.track("foo");
+  tracker.maybeUntrack("foo");
+  t.strictEqual(obj.foo, "bar");
+
+  state = null;
+  tracker.maybeUntrack("foo");
+  t.strictEqual(obj.foo, null, "descriptor should not be removed if null is returned");
+
+  state = undefined;
+  tracker.maybeUntrack("foo");
+  t.ok(!("foo" in obj), "descriptor should have been removed");
+
+  t.done();
+};

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -17097,5 +17097,14 @@ exports.tests = {
     test.notDeepEqual(doc, docClone, 'clone');
 
     test.done();
+  },
+
+  "getElementById() should work after changing the id atribute of an <img> element": function (test) {
+    var doc = jsdom.jsdom();
+    var img = doc.createElement("img");
+    doc.body.appendChild(img);
+    img.setAttribute("id", "foo");
+    test.ok(doc.getElementById("foo") === img);
+    test.done();
   }
 };

--- a/test/living-html/named-properties-window.js
+++ b/test/living-html/named-properties-window.js
@@ -1,0 +1,339 @@
+"use strict";
+const jsdom = require("../../");
+const todo = require("../util").todo;
+
+exports["A named property should return an element as-is if its name attribute matches"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("name", "foo");
+  doc.body.appendChild(img);
+
+  t.ok(window.foo === img);
+  t.done();
+};
+
+exports["A named property should not be set if the element is not reachable from the Document"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("name", "foo");
+
+  t.ok(!("foo" in window));
+
+  t.done();
+};
+
+exports["A named property should be enumerable"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("name", "foo");
+  doc.body.appendChild(img);
+
+  let found = false;
+  for (let key in window) {
+    if (key === "foo") {
+      found = true;
+    }
+  }
+  t.ok(found);
+  t.done();
+};
+
+exports["A named property should returns any element for which the id attribute matches"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+
+  t.ok(window.foo === img);
+  t.done();
+};
+
+exports["A non element node in the document should not cause errors"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  doc.body.appendChild(doc.createTextNode("foo"));
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+
+  t.ok(window.foo === img);
+  t.done();
+};
+
+exports["Changing an attribute should update the named properties (id)"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  doc.body.appendChild(img);
+  img.setAttribute("id", "foo");
+  t.ok(window.foo === img);
+
+  img.setAttribute("id", "bar");
+  t.ok(!("foo" in window));
+  t.ok(window.bar === img);
+
+  t.done();
+};
+
+exports["Changing an attribute should update the named properties (name)"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  doc.body.appendChild(img);
+  img.setAttribute("name", "foo");
+  t.ok(window.foo === img);
+
+  img.setAttribute("name", "bar");
+  t.ok(!("foo" in window));
+  t.ok(window.bar === img);
+
+  t.done();
+};
+
+exports["Changing an attribute that is not id or name should not cause errors"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("alt", "Cat pictures on the internet");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+  t.ok(window.foo === img);
+
+  img.setAttribute("alt", "Dog pictures on the internet");
+  t.ok(window.foo === img);
+
+  t.done();
+};
+
+exports["Removing an element should update the named properties"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+  t.ok(window.foo === img);
+
+  doc.body.removeChild(img);
+  t.ok(!("foo" in window));
+
+  t.done();
+};
+
+exports["Removing a non-element node should not cause errors"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const text = doc.createTextNode("foo");
+  doc.body.appendChild(text);
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+  t.ok(window.foo === img);
+
+  doc.body.removeChild(text);
+  t.ok(window.foo === img);
+
+  t.done();
+};
+
+exports["A document without a Window should not cause errors"] = function (t) {
+  const doc = jsdom.jsdom().implementation.createHTMLDocument();
+  t.strictEqual(doc.defaultView, null, "Test case prerequisite");
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+  t.ok(!!img.parentNode);
+
+  img.setAttribute("id", "bar");
+  t.strictEqual(img.getAttribute("id"), "bar");
+
+  doc.body.removeChild(img);
+  t.ok(!img.parentNode);
+
+  t.done();
+};
+
+exports["A named property should return a HTMLCollection if there are multiple matches"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img1 = doc.createElement("img");
+  img1.setAttribute("name", "foo");
+  doc.body.appendChild(img1);
+
+  // inserted at a later moment, however it should occur first because of tree-order
+  const img0 = doc.createElement("img");
+  img0.setAttribute("name", "foo");
+  doc.body.insertBefore(img0, img1);
+
+  const div = doc.createElement("div");
+  div.setAttribute("id", "foo");
+  doc.body.appendChild(div);
+
+  t.ok(window.foo instanceof window.HTMLCollection);
+  t.strictEqual(window.foo.length, 3);
+  t.ok(window.foo[0] === img0);
+  t.ok(window.foo[1] === img1);
+  t.ok(window.foo[2] === div);
+
+  t.done();
+};
+
+exports["A named property should not be set if a property already exists"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  window.foo = 5;
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+
+  t.ok(window.foo === 5);
+  t.done();
+};
+
+exports["A named property should not be set if a property already exists, even if undefined"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  window.foo = undefined;
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+
+  t.ok(window.foo === undefined);
+  t.done();
+};
+
+exports["If a property is occupied by a named property but then the user " +
+        "sets it, the user's value shadows it"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+
+  window.foo = 5;
+
+  t.ok(window.foo === 5);
+  t.done();
+};
+
+exports["If a named property is shadowed by the user but then deleted, " +
+        "the named property value should return."] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  window.foo = 5;
+
+  const img = doc.createElement("img");
+  img.setAttribute("id", "foo");
+  doc.body.appendChild(img);
+
+  delete window.foo;
+
+  // Would require ES6 Proxy to properly implement this behaviour
+  todo(t, function (t) {
+    t.ok(window.foo === img);
+  });
+
+  t.done();
+};
+
+exports["Only elements with specific tag names may be returned if " +
+        "their name attribute matches"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+  const tags = ["a", "applet", "area", "embed", "form", "frameset", "img", "object",
+                "A", "APPLET", "AREA", "EMBED", "FORM", "FRAMESET", "IMG", "OBJECT"];
+
+  tags.forEach(function (tagName) {
+    const element = doc.createElement(tagName);
+    element.setAttribute("name", "foo");
+    doc.body.appendChild(element);
+  });
+
+  tags.forEach(function (tagName, index) {
+    const element = window.foo[index];
+    t.ok(element && element.nodeName.toUpperCase() === tags[index].toUpperCase());
+  });
+
+  t.done();
+};
+
+exports["Only elements with specific tag names may be returned if " +
+        "their name attribute matches (negative test)"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  // Not exhaustive
+  const tags = ["div", "span", "style", "script", "h1", "strong", "input",
+                "audio", "button", "select", "textarea"];
+
+  tags.forEach(function (tagName) {
+    const element = doc.createElement(tagName);
+    element.setAttribute("name", "foo");
+    doc.body.appendChild(element);
+  });
+
+  t.ok(!window.foo);
+
+  t.done();
+};
+
+exports["Removing an element for which the name attribute is not tracked, " +
+        "should not cause errors upon removing it"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  // Not exhaustive
+  const tags = ["div", "span", "style", "script", "h1", "strong", "input",
+                "audio", "button", "select", "textarea"];
+
+  const img = doc.createElement("img");
+  img.setAttribute("name", "foo");
+  doc.body.appendChild(img);
+
+  tags.forEach(function (tagName) {
+    const element = doc.createElement(tagName);
+    element.setAttribute("name", "foo");
+    doc.body.appendChild(element);
+    doc.body.removeChild(element);
+  });
+
+  t.ok(window.foo === img);
+  t.done();
+};
+
+exports["A named property that matches any element that contains a nested browsing " +
+        "context, should return the WindowProxy of that context"] = function (t) {
+  const doc = jsdom.jsdom();
+  const window = doc.defaultView;
+
+  const iframe = doc.createElement("iframe");
+  iframe.setAttribute("name", "foo");
+  doc.body.appendChild(iframe);
+
+  t.ok(iframe.contentWindow, "test prerequisite");
+  t.ok(window.foo === iframe.contentWindow);
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -72,6 +72,7 @@ var files = [
   "jsdom/xml.js",
   "jsdom/selectors.js",
   "jsdom/named-properties-tracker.js",
+  "living-html/named-properties-window.js",
 
   "jsonp/jsonp.js",
   "browser/css.js",

--- a/test/runner
+++ b/test/runner
@@ -71,6 +71,7 @@ var files = [
   "jsdom/virtual-console.js",
   "jsdom/xml.js",
   "jsdom/selectors.js",
+  "jsdom/named-properties-tracker.js",
 
   "jsonp/jsonp.js",
   "browser/css.js",

--- a/test/util.js
+++ b/test/util.js
@@ -72,3 +72,12 @@ exports.domExceptionPredicate = function (document, name) {
            error.code === exceptionTable[name].legacyCodeValue;
   };
 };
+
+exports.todo = function (test, fn) {
+  fn({
+    ok: function (value, message) {
+      test.ok(!value, "Marked as TODO: " + message);
+    }
+    // add more as needed
+  });
+};

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -50,6 +50,7 @@ self.onmessage = function (e) {
     "jsdom/env": require("../test/jsdom/env"), // 9/25
     "jsdom/utils": require("../test/jsdom/utils"), // ok
     "jsdom/inside-worker-smoke-tests": require("../test/jsdom/inside-worker-smoke-tests"),
+    "jsdom/named-properties-tracker.js": require("../test/jsdom/named-properties-tracker"),
     "jsonp/jsonp": require("../test/jsonp/jsonp"), // 0/1
     "browser/css": require("../test/browser/css"), // ok
     "browser/index": require("../test/browser/index"), // ok
@@ -81,6 +82,7 @@ self.onmessage = function (e) {
     "window/console",
     "jsdom/utils",
     "jsdom/inside-worker-smoke-tests",
+    "jsdom/named-properties-tracker.js",
     "browser/css",
     "browser/index",
 


### PR DESCRIPTION
Fixes the following per html spec:

* Named properties no longer override existing properties. For example `<iframe name="addEventListener">`
* Named properties on the window also return an element or a list of elements based on their id (#822) and name. (currently only the `contentWindow` of iframes are returned)
* `getElementById` ignored <img> elements who had their id set *after* being inserted into the document

Also, I have removed a useless circular `require()` workaround. This workaround was causing issues. 
Node.js can figure it out if you set `module.exports` *before* you `require()`

Named properties should also exist for `<form>`, however I am not doing that in this PR because the tracking of form ownership needs a lot of work. This PR would get very big.

The tracking of named properties is very close to the spec, but not complete. The spec implements them using a default/fallback getter, which do not exist in v8 yet. The edge case where this difference matters has been documented using an inverted test case.