### PR TITLE
Add web-platform-tests NodeIterator tests

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -47,7 +47,7 @@
     "test/level2",
     "test/level3",
     "test/sizzle",
-    "test/w3c",
+    "test/w3c/tests",
     "test/window",
     "test/*.js",
     "test/jsdom/index.js",

--- a/.jshintignore
+++ b/.jshintignore
@@ -19,7 +19,7 @@ test/level1
 test/level2
 test/level3
 test/sizzle
-test/w3c
+test/w3c/tests
 test/window
 test/*.js
 

--- a/test/w3c/index.js
+++ b/test/w3c/index.js
@@ -1,4 +1,4 @@
-﻿"use strict";
+"use strict";
 
 var w3cTest = require("./w3ctest")(exports);
 
@@ -19,4 +19,5 @@ w3cTest("dom/nodes/DocumentType-literal.html");
 w3cTest("dom/nodes/DocumentType-literal.xhtml");
 w3cTest("dom/nodes/Node-cloneNode.html");
 w3cTest("dom/traversal/NodeFilter-constants.html");
+w3cTest("dom/traversal/NodeIterator.html");
 w3cTest("html/syntax/serializing-html-fragments/outerHTML.html");

--- a/test/w3c/w3ctest.js
+++ b/test/w3c/w3ctest.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var fs = require('fs');
-var path = require('path');
+var fs = require("fs");
+var path = require("path");
 var request = require("request");
 var jsdom = require("../..");
 var resolveHref = require("../../lib/jsdom/utils").resolveHref;
 
 function createJsdom(source, url, t) {
-  const reporterHref = resolveHref(__dirname, 'w3c/tests/resources/testharnessreport.js');
+  const reporterHref = resolveHref(__dirname, "w3c/tests/resources/testharnessreport.js");
 
   jsdom.env({
     html: source,
@@ -18,18 +18,19 @@ function createJsdom(source, url, t) {
     },
     resourceLoader: function (resource, callback) {
       if (resource.url.href === reporterHref) {
-        callback(null, 'window.shimTest();');
+        callback(null, "window.shimTest();");
       } else {
         resource.defaultFetch(callback);
       }
     },
     created: function (err, window) {
       if (err) {
-        t.ifError(err, 'window should be created without error');
+        t.ifError(err, "window should be created without error");
         t.done();
       }
 
       window.shimTest = function () {
+        /* jshint -W106 */
         window.add_result_callback(function (test) {
           if (test.status === 1) {
             t.ok(false, "Failed in \"" + test.name + "\": \n" + test.message);
@@ -40,40 +41,40 @@ function createJsdom(source, url, t) {
           }
         });
 
-        window.add_completion_callback(function (tests, harness_status) {
-          t.ok(harness_status.status !== 2, "test harness should not timeout");
+        window.add_completion_callback(function (tests, harnessStatus) {
+          t.ok(harnessStatus.status !== 2, "test harness should not timeout");
           window.close();
           t.done();
         });
       };
     },
 
-    loaded: function (err, window) {
+    loaded: function (err) {
       t.ifError(err && err[0].data.error);
     }
   });
 }
 
 function testUrl(url, t) {
-  fs.readFile(path.resolve(__dirname, 'tests', url), 'utf8', function (err, file) {
+  fs.readFile(path.resolve(__dirname, "tests", url), "utf8", function (err, file) {
     if (err) {
-      request.get('http://w3c-test.org/' + url, function (err, resp, respBody) {
+      request.get("http://w3c-test.org/" + url, function (err, resp, respBody) {
         if (err) {
-          t.ifError(err, 'request should go through without error');
+          t.ifError(err, "request should go through without error");
           t.done();
           return;
         }
         if (resp.statusCode < 200 || resp.statusCode >= 300) {
-          t.ok(false, 'request should return OK status code');
+          t.ok(false, "request should return OK status code");
           t.done();
           return;
         }
 
-        createJsdom(respBody, 'http://w3c-test.org/' + url, t);
+        createJsdom(respBody, "http://w3c-test.org/" + url, t);
       });
     } else {
-      file = file.replace(/\/resources\//gi, __dirname + '/tests/resources/');
-      createJsdom(file, path.resolve(__dirname, 'tests', url), t);
+      file = file.replace(/\/resources\//gi, __dirname + "/tests/resources/");
+      createJsdom(file, path.resolve(__dirname, "tests", url), t);
     }
   });
 }


### PR DESCRIPTION
Required fixing a bug in w3ctest.js which would replace both <script> tags with our shim, instead of just the reporter. We did this in a more principled way by overriding the resourceLoader.

Fixes #1117.