### PR TITLE
Return instance from virtualConsole.sendTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,12 +398,8 @@ jsdom.env({
 ```js
 var jsdom = require("jsdom");
 
-var virtualConsole = jsdom.createVirtualConsole();
-
-virtualConsole.sendTo(console);
-
 var document = jsdom.jsdom(undefined, {
-  virtualConsole: virtualConsole
+  virtualConsole: jsdom.createVirtualConsole().sendTo(console)
 });
 ```
 

--- a/lib/jsdom/virtual-console.js
+++ b/lib/jsdom/virtual-console.js
@@ -18,6 +18,7 @@ utils.inheritFrom(EventEmitter, VirtualConsole, {
         });
       }
     }, this);
+    return this;
   }
 });
 

--- a/test/jsdom/virtual-console.js
+++ b/test/jsdom/virtual-console.js
@@ -181,3 +181,11 @@ exports["virtualConsole logs messages from child windows"] = function (t) {
     t.done();
   };
 };
+
+exports["virtualConsole.sendTo returns its instance of virtualConsole"] = function (t) {
+  const window = jsdom.jsdom().defaultView;
+  const virtualConsole = jsdom.getVirtualConsole(window);
+  const actual = virtualConsole.sendTo(console);
+  t.ok(actual === virtualConsole, "sendTo returns its instance of virtualConsole");
+  t.done();
+};


### PR DESCRIPTION
I noticed a possible shorthand when dealing with the virtual console and wanted to propose it here.

This PR makes `VirtualConsole.sendTo` return `this` so that you can write the shorthand:

```
jsdom.env("<p></p>", {
  virtualConsole: jsdom.createVirtualConsole().sendTo(console)
  done: function (err, window) {}
});
```

It also updates one place in the README to illustrate how it's done.