### PR TITLE
Fix #1119: virtualConsole.sendTo should send jsdomErrors to console.error by default

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,7 @@
     "immed": true,
     "indent": 2,
     "latedef": "nofunc",
+    "loopfunc": true,
     "newcap": true,
     "noarg": true,
     "noempty": true,

--- a/README.md
+++ b/README.md
@@ -204,9 +204,16 @@ it is often also desirable to listen for any script errors during initialization
 ```js
 var virtualConsole = jsdom.createVirtualConsole();
 virtualConsole.on("jsdomError", function (error) {
-  console.error(error.message, error.detail);
+  console.error(error.stack, error.detail);
 });
 
+var window = jsdom.jsdom(..., { virtualConsole }).defaultView;
+```
+
+You also get this functionality for free by default if you use `virtualConsole.sendTo`; again, see more below:
+
+```js
+var virtualConsole = jsdom.createVirtualConsole().sendTo(console);
 var window = jsdom.jsdom(..., { virtualConsole }).defaultView;
 ```
 
@@ -422,6 +429,8 @@ var document = jsdom.jsdom(undefined, {
   virtualConsole: jsdom.createVirtualConsole().sendTo(console)
 });
 ```
+
+By default this will forward all `"jsdomError"` events to `console.error`. If you want to maintain only a strict one-to-one mapping of events to method calls, and perhaps handle `"jsdomErrors"` yourself, then you can do `jsdom.createVirtualConsole({ omitJsdomErrors: true })`.
 
 #### Create an event emitter for a window's console
 

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -22,8 +22,8 @@ require("./jsdom/living"); //Enable living standard features
 
 var canReadFilesFromFS = !!fs.readFile; // in a browserify environment, this isn't present
 
-exports.createVirtualConsole = function () {
-  return new VirtualConsole();
+exports.createVirtualConsole = function (options) {
+  return new VirtualConsole(options);
 };
 
 exports.getVirtualConsole = function (window) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -230,15 +230,18 @@ function Window(options) {
       }
     })(this);
 
+    // Clear out all listeners. Any in-flight or upcoming events should not get delivered.
+    this._events = Object.create(null);
+
     if (this._document) {
       if (this._document.body) {
         this._document.body.innerHTML = "";
       }
 
       if (this._document.close) {
-        // We need to empty out the event listener array because
-        // document.close() causes "load" event to re-fire.
-        this._document._listeners = [];
+        // It's especially important to clear out the listeners here because document.close() causes a "load" event to
+        // fire.
+        this._document._listeners = Object.create(null);
         this._document.close();
       }
       delete this._document;

--- a/lib/jsdom/virtual-console.js
+++ b/lib/jsdom/virtual-console.js
@@ -1,28 +1,28 @@
 "use strict";
+const EventEmitter = require("events").EventEmitter;
 
-var EventEmitter = require("events").EventEmitter;
-var utils = require("./utils");
+module.exports = class VirtualConsole extends EventEmitter {
+  constructor(options) {
+    super();
 
-function VirtualConsole(options) {
-  if (options === undefined) {
-    options = {};
+    if (options === undefined) {
+      options = {};
+    }
+    this.omitJsdomErrors = Boolean(options.omitJsdomErrors);
+
+    // If "error" event has no listeners,
+    // EventEmitter throws an exception
+    this.on("error", function () {});
   }
-  this.omitJsdomErrors = Boolean(options.omitJsdomErrors);
 
-  // If "error" event has no listeners,
-  // EventEmitter throws an exception
-  this.on("error", function () {});
-}
-
-utils.inheritFrom(EventEmitter, VirtualConsole, {
-  sendTo: function (anyConsole) {
-    Object.keys(anyConsole).forEach(function (method) {
+  sendTo(anyConsole) {
+    for (const method of Object.keys(anyConsole)) {
       if (typeof anyConsole[method] === "function") {
         this.on(method, function () {
           anyConsole[method].apply(anyConsole, arguments);
         });
       }
-    }, this);
+    }
 
     this.on("jsdomError", function (e) {
       if (!this.omitJsdomErrors) {
@@ -32,6 +32,4 @@ utils.inheritFrom(EventEmitter, VirtualConsole, {
 
     return this;
   }
-});
-
-module.exports = VirtualConsole;
+};

--- a/lib/jsdom/virtual-console.js
+++ b/lib/jsdom/virtual-console.js
@@ -3,7 +3,12 @@
 var EventEmitter = require("events").EventEmitter;
 var utils = require("./utils");
 
-function VirtualConsole() {
+function VirtualConsole(options) {
+  if (options === undefined) {
+    options = {};
+  }
+  this.omitJsdomErrors = Boolean(options.omitJsdomErrors);
+
   // If "error" event has no listeners,
   // EventEmitter throws an exception
   this.on("error", function () {});
@@ -18,6 +23,13 @@ utils.inheritFrom(EventEmitter, VirtualConsole, {
         });
       }
     }, this);
+
+    this.on("jsdomError", function (e) {
+      if (!this.omitJsdomErrors) {
+        anyConsole.error(e.stack, e.detail);
+      }
+    });
+
     return this;
   }
 });

--- a/test/living-html/on-error.js
+++ b/test/living-html/on-error.js
@@ -164,7 +164,7 @@ exports["unhandled non-Error exceptions thrown in sync script excecution during 
   const virtualConsole = createVirtualConsole();
   virtualConsole.on("jsdomError", function (error) {
     t.ok(error instanceof Error);
-    t.equal(error.message, "Uncaught {}");
+    t.ok(error.message === "Uncaught Object {}" || error.message === "Uncaught {}"); // io.js v3 introduces the prefix
     t.equal(typeof error.detail, "object");
     t.notEqual(error.detail, null);
     t.done();


### PR DESCRIPTION
I also threw in a commit that classes up virtual-console.js.