### PR TITLE
Benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ v8.log
 node_modules
 test/worker-bundle.js
 npm-debug.log
+benchmark/browser-bundle.js

--- a/.jscsrc
+++ b/.jscsrc
@@ -27,6 +27,10 @@
 
   "excludeFiles": [
     "node_modules/**",
+
+    "benchmark/browser-bundle.js",
+    "test/worker-bundle.js",
+
     "lib/jsdom/browser/htmltodom.js",
     "lib/jsdom/browser/default-stylesheet.js",
     "lib/jsdom/level1/core.js",

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,6 @@
+benchmark/browser-bundle.js
+test/worker-bundle.js
+
 lib/jsdom/browser/htmltodom.js
 lib/jsdom/browser/default-stylesheet.js
 lib/jsdom/level1/core.js

--- a/benchmark/browser-runner.html
+++ b/benchmark/browser-runner.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>JSDom benchmarks</title>
+    <script src="browser-bundle.js"></script>
+    <script>
+      window.run = require("jsdom-browser-runner");
+    </script>
+  </head>
+  <body>
+    <p>Execute <code>run('dom/construction/createElement')</code> to run a benchmark.
+      Or <code>run()</code> to run them all.
+      You can also specify to only run a benchmark for a specific implementation,
+      "jsdom" or "native": <code>run('dom/construction', 'jsdom')</code>.
+    </p>
+  </body>
+</html>

--- a/benchmark/browser-runner.js
+++ b/benchmark/browser-runner.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const consoleReporter = require("./console-reporter");
+const pathToSuites = require("./path-to-suites");
+const benchmarks = require(".");
+
+module.exports = function (suites, documentImplementation) {
+  if (typeof suites === "string") {
+    suites = suites.trim().split(/,/);
+  }
+
+  let suitesToRun = pathToSuites(benchmarks, suites);
+  suitesToRun.forEach(consoleReporter);
+
+  suitesToRun = suitesToRun.map(function (suite) {
+    let runSuite = suite;
+    if (documentImplementation) {
+      runSuite = suite.filter(function (benchmark) {
+        return benchmark.jsdomDocumentImplementation === documentImplementation;
+      });
+      runSuite.name = suite.name;
+      consoleReporter(runSuite);
+    }
+
+    return runSuite;
+  });
+
+  function runNext() {
+    /* jshint -W040 */
+    if (this && this.off) {
+      // there is no .once()
+      this.off("complete", runNext);
+    }
+
+    const suite = suitesToRun.shift();
+    if (!suite) {
+      console.log("Done!");
+      return;
+    }
+
+    suite.off("complete", runNext);
+    suite.on("complete", runNext);
+    suite.run({async: true});
+  }
+
+  runNext();
+
+};

--- a/benchmark/console-reporter.js
+++ b/benchmark/console-reporter.js
@@ -1,0 +1,47 @@
+"use strict";
+
+/* jshint -W040 */
+
+function onError(event) {
+  const bench = event.target;
+  console.error("Error in benchmark", bench.name, ":", bench.error);
+}
+
+function onStart() {
+  console.log("# " + this.name + " #");
+}
+
+function onCycle(event) {
+  console.log(String(event.target));
+}
+
+function onComplete() {
+  if (this.length > 1) {
+    const fastest = this.filter("fastest")[0];
+    const slowest = this.filter("slowest")[0];
+    if (fastest) {
+      const relativeDiff = slowest && Math.round(slowest.stats.mean / fastest.stats.mean * 100) / 100;
+      console.info("Fastest is \"" +
+                   fastest.name.trim() +
+                   "\", which is " +
+                   relativeDiff +
+                   "x faster than the slowest \"" +
+                   slowest.name +
+                   "\"");
+    }
+  }
+
+  console.log("");
+}
+
+module.exports = function consoleReporter(suite) {
+  suite.off("error", onError);
+  suite.off("start", onStart);
+  suite.off("cycle", onCycle);
+  suite.off("complete", onComplete);
+  suite.on("error", onError);
+  suite.on("start", onStart);
+  suite.on("cycle", onCycle);
+  suite.on("complete", onComplete);
+  return suite;
+};

--- a/benchmark/document-suite.js
+++ b/benchmark/document-suite.js
@@ -1,0 +1,84 @@
+"use strict";
+const Benchmark = require("benchmark");
+const extend = require("xtend");
+const shallowClone = extend;
+const jsdomBenchmark = require("./jsdom-benchmark");
+
+// jsdom might be an empty object if omitted by browserify
+const jsdom = require("..");
+
+const nativeDoc = global.document;
+const jsdomDoc = jsdom.jsdom && jsdom.jsdom();
+
+function noop() {}
+
+function addBenchmark(suite, benchmark) {
+  const event = new Benchmark.Event({type: "add", target: benchmark});
+  suite.emit(event);
+  if (!event.cancelled) {
+    suite.push(benchmark);
+  }
+}
+
+function benchmarkFunctions(document, options) {
+  const setup = options.setup || noop;
+  const fn = options.fn;
+  const teardown = options.teardown || noop;
+
+  return {
+    setup: function () { setup.call(this, document); },
+    fn: options.defer ?
+        function (deferred) { fn.call(this, deferred, document); } :
+        function () { fn.call(this, document); },
+    teardown: function () { teardown.call(this, document); }
+  };
+}
+
+/**
+ * Create a Benchmark.js Suite which runs your benchmark in
+ * different document implementations.
+ * @param {Object|function} optionsArg Options to pass to `Benchmark`. A function
+ *                          can also be given if you do not want to set any options.
+ * @param {Benchmark.Suite} [optionsArg.suite=new Benchmark.Suite()] The suite to add the benchmarks to
+ * @param {function|string}   optionsArg.fn                           Benchmark test function
+ * @param {function|string}  [optionsArg.setup]                       Compiled/called before the test loop
+ * @param {function|string}  [optionsArg.teardown]                    Compiled/called after the test loop
+ * @param {boolean}          [optionsArg.defer=false]                 A flag to indicate the benchmark is deferred
+ * @returns {Benchmark.Suite}
+ */
+module.exports = function documentSuite(optionsArg) {
+
+  const options = typeof optionsArg === "function" ?
+                  { fn: optionsArg } :
+                  shallowClone(optionsArg);
+
+  // default to async because that is required for defer:true
+  const suite = options.suite || new Benchmark.Suite({async: true});
+  delete options.suite; // do not pass to `Benchmark`
+
+  if (nativeDoc) {
+    const newOptions = extend(
+      options,
+      benchmarkFunctions(nativeDoc, options),
+      {jsdomDocumentImplementation: "native"}
+    );
+    const benchmark = jsdomBenchmark(newOptions);
+    benchmark.name = benchmark.name ? benchmark.name + " :: native" : "native";
+    addBenchmark(suite, benchmark);
+  }
+
+  if (jsdomDoc) {
+    const newOptions = extend(
+      options,
+      benchmarkFunctions(jsdomDoc, options),
+      {jsdomDocumentImplementation: "jsdom"}
+    );
+    const benchmark = jsdomBenchmark(newOptions);
+
+    // extra space in "jsdom " so that it aligns with "native"
+    benchmark.name = benchmark.name ? benchmark.name + " :: jsdom " : "jsdom ";
+    addBenchmark(suite, benchmark);
+  }
+
+  return suite;
+};

--- a/benchmark/dom/construction.js
+++ b/benchmark/dom/construction.js
@@ -1,0 +1,31 @@
+"use strict";
+const suite = require("../document-suite");
+
+exports.createElement = suite(function (document) {
+  document.createElement("div");
+});
+
+exports.createTextNode = suite(function (document) {
+  document.createTextNode("foo");
+});
+
+exports.createComment = suite(function (document) {
+  document.createComment("foo");
+});
+
+exports.createDocumentFragment = suite(function (document) {
+  document.createDocumentFragment("foo");
+});
+
+exports.createNodeIterator = suite(function (document) {
+  document.createNodeIterator(document.documentElement);
+});
+
+exports.createEvent = suite(function (document) {
+  document.createEvent("Event");
+});
+
+exports.createProcessingInstruction = suite(function (document) {
+  document.createProcessingInstruction("php", "echo 123; ?");
+});
+

--- a/benchmark/dom/index.js
+++ b/benchmark/dom/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
 module.exports = {
-  construction: require("./construction")
+  construction: require("./construction"),
+  "tree-modification": require("./tree-modification")
 };

--- a/benchmark/dom/index.js
+++ b/benchmark/dom/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  construction: require("./construction")
+};

