### PR TITLE
Proxy: include tunnel configutarion

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -177,7 +177,8 @@ exports.env = exports.jsdom.env = function () {
     var options = {
       encoding: config.encoding || "utf8",
       headers: config.headers || {},
-      proxy: config.proxy || null
+      proxy: config.proxy || null,
+      tunnel: config.tunnel || true
     };
 
     config.cookieJar = config.cookieJar || new CookieJar();


### PR DESCRIPTION
https://github.com/request/request => tunnel - controls the behavior of HTTP CONNECT tunneling as follows:
 - undefined (default) - true if the destination is https or a previous request in the redirect chain used a tunneling proxy, false otherwise
 - true - always tunnel to the destination by making a CONNECT request to the proxy
 - false - request the destination as a GET request.