### PR TITLE
use xtend over custom impl.

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -5,6 +5,7 @@
 
 var fs = require("fs");
 var path = require("path");
+var xtend = require("xtend/mutable");
 var URL = require("url");
 var CookieJar = require("tough-cookie").CookieJar;
 
@@ -334,7 +335,7 @@ function getConfigFromArguments(args) {
           if (Array.isArray(arg)) {
             config.scripts = arg;
           } else {
-            extend(config, arg);
+            xtend(config, arg);
           }
           break;
       }
@@ -382,12 +383,6 @@ function ensureArray(value) {
     array = [array];
   }
   return array;
-}
-
-function extend(config, overrides) {
-  Object.keys(overrides).forEach(function (key) {
-    config[key] = overrides[key];
-  });
 }
 
 function setParsingModeFromExtension(config, filename) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "request": "^2.55.0",
     "tough-cookie": "^1.1.0",
     "xml-name-validator": ">= 2.0.1 < 3.0.0",
-    "xmlhttprequest": ">= 1.6.0 < 2.0.0"
+    "xmlhttprequest": ">= 1.6.0 < 2.0.0",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "browserify": "^9.0.8",


### PR DESCRIPTION
Relatively simple pull request.

It just uses the `xtend` module over the custom implementation.

On the one hand,  it'd be nice to just use `Object.assign`,  but skipping that,  at least this way its less [untested] code that could (potentially, obviously, this is a very ideological example) potentially be erroneous.

Not really fussed either way,  just passing through :+1: , thanks for the module.