### PR TITLE
Always run web platform tests from a server

### DIFF
--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -6,6 +6,8 @@ const URL = require("whatwg-url-compat").createURLConstructor();
 const domSymbolTree = require("./living/helpers/internal-constants").domSymbolTree;
 const SYMBOL_TREE_POSITION = require("symbol-tree").TreePosition;
 
+exports.URL = URL;
+
 exports.toFileUrl = function (fileName) {
   // Beyond just the `path.resolve`, this is mostly for the benefit of Windows,
   // where we need to convert "\" to "/" and add an extra "/" prefix before the

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "request": "^2.55.0",
     "symbol-tree": ">= 3.1.0 < 4.0.0",
     "tough-cookie": "^1.1.0",
-    "whatwg-url-compat": "~0.6.1",
+    "whatwg-url-compat": "~0.6.5",
     "xml-name-validator": ">= 2.0.1 < 3.0.0",
     "xmlhttprequest": ">= 1.6.0 < 2.0.0",
     "xtend": "^4.0.0"
@@ -45,6 +45,7 @@
     "portfinder": "0.4.0",
     "q": "^1.2.0",
     "selenium-standalone": "^4.4.0",
+    "st": "^0.5.5",
     "wd": "0.3.11"
   },
   "browser": {

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -69,7 +69,7 @@ self.onmessage = function (e) {
     "jsonp/jsonp": require("../test/jsonp/jsonp"), // 0/1
     "browser/css": require("../test/browser/css"), // ok
     "browser/index": require("../test/browser/index"), // ok
-    "w3c/index.js": require("../test/w3c/index"), // 0/2
+    //"w3c/index.js": require("../test/w3c/index"), // cannot browserify
     "w3c/domparsing.js": require("../test/w3c/domparsing")
   };
 


### PR DESCRIPTION
This fixes certain base URL tests I am soon hoping to add, which use hrefs like "/foo/bar.html" that don't work very well on the file system.

In theory we should be running their python server. But, it requires modifying your hosts file, which is pretty sad. We can just do this hack until we run in to the need to run tests that require that level of complexity.