### PR TITLE
Add getVirtualConsole back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ var document = jsdom.jsdom(undefined, {
 });
 ```
 
-After initialization, you can retreive the `virtualConsole` by using:
+Post-initialization, if you didn't pass in a `virtualConsole` or no longer have a reference to it, you can retreive the `virtualConsole` by using:
 
 ```js
 var virtualConsole = jsdom.getVirtualConsole(window);

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ var document = jsdom.jsdom(undefined, {
 });
 ```
 
-#### Get an event emitter for a window's console
+#### Create an event emitter for a window's console
 
 ```js
 var jsdom = require("jsdom");
@@ -421,6 +421,12 @@ virtualConsole.on("log", function (message) {
 var document = jsdom.jsdom(undefined, {
   virtualConsole: virtualConsole
 });
+```
+
+After initialization, you can retreive the `virtualConsole` by using:
+
+```js
+var virtualConsole = jsdom.getVirtualConsole(window);
 ```
 
 ## What Standards Does jsdom Support, Exactly?


### PR DESCRIPTION
Realized that #1108 removed any documentation for `getVirtualConsole`. Since it's in the public API I felt like it should still be documented somewhere.