### PR TITLE
document.open() should return the Document on which the method was invoked

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -297,6 +297,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
     this._childNodes = [];
     this._documentElement = null;
     this._modified();
+    return this;
   },
   close : function() {
     this._queue.resume();

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19938,5 +19938,13 @@ exports.tests = {
 
     test.ok(div.toString() === '[object HTMLDivElement]', 'div.toString() should return "[object HTMLDivElement] just like a browser');
     test.done();
+  },
+
+  document_open_return_self: function(test) {
+    var doc = load("document");
+    var docOpen = doc.open();
+    doc.close();
+    test.ok(doc === docOpen, 'doc.open() should return the Document on which the method was invoked');
+    test.done();
   }
 };


### PR DESCRIPTION
As mentioned in the last step of the [spec](https://html.spec.whatwg.org/multipage/webappapis.html#opening-the-input-stream:document-37) `document.open` should return the `Document` it was invoked on.