--- a/benchmark/dom/tree-modification.js
+++ b/benchmark/dom/tree-modification.js
@@ -1,0 +1,167 @@
+"use strict";
+const suite = require("../document-suite");
+
+exports["appendChild: no siblings"] = function () {
+  let parent;
+  let children;
+  let it;
+
+  return suite({
+    setup: function (document) {
+      parent = [];
+      children = [];
+
+      for (let i = 0; i < this.count; ++i) {
+        parent.push(document.createElement("div"));
+        children.push(document.createElement("div"));
+      }
+
+      it = 0;
+    },
+    fn: function () {
+      parent[it].appendChild(children[it]);
+      ++it;
+    }
+  });
+};
+
+exports["appendChild: many siblings"] = function () {
+  let parent;
+  let children;
+  let it;
+
+  return suite({
+    setup: function (document) {
+      parent = document.createElement("div");
+      children = [];
+
+      for (let i = 0; i < this.count; ++i) {
+        children.push(document.createElement("div"));
+      }
+
+      it = 0;
+    },
+    fn: function () {
+      parent.appendChild(children[it]);
+      ++it;
+    }
+  });
+};
+
+exports["appendChild: many parents"] = function () {
+  const DEPTH = 500;
+  let itData;
+  let it;
+
+  return suite({
+    setup: function (document) {
+      itData = new Array(this.count);
+
+      for (let i = 0; i < this.count; ++i) {
+        let nodes = new Array(DEPTH);
+
+        for (let n = 0; n < DEPTH; ++n) {
+          nodes[n] = document.createElement("div");
+        }
+
+        itData[i] = nodes;
+      }
+
+      it = 0;
+    },
+    fn: function () {
+      let nodes = itData[it];
+
+      for (let n = 1; n < DEPTH; ++n) {
+        nodes[n - 1].appendChild(nodes[n]);
+      }
+
+      ++it;
+    }
+  });
+};
+
+
+exports["removeChild: no siblings"] = function () {
+  let parent;
+  let children;
+  let it;
+
+  return suite({
+    setup: function (document) {
+      parent = [];
+      children = [];
+
+      for (let i = 0; i < this.count; ++i) {
+        parent.push(document.createElement("div"));
+        children.push(document.createElement("div"));
+        parent[i].appendChild(children[i]);
+      }
+
+      it = 0;
+    },
+    fn: function () {
+      parent[it].removeChild(children[it]);
+      ++it;
+    }
+  });
+};
+
+exports["removeChild: many siblings"] = function () {
+  let parent;
+  let children;
+  let it;
+
+  return suite({
+    setup: function (document) {
+      parent = document.createElement("div");
+      children = [];
+
+      for (let i = 0; i < this.count; ++i) {
+        children.push(document.createElement("div"));
+        parent.appendChild(children[i]);
+      }
+
+      it = 0;
+    },
+    fn: function () {
+      parent.removeChild(children[it]);
+      ++it;
+    }
+  });
+};
+
+exports["removeChild: many parents"] = function () {
+  const DEPTH = 100;
+  let itData;
+  let it;
+
+  return suite({
+    setup: function (document) {
+      itData = new Array(this.count);
+
+      for (let i = 0; i < this.count; ++i) {
+        let nodes = new Array(DEPTH + 1);
+        nodes[0] = document.createElement("div");
+
+        for (let n = 0; n < DEPTH; ++n) {
+          nodes[n + 1] = document.createElement("div");
+          nodes[n].appendChild(nodes[n + 1]);
+        }
+
+        itData[i] = nodes;
+      }
+
+      it = 0;
+    },
+    fn: function () {
+      let nodes = itData[it];
+
+      for (let n = 0; n < DEPTH; ++n) {
+        nodes[n].removeChild(nodes[n + 1]);
+      }
+
+      ++it;
+    }
+  });
+};

