### PR TITLE
xhr shouldn't get cookies when requesting a file://

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -3,6 +3,7 @@
 var CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
 var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 var URL = require("url");
+var os = require("os");
 var notImplemented = require("./not-implemented");
 var History = require("./history");
 var VirtualConsole = require("../virtual-console");
@@ -19,6 +20,7 @@ module.exports = Window;
 var dom = require("../living");
 
 var cssSelectorSplitRE = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
+var fileHrefWindowsRE = /file:\/\/\/([a-zA-Z]):/; // XMLHttpRequest requires non-triple slash for windows paths.
 
 var defaultStyleSheet = cssom.parse(require("./default-stylesheet"));
 
@@ -153,9 +155,12 @@ function Window(options) {
     var protocol = "";
     xhr._open = xhr.open;
     xhr.open = function (method, url, async, user, password) {
-      url = URL.resolve(window.document.URL, url);
-      lastUrl = url;
+      url = resolveHref(window.document.URL, url);
       protocol = URL.parse(url).protocol;
+      if (protocol === "file:" && os.platform() === "win32") {
+        url = url.replace(fileHrefWindowsRE, "file://$1:");
+      }
+      lastUrl = url;
       return xhr._open(method, url, async, user, password);
     };
     xhr._send = xhr.send;
@@ -188,7 +193,7 @@ function Window(options) {
         }
       }
 
-      if(protocol !== "file:") {
+      if (protocol !== "file:") {
         xhr.addEventListener("readystatechange", setReceivedCookies);
       }
       return xhr._send(data);

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -2,8 +2,6 @@
 
 var CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
 var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
-var URL = require("url");
-var os = require("os");
 var notImplemented = require("./not-implemented");
 var History = require("./history");
 var VirtualConsole = require("../virtual-console");
@@ -20,7 +18,6 @@ module.exports = Window;
 var dom = require("../living");
 
 var cssSelectorSplitRE = /((?:[^,"']|"[^"]*"|'[^']*')+)/;
-var fileHrefWindowsRE = /file:\/\/\/([a-zA-Z]):/; // XMLHttpRequest requires non-triple slash for windows paths.
 
 var defaultStyleSheet = cssom.parse(require("./default-stylesheet"));
 
@@ -152,14 +149,9 @@ function Window(options) {
   this.XMLHttpRequest = function () {
     var xhr = new XMLHttpRequest();
     var lastUrl = "";
-    var protocol = "";
     xhr._open = xhr.open;
     xhr.open = function (method, url, async, user, password) {
       url = resolveHref(window.document.URL, url);
-      protocol = URL.parse(url).protocol;
-      if (protocol === "file:" && os.platform() === "win32") {
-        url = url.replace(fileHrefWindowsRE, "file://$1:");
-      }
       lastUrl = url;
       return xhr._open(method, url, async, user, password);
     };
@@ -193,7 +185,7 @@ function Window(options) {
         }
       }
 
-      if (protocol !== "file:") {
+      if (window.document.location.protocol !== "file:") {
         xhr.addEventListener("readystatechange", setReceivedCookies);
       }
       return xhr._send(data);

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -2,6 +2,7 @@
 
 var CSSStyleDeclaration = require("cssstyle").CSSStyleDeclaration;
 var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+var URL = require("url");
 var notImplemented = require("./not-implemented");
 var History = require("./history");
 var VirtualConsole = require("../virtual-console");
@@ -149,10 +150,12 @@ function Window(options) {
   this.XMLHttpRequest = function () {
     var xhr = new XMLHttpRequest();
     var lastUrl = "";
+    var protocol = "";
     xhr._open = xhr.open;
     xhr.open = function (method, url, async, user, password) {
-      url = resolveHref(window.document.URL, url);
+      url = URL.resolve(window.document.URL, url);
       lastUrl = url;
+      protocol = URL.parse(url).protocol;
       return xhr._open(method, url, async, user, password);
     };
     xhr._send = xhr.send;
@@ -185,7 +188,9 @@ function Window(options) {
         }
       }
 
-      xhr.addEventListener("readystatechange", setReceivedCookies);
+      if(protocol !== "file:") {
+        xhr.addEventListener("readystatechange", setReceivedCookies);
+      }
       return xhr._send(data);
     };
     Object.defineProperty(xhr, "response", {

--- a/test/living-html/cookie.js
+++ b/test/living-html/cookie.js
@@ -170,6 +170,24 @@ exports["Set cookie by XHR"] = function (t) {
   });
 };
 
+exports["Do not set cookies by XHR for local files"] = function (t) {
+  var fileUrl = "file://" + URL.resolve(__dirname + "/", "cookie.js");
+  jsdom.env({
+    url: testHost + "/TestPath/test-page",
+    done: function (err, window) {
+      var xhr = new window.XMLHttpRequest();
+
+      xhr.onload = function () {
+        t.strictEqual(window.document.cookie, '');
+        t.done();
+      };
+
+      xhr.open("GET", fileUrl, true);
+      xhr.send();
+    }
+  });
+};
+
 exports["Send Cookies header via resource request"] = function (t) {
   jsdom.env({
     url: testHost + "/TestPath/set-cookie-from-server",


### PR DESCRIPTION
There are two bugs here actually.

- if you request a local file then `XMLHttpRequest` has a null response object, calling `getResponseHeader` throws as a result.
- using `require("../utils").resolveHref` actually returns an invalid url on windows.

Regarding the first item, simply do not attempt to get the cookies if the url has a "file:" protocol.

Regarding the second item, using `URL.resolve` instead solves the problem. Specifically the problem is that a url such as:

```
file://c:/path/to/file.txt
```

is changed when using `require("../utils").resolveHref` into:
```
file:///c:/path/to/file.txt
```

Notice the triple `///` after file. It seems to be thinking that file paths should be preceded by a `/`, which isn't true on Windows.

I ran the tests on Windows:
```
OK: 7249 assertions (73055ms)
```