### PR TITLE
Document config.virtualConsole options for jsdom.env().

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ jsdom.env(config);
 - `config.resourceLoader`: a function that intercepts subresource requests and allows you to re-route them, modify, or outright replace them with your own content. More below.
 - `config.done`, `config.onload`, `config.created`: see below.
 - `config.concurrentNodeIterators`: the maximum amount of `NodeIterator`s that you can use at the same time. The default is `10`; setting this to a high value will hurt performance.
+- `config.virtualConsole`: a virtual console instance that can capture the window’s console output.
 
 Note that at least one of the callbacks (`done`, `onload`, or `created`) is required, as is one of `html`, `file`, or `url`.
 


### PR DESCRIPTION
Document that the virtualConsole option is available when calling `jsdom.env()` (since https://github.com/tmpvar/jsdom/commit/e2d2481d00e53a4ad8d9a82161929287b60219ef)