--- a/benchmark/get-suites.js
+++ b/benchmark/get-suites.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = function getSuites(obj) {
+  if (typeof obj.run === "function") {
+    // a single suite
+    return [obj];
+  }
+
+  let ret = [];
+  // sort() to ensure consistent order in which benchmarks execute
+  Object.keys(obj).sort().forEach(function (name) {
+    ret = ret.concat(module.exports(obj[name]));
+  });
+
+  return ret;
+};

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 module.exports = {
+  jsdom: require("./jsdom"),
   dom: require("./dom")
 };
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+  dom: require("./dom")
+};
+
+require("./prepare-suites")("", module.exports);

--- a/benchmark/jsdom-benchmark.js
+++ b/benchmark/jsdom-benchmark.js
@@ -1,0 +1,30 @@
+"use strict";
+const Benchmark = require("benchmark");
+const extend = require("xtend");
+
+function noop() {}
+
+module.exports = function jsdomBenchmark(optionsArg) {
+  const options = extend(
+    typeof optionsArg === "function" ? { fn: optionsArg } : optionsArg,
+    {
+      jsdomSetup: optionsArg.setup || noop,
+      jsdomFn: optionsArg.fn,
+      jsdomTeardown: optionsArg.teardown || noop
+    }
+  );
+
+  if (options.defer) {
+    // `this` refers to a Benchmark.Deferred
+    options.setup = "this.benchmark.jsdomSetup();";
+    options.fn = "this.benchmark.jsdomFn(deferred);";
+    options.teardown = "this.benchmark.jsdomTeardown();";
+  } else {
+    // `this` refers to a Benchmark
+    options.setup = "this.jsdomSetup();";
+    options.fn = "this.jsdomFn();";
+    options.teardown = "this.jsdomTeardown();";
+  }
+
+  return new Benchmark(options);
+};

