### PR TITLE
Issue node xhr file support

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -161,7 +161,7 @@ function Window(options) {
         // set the response for file urls.
         return null;
       }
-      return xhr.getAllResponseHeaders();
+      return xhr._getAllResponseHeaders();
     };
     xhr._send = xhr.send;
     xhr.send = function (data) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -154,6 +154,15 @@ function Window(options) {
       lastUrl = fixUrlForBuggyXhr(resolveHref(window.document.URL, url));
       return xhr._open(method, lastUrl, async, user, password);
     };
+    xhr._getAllResponseHeaders = xhr.getAllResponseHeaders;
+    xhr.getAllResponseHeaders = function () {
+      if (window.document.location.protocol === "file:") {
+        // Monkey patch this function for files, the node-xhr module doesn't properly
+        // set the response for file urls.
+        return "";
+      }
+      return xhr.getAllResponseHeaders();
+    };
     xhr._send = xhr.send;
     xhr.send = function (data) {
       var cookieJar = window.document._cookieJar;
@@ -193,6 +202,10 @@ function Window(options) {
           return this.responseText;
         } else if (this.responseType === "json") {
           return JSON.parse(this.responseText);
+        } else if (window.document.location.protocol === "file:") {
+          // node-xhr doesn't properly set the responseType for file requests.
+          // return the text anyway.
+          return this.responseText;
         } else {
           return null; // emulate failed requeest
         }

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -159,7 +159,7 @@ function Window(options) {
       if (window.document.location.protocol === "file:") {
         // Monkey patch this function for files, the node-xhr module doesn't properly
         // set the response for file urls.
-        return "";
+        return null;
       }
       return xhr.getAllResponseHeaders();
     };

--- a/test/misc/xhr-file-urls.js
+++ b/test/misc/xhr-file-urls.js
@@ -17,6 +17,20 @@ exports["Getting a file URL should work (from the same file URL)"] = function (t
   xhr.send();
 };
 
+exports["Getting a file URL should have valid response"] = function (t) {
+  // From https://github.com/tmpvar/jsdom/pull/1180
+  const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.onload = function () {
+    t.equal(xhr.response, fs.readFileSync(__filename));
+    t.done();
+  };
+
+  xhr.open("GET", toFileUrl(__filename), true);
+  xhr.send();
+};
+
 exports["Getting a file URL should not throw for getResponseHeader"] = function (t) {
   // From https://github.com/tmpvar/jsdom/pull/1180
   const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
@@ -25,6 +39,22 @@ exports["Getting a file URL should not throw for getResponseHeader"] = function 
   xhr.onload = function () {
     t.doesNotThrow(function () {
       t.strictEqual(xhr.getResponseHeader("Blahblahblah"), null);
+    });
+    t.done();
+  };
+
+  xhr.open("GET", toFileUrl(__filename), true);
+  xhr.send();
+};
+
+exports["Getting a file URL should not throw for getAllResponseHeaders"] = function (t) {
+  // From https://github.com/tmpvar/jsdom/pull/1180
+  const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.onload = function () {
+    t.doesNotThrow(function () {
+      t.strictEqual(xhr.getAllResponseHeaders(), null);
     });
     t.done();
   };

--- a/test/misc/xhr-file-urls.js
+++ b/test/misc/xhr-file-urls.js
@@ -1,7 +1,25 @@
 "use strict";
 const fs = require("fs");
 const jsdom = require("../..");
+const http = require("http");
+const portfinder = require("portfinder");
 const toFileUrl = require("../util").toFileUrl(__dirname);
+
+var server = [];
+var testHost = null;
+
+exports.setUp = function (done) {
+  portfinder.getPort(function (err, port) {
+    server = http.createServer(function (req, res) {
+      res.writeHead(200, [["date", "0"]]);
+      res.end("<body></body>");
+    });
+
+    server.listen(port);
+    testHost = "http://127.0.0.1:" + port;
+    done();
+  });
+};
 
 exports["Getting a file URL should work (from the same file URL)"] = function (t) {
   // From https://github.com/tmpvar/jsdom/pull/1180
@@ -18,7 +36,7 @@ exports["Getting a file URL should work (from the same file URL)"] = function (t
 };
 
 exports["Getting a file URL should have valid response"] = function (t) {
-  // From https://github.com/tmpvar/jsdom/pull/1180
+  // From https://github.com/tmpvar/jsdom/pull/1183
   const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
 
   const xhr = new window.XMLHttpRequest();
@@ -48,7 +66,7 @@ exports["Getting a file URL should not throw for getResponseHeader"] = function 
 };
 
 exports["Getting a file URL should not throw for getAllResponseHeaders"] = function (t) {
-  // From https://github.com/tmpvar/jsdom/pull/1180
+  // From https://github.com/tmpvar/jsdom/pull/1183
   const window = jsdom.jsdom(undefined, { url: toFileUrl(__filename) }).defaultView;
 
   const xhr = new window.XMLHttpRequest();
@@ -60,5 +78,21 @@ exports["Getting a file URL should not throw for getAllResponseHeaders"] = funct
   };
 
   xhr.open("GET", toFileUrl(__filename), true);
+  xhr.send();
+};
+
+exports["Getting a non-file URL should not fail for getAllResponseHeaders"] = function (t) {
+  // From https://github.com/tmpvar/jsdom/pull/1183
+  const window = jsdom.jsdom(undefined, { url: testHost + "/TestPath/get-headers" }).defaultView;
+
+  const xhr = new window.XMLHttpRequest();
+  xhr.onload = function () {
+    t.doesNotThrow(function () {
+      t.strictEqual(xhr.getAllResponseHeaders(), "date: 0\r\nconnection: close\r\ntransfer-encoding: chunked");
+    })
+    t.done();
+  };
+
+  xhr.open("GET", testHost + "/TestPath/get-headers", true);
   xhr.send();
 };


### PR DESCRIPTION
This fixes the last two issues here for me.

`getAllResponseHeaders` needed to be patched to not throw for `file:` uri's, as there is a bug in node-xhr where it doesn't even attempt to set its internal response object.

Similarly the `response` getter needed to be patched to return the `responseText` for file urls since the node-xhr project doesn't properly set the `resonseType` like it should.

I added unit tests to cover these two cases.