### PR TITLE
explanation why io.js instead of node.js in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A JavaScript implementation of the WHATWG DOM and HTML standards, for use with [
 $ npm install jsdom
 ```
 
-Note that as of our 4.0.0 release, jsdom no longer works with Node.js™, and instead requires io.js. You are still welcome to install a release in [the 3.x series](https://github.com/tmpvar/jsdom/tree/3.x) if you use Node.js™.
+Note that as of our 4.0.0 release, jsdom no longer works with Node.js™ ([why?](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#400)), and instead requires io.js (which is planned to replace Node.js™). In the meantime you are still welcome to install a release in [the 3.x series](https://github.com/tmpvar/jsdom/tree/3.x) if you use Node.js™.
 
 ## Human contact
 


### PR DESCRIPTION
makes it easier to understand why jsdom won't work with node.js and should reduce questions like #1187, #1145, #1081