--- a/benchmark/jsdom/api.js
+++ b/benchmark/jsdom/api.js
@@ -1,0 +1,49 @@
+"use strict";
+const Benchmark = require("benchmark");
+const jsdomBenchmark = require("../jsdom-benchmark");
+const jsdom = require("../..");
+
+exports["env() defaults"] = function () {
+  const suite = new Benchmark.Suite({async: true});
+
+  suite.push(jsdomBenchmark({
+    defer: true,
+    fn: function (deferred) {
+      jsdom.env({
+        html: "",
+        done: deferred.resolve.bind(deferred)
+      });
+    }
+  }));
+
+  return suite;
+};
+
+exports["jsdom() defaults"] = function () {
+  const suite = new Benchmark.Suite();
+
+  suite.push(jsdomBenchmark({
+    fn: function () {
+      jsdom.jsdom();
+    }
+  }));
+
+  return suite;
+};
+
+exports["jsdom() no resources"] = function () {
+  const suite = new Benchmark.Suite();
+
+  suite.push(jsdomBenchmark({
+    fn: function () {
+      jsdom.jsdom("", {
+        features: {
+          FetchExternalResources: false,
+          ProcessExternalResources: false
+        }
+      });
+    }
+  }));
+
+  return suite;
+};

--- a/benchmark/jsdom/index.js
+++ b/benchmark/jsdom/index.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  api: require("./api")
+};

--- a/benchmark/path-to-suites.js
+++ b/benchmark/path-to-suites.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const getSuites = require("./get-suites");
+
+module.exports = function pathToSuites(benchmarks, paths) {
+  let ret = [];
+  if (paths && paths.length) {
+
+    // dom/construction/createElement => benchmarks.dom.construction.createElement
+    paths.forEach(function (path) {
+      const parts = path.split(/[\/\\]/);
+      let suites = benchmarks;
+
+      parts.forEach(function (part) {
+        suites = suites.hasOwnProperty(part) && suites[part];
+        if (!suites) {
+          throw Error("Invalid suite: '" + path + "'");
+        }
+      });
+
+      ret = ret.concat(getSuites(suites));
+    });
+
+  } else {
+    ret = ret.concat(getSuites(benchmarks));
+  }
+
+  return ret;
+};

--- a/benchmark/prepare-suites.js
+++ b/benchmark/prepare-suites.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = function prepareSuites(path, obj) {
+  // set a default suite name
+  if (typeof obj.run === "function") {
+    // a single suite
+    if (!obj.name) {
+      obj.name = path;
+    }
+    return;
+  }
+
+  Object.keys(obj).forEach(function (name) {
+    const currentPath = (path ? path + "/" : "") + name;
+    // If an entry in a manifest file (e.g. dom/index.js) is a function,
+    // assume that function will generate the suite (or another manifest)
+    if (typeof obj[name] === "function") {
+      obj[name] = obj[name](currentPath);
+    }
+
+    module.exports(currentPath, obj[name]);
+  });
+};

--- a/benchmark/runner.js
+++ b/benchmark/runner.js
@@ -4,17 +4,27 @@
 const consoleReporter = require("./console-reporter");
 const pathToSuites = require("./path-to-suites");
 const benchmarks = require(".");
+const fs = require("fs");
+const path = require("path");
 
 const optimist = require("optimist")
   .usage("Run the jsdom benchmark suite")
   .alias("s", "suites")
   .string("s")
   .describe("s", "suites that you want to run. ie: -s dom/construction/createElement,dom/foo")
+  .describe("bundle", "generate the javascript bundle required to run benchmarks in a browser")
   .alias("h", "help")
   .describe("h", "show the help");
 
 if (optimist.argv.help) {
   optimist.showHelp();
+  return;
+}
+
+if (optimist.argv.bundle) {
+  var bundle = require("browserify")({debug: true});
+  bundle.require(path.resolve(__dirname, "browser-runner.js"), {expose: "jsdom-browser-runner"});
+  bundle.bundle().pipe(fs.createWriteStream(__dirname + "/browser-bundle.js"));
   return;
 }
 

--- a/benchmark/runner.js
+++ b/benchmark/runner.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+"use strict";
+
+const consoleReporter = require("./console-reporter");
+const pathToSuites = require("./path-to-suites");
+const benchmarks = require(".");
+
+const optimist = require("optimist")
+  .usage("Run the jsdom benchmark suite")
+  .alias("s", "suites")
+  .string("s")
+  .describe("s", "suites that you want to run. ie: -s dom/construction/createElement,dom/foo")
+  .alias("h", "help")
+  .describe("h", "show the help");
+
+if (optimist.argv.help) {
+  optimist.showHelp();
+  return;
+}
+
+let suitesToRun;
+if (optimist.argv.suites) {
+  suitesToRun = pathToSuites(benchmarks, optimist.argv.suites.trim().split(/,/));
+} else {
+  suitesToRun = pathToSuites(benchmarks);
+}
+
+suitesToRun.forEach(consoleReporter);
+
+function runNext() {
+  /* jshint -W040 */
+  if (this && this.off) {
+    // there is no .once()
+    this.off("complete", runNext);
+  }
+
+  const suite = suitesToRun.shift();
+  if (!suite) {
+    console.log("Done!");
+    return;
+  }
+
+  suite.off("complete", runNext);
+  suite.on("complete", runNext);
+  suite.run({async: true});
+}
+
+runNext();

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "benchmark": "1.0.0",
-    "browserify": "^9.0.8",
+    "browserify": "^10.2.4",
     "colors": "^1.0.3",
     "http-server": "^0.8.0",
     "jscs": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "benchmark": "1.0.0",
     "browserify": "^9.0.8",
     "colors": "^1.0.3",
     "http-server": "^0.8.0",


### PR DESCRIPTION
I would like for jsdom to care more about performance. This change adds a simple way to create benchmarks using http://benchmarkjs.com/. 

When the benchmarks are run in node, only the performance of jsdom is measured. This is useful to compare the effects of a proposed patch or to find out where a performance regression was introduced using `git bisect`.

If the benchmarks are run in chrome, a comparison will be made with the native DOM of chrome. This is useful to find good spots to improve jsdom. For example one of the benchmarks I included in this PR shows that `appendChild` is extremely slow compared to chrome if there are a lot of parents _(appending elements vertically appears to be something like `O(n^2)` instead of `O(n)`)_.

Currently the benchmarks scripts all use `var` because strict mode is not yet supported. But I will rebase this PR when support for it lands in the library I am using: https://github.com/bestiejs/benchmark.js/pull/97

Another point of interest is that if you specify setup, tearDown, cycle functions, they will actually all be part of the same function, so they are all in the same variable scope. You can see this in `benchmark/dom/tree-modification.js`. I am not sure if this is a desired style? Alternatives would include using globals or using `this` (must be non enumerable) ~~or a big closure around the benchmark.~~

A couple points on my implementation:

* The runner does not use `fs` at all, every benchmark file is included with a static `require()`. This makes it easier to browserify. This is different from jsdom's unit test runner
* You can specify what benchmarks to run using a command line flag: `node benchmark/runner -s jsdom/api,dom/construction/createElement`
* The browser bundle is generated using `node benchmark/runner --bundle`, you can then open the browser-runner.html in chrome
* You use the console (F12) in chrome to run benchmarks, it also reports to the console. There is no fancy html UI. This is much simpler and lets you more easily do fancy things like profiling: `console.profile(); run('dom/construction/createElement', 'jsdom'); console.profileEnd();`
* I included a few examples in this PR to demonstrate all the features (synchronous test, setup function, async test, etc), but this is of course not complete

Here is some sample output:
```
# dom/construction/createTextNode #
native x 1,848,191 ops/sec ±18.95% (26 runs sampled)
jsdom  x 6,000,818 ops/sec ±46.22% (64 runs sampled)
Fastest is "jsdom", which is 3.25x faster than the slowest "native"

# dom/tree-modification/appendChild: many parents #
native x 3,983,773 ops/sec ±1.45% (5 runs sampled)
jsdom  x 1,863 ops/sec ±97.50% (22 runs sampled)
Fastest is "native", which is 2138.46x faster than the slowest "jsdom "
```

Perhaps contributing.md should be updated to ask people to run a benchmark if they change something that might impact performance?