### PR TITLE
Fix XHR for file URLs by working around node-XHR bug

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -151,9 +151,8 @@ function Window(options) {
     var lastUrl = "";
     xhr._open = xhr.open;
     xhr.open = function (method, url, async, user, password) {
-      url = resolveHref(window.document.URL, url);
-      lastUrl = url;
-      return xhr._open(method, url, async, user, password);
+      lastUrl = fixUrlForBuggyXhr(resolveHref(window.document.URL, url));
+      return xhr._open(method, lastUrl, async, user, password);
     };
     xhr._send = xhr.send;
     xhr.send = function (data) {
@@ -411,4 +410,10 @@ function stopAllTimers(window) {
     t[1].call(window, t[0]);
   });
   window.__timers = [];
+}
+
+function fixUrlForBuggyXhr(url) {
+  // node-XMLHttpRequest doesn't properly handle file URLs. It only accepts file://C:/..., not file:///C:/...
+  // See https://github.com/tmpvar/jsdom/pull/1180
+  return url.replace(/^file:\/\/\/([a-zA-Z]:)/, "file://$1");
 }

--- a/test/living-html/cookie.js
+++ b/test/living-html/cookie.js
@@ -4,6 +4,7 @@ var http = require("http");
 var URL = require("url");
 var portfinder = require("portfinder");
 var jsdom = require("../..");
+var toFileUrl = require("../util").toFileUrl(__dirname);
 
 var server = [];
 var testHost = null;
@@ -168,6 +169,20 @@ exports["Set cookie by XHR"] = function (t) {
       xhr.send();
     }
   });
+};
+
+exports["Getting a file URL should not set any cookies"] = function (t) {
+  // From https://github.com/tmpvar/jsdom/pull/1180
+  const window = jsdom.jsdom(undefined, { url: "http://example.com/" }).defaultView;
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.onload = function () {
+    t.strictEqual(window.document.cookie, "");
+    t.done();
+  };
+
+  xhr.open("GET", toFileUrl(__filename), true);
+  xhr.send();
 };
 
 exports["Send Cookies header via resource request"] = function (t) {

--- a/test/misc/xhr-file-urls.js
+++ b/test/misc/xhr-file-urls.js
@@ -1,0 +1,34 @@
+"use strict";
+const fs = require("fs");
+const jsdom = require("../..");
+const toFileUrl = require("../util").toFileUrl(__dirname);
+
+exports["Getting a file URL should work (from the same file URL)"] = function (t) {
+  // From https://github.com/tmpvar/jsdom/pull/1180
+  const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.onload = function () {
+    t.equal(xhr.responseText, fs.readFileSync(__filename));
+    t.done();
+  };
+
+  xhr.open("GET", toFileUrl(__filename), true);
+  xhr.send();
+};
+
+exports["Getting a file URL should not throw for getResponseHeader"] = function (t) {
+  // From https://github.com/tmpvar/jsdom/pull/1180
+  const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.onload = function () {
+    t.doesNotThrow(function () {
+      t.strictEqual(xhr.getResponseHeader("Blahblahblah"), null);
+    });
+    t.done();
+  };
+
+  xhr.open("GET", toFileUrl(__filename), true);
+  xhr.send();
+};

--- a/test/runner
+++ b/test/runner
@@ -66,6 +66,7 @@ var files = [
   "living-html/post-message.js",
 
   "misc/url.js",
+  "misc/xhr-file-urls.js",
 
   "window/history.js",
   "window/script.js",

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -47,6 +47,7 @@ self.onmessage = function (e) {
     "living-html/on-error.js": require("../test/living-html/on-error.js"), // ok
     "living-html/navigator.js": require("../test/living-html/navigator.js"), // ok
     "misc/url.js": require("../test/misc/url.js"), // ok
+    "misc/xhr-file-urls.js": require("../test/misc/xhr-file-urls.js"), // 0/2; file I/O does not work in browsers
 
     "window/history": require("../test/window/history"), // ok
     "window/script": require("../test/window/script"), // 0/10


### PR DESCRIPTION
Closes #1180.

Please review @justinmchase. I was unable to write a test showing that getResponseHeader throws as long as the file URL was two-slashes only.