### PR TITLE
Re-do NodeList and HTMLCollection

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -22,6 +22,9 @@ var proxiedWindowEventHandlers = require("../living/helpers/proxied-window-event
 const domSymbolTree = require("../living/helpers/internal-constants").domSymbolTree;
 const NODE_TYPE = require("../living/node-type");
 const resetDOMTokenList = require("../living/dom-token-list").reset;
+const createLiveNodeList = require("../living/node-list").createLive;
+const updateNodeList = require("../living/node-list").update;
+const updateHTMLCollection = require("../living/html-collection").update;
 
 // utility functions
 var attachId = function(id,elm,doc) {
@@ -69,102 +72,6 @@ var core = exports;
 
 core.DOMException = require("../web-idl/DOMException");
 core.NamedNodeMap = require("../living/attributes").NamedNodeMap;
-
-core.NodeList = function NodeList(element, query) {
-  if (!query) {
-    // Non-live NodeList
-    if (Array.isArray(element)) {
-      Array.prototype.push.apply(this, element);
-    }
-    Object.defineProperties(this, {
-      _length: {value: element ? element.length : 0, writable:true}
-    });
-  } else {
-    Object.defineProperties(this, {
-      _element: {value: element},
-      _query: {value: query},
-      _snapshot: {writable: true},
-      _length: {value: 0, writable: true},
-      _version: {value: -1, writable: true}
-    });
-    this._update();
-  }
-};
-
-function lengthFromProperties(arrayLike) {
-  var max = -1;
-  var keys = Object.keys(arrayLike);
-  var highestKeyIndex = keys.length - 1;
-
-  // abuses a v8 implementation detail for a very fast case
-  // (if this implementation detail changes, this method will still
-  //  return correct results)
-  if (highestKeyIndex == keys[highestKeyIndex]) { // not ===
-    return keys.length;
-  }
-
-  for (var i = highestKeyIndex; i >= 0 ; --i) {
-    var asNumber = + keys[i];
-
-    if (!isNaN(asNumber) && asNumber > max) {
-      max = asNumber;
-    }
-  }
-  return max + 1;
-}
-core.NodeList.prototype = {
-  _update: function() {
-    var i;
-
-    if (!this._element) {
-      this._length = lengthFromProperties(this);
-    } else {
-      if (this._version < this._element._version) {
-        var nodes = this._snapshot = this._query();
-        this._resetTo(nodes);
-        this._version = this._element._version;
-      }
-    }
-  },
-  _resetTo: function(array) {
-    var startingLength = lengthFromProperties(this);
-    for (var i = 0; i < startingLength; ++i) {
-      delete this[i];
-    }
-
-    for (var j = 0; j < array.length; ++j) {
-      this[j] = array[j];
-    }
-    this._length = array.length;
-  },
-  _toArray: function() {
-    if (this._element) {
-      this._update();
-      return this._snapshot;
-    }
-
-    return Array.prototype.slice.call(this);
-  },
-  get length() {
-    this._update();
-    return this._length || 0;
-  },
-  set length(length) {
-    return this._length;
-  },
-  item: function(index) {
-    this._update();
-    return this[index] || null;
-  },
-  toString: function() {
-    return '[ jsdom NodeList ]: contains ' + this.length + ' items';
-  }
-};
-Object.defineProperty(core.NodeList.prototype, 'constructor', {
-  value: core.NodeList,
-  writable: true,
-  configurable: true
-});
 
 core.DOMImplementation = function DOMImplementation(document, /* Object */ features) {
   throw new TypeError("Illegal constructor");
@@ -342,11 +249,13 @@ core.Node.prototype = {
   get childNodes() {
     if (!this._childNodesList) {
       var self = this;
-      this._childNodesList = new core.NodeList(this, function() {
+      this._childNodesList = createLiveNodeList(this, function() {
         return domSymbolTree.childrenToArray(self);
       });
+    } else {
+      updateNodeList(this._childNodesList);
     }
-    this._childNodesList._update();
+
     return this._childNodesList;
   },
   set childNodes(unused) { throw new core.DOMException();},
@@ -433,10 +342,10 @@ core.Node.prototype = {
     }
 
     if (this._childrenList) {
-      this._childrenList._update();
+      updateHTMLCollection(this._childrenList);
     }
     if (this._childNodesList) {
-      this._childNodesList._update();
+      updateNodeList(this._childNodesList);
     }
     this._clearMemoizedQueries();
   },
@@ -813,7 +722,7 @@ inheritFrom(core.Node, core.Element, {
 
       return false;
     }
-    return new core.NodeList(this._ownerDocument || this, mapper(this, filterByTagName, true));
+    return createLiveNodeList(this._ownerDocument || this, mapper(this, filterByTagName, true));
   }),
 
   getElementsByClassName: function (className) {
@@ -835,7 +744,7 @@ inheritFrom(core.Node, core.Element, {
       return false;
     }
 
-    return new core.NodeList(this.ownerDocument || this, mapper(this, filterByClassName));
+    return createLiveNodeList(this.ownerDocument || this, mapper(this, filterByClassName));
   }
 });
 
@@ -1022,7 +931,7 @@ inheritFrom(core.Node, core.Document, {
       }
       return false;
     }
-    return new core.NodeList(this.documentElement || this, mapper(this, filterByTagName, true));
+    return createLiveNodeList(this.documentElement || this, mapper(this, filterByTagName, true));
   }),
 
   getElementsByClassName: function (className) {
@@ -1044,7 +953,7 @@ inheritFrom(core.Node, core.Document, {
       return false;
     }
 
-    return new core.NodeList(this.ownerDocument || this, mapper(this, filterByClassName));
+    return createLiveNodeList(this.ownerDocument || this, mapper(this, filterByClassName));
   },
 
   write: function () {

--- a/lib/jsdom/level2/core.js
+++ b/lib/jsdom/level2/core.js
@@ -2,6 +2,7 @@ var core         = require("../level1/core");
 var memoizeQuery = require('../utils').memoizeQuery;
 var validateAndExtract = require('../living/helpers/validate-names').validateAndExtract;
 var mapper = require("../utils").mapper;
+const createLiveNodeList = require("../living/node-list").createLive;
 const NODE_TYPE = require("../living/node-type");
 
 core.Element.prototype.getElementsByTagNameNS = memoizeQuery(function(/* String */ namespaceURI,
@@ -21,8 +22,7 @@ core.Element.prototype.getElementsByTagNameNS = memoizeQuery(function(/* String 
     return false;
   }
 
-  return new core.NodeList(this.ownerDocument || this,
-                           mapper(this, filterByTagName));
+  return createLiveNodeList(this.ownerDocument || this, mapper(this, filterByTagName));
 });
 
 core.Document.prototype.createAttributeNS = function (namespace, qualifiedName) {

--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -19,6 +19,7 @@ var resourceLoader        = require('../browser/resource-loader'),
 const notImplemented = require("../browser/not-implemented");
 const proxiedWindowEventHandlers = require("../living/helpers/proxied-window-event-handlers");
 const domSymbolTree = require("../living/helpers/internal-constants").domSymbolTree;
+const createHTMLCollection = require("../living/html-collection").create;
 const NODE_TYPE = require("../living/node-type");
 
 // Setup the javascript language processor
@@ -89,70 +90,6 @@ function define(elementClass, def) {
   });
 }
 
-
-
-core.HTMLCollection = function HTMLCollection(element, query) {
-  this._keys = [];
-  core.NodeList.call(this, element, query);
-};
-inheritFrom(core.NodeList, core.HTMLCollection, {
-  namedItem: function(name) {
-    // Try property shortcut; should work in most cases
-    if (Object.prototype.hasOwnProperty.call(this, name)) {
-      return this[name];
-    }
-
-    var results = this._toArray(),
-        l       = results.length,
-        node,
-        matchingName = null;
-
-    for (var i=0; i<l; i++) {
-      node = results[i];
-      if (node.getAttribute('id') === name) {
-        return node;
-      } else if (node.getAttribute('name') === name) {
-        matchingName = node;
-      }
-    }
-    return matchingName;
-  },
-  toString: function() {
-    return '[ jsdom HTMLCollection ]: contains ' + this.length + ' items';
-  },
-  _resetTo: function(array) {
-    var i, _this = this;
-
-    for (i = 0; i < this._keys.length; ++i) {
-      delete this[this._keys[i]];
-    }
-    this._keys = [];
-
-    core.NodeList.prototype._resetTo.apply(this, arguments);
-
-    function testAttr(node, attr) {
-      var val = node.getAttribute(attr);
-      if (val && !Object.prototype.hasOwnProperty.call(_this, val)) {
-        _this[val] = node;
-        _this._keys.push(val);
-      }
-    }
-    for (i = 0; i < array.length; ++i) {
-      testAttr(array[i], 'id');
-    }
-    for (i = 0; i < array.length; ++i) {
-      testAttr(array[i], 'name');
-    }
-  }
-});
-Object.defineProperty(core.HTMLCollection.prototype, 'constructor', {
-  value: core.NodeList,
-  writable: true,
-  configurable: true
-});
-
-core.HTMLOptionsCollection = core.HTMLCollection;
-
 function closest(e, tagName) {
   tagName = tagName.toUpperCase();
   while (e) {
@@ -168,7 +105,7 @@ function closest(e, tagName) {
 
 function descendants(e, tagName, recursive) {
   var owner = recursive ? e._ownerDocument || e : e;
-  return new core.HTMLCollection(owner, mapper(e, function(n) {
+  return createHTMLCollection(owner, mapper(e, function(n) {
     return n.tagName === tagName;
   }, recursive));
 }
@@ -267,7 +204,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
     return this.getElementsByTagName('IMG');
   },
   get applets() {
-    return new core.HTMLCollection(this, mapper(this, function(el) {
+    return createHTMLCollection(this, mapper(this, function(el) {
       if (el && el.tagName) {
         var upper = el.tagName.toUpperCase();
         if (upper === "APPLET") {
@@ -281,7 +218,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
     }));
   },
   get links() {
-    return new core.HTMLCollection(this, mapper(this, function(el) {
+    return createHTMLCollection(this, mapper(this, function(el) {
       if (el && el.tagName) {
         var upper = el.tagName.toUpperCase();
         if (upper === "AREA" || (upper === "A" && el.href)) {
@@ -323,7 +260,7 @@ inheritFrom(core.Document, core.HTMLDocument, {
   },
 
   getElementsByName : function(elementName) {
-    return new core.HTMLCollection(this, mapper(this, function(el) {
+    return createHTMLCollection(this, mapper(this, function(el) {
       return (el.getAttribute && el.getAttribute("name") === elementName);
     }));
   },
@@ -478,7 +415,7 @@ define('HTMLFormElement', {
       core.HTMLElement.prototype._descendantRemoved.apply(this, arguments);
     },
     get elements() {
-      return new core.HTMLCollection(this._ownerDocument, mapper(this, function(e) {
+      return createHTMLCollection(this._ownerDocument, mapper(this, function(e) {
         return listedElements.test(e.nodeName) ; // TODO exclude <input type="image">
       }));
     },
@@ -495,7 +432,7 @@ define('HTMLFormElement', {
     submit: function() {
     },
     reset: function() {
-      this.elements._toArray().forEach(function(el) {
+      Array.prototype.forEach.call(this.elements, function(el) {
         if (typeof el._formReset === 'function') {
           el._formReset();
         }
@@ -660,7 +597,7 @@ define('HTMLSelectElement', {
   tagName: 'SELECT',
   proto: {
     _formReset: function() {
-      this.options._toArray().forEach(function(option, i) {
+      Array.prototype.forEach.call(this.options, function(option) {
         option._selectedness = option.defaultSelected;
         option._dirtyness = false;
       });
@@ -671,16 +608,15 @@ define('HTMLSelectElement', {
         return;
       }
 
-      var options = this.options._toArray();
-      var selected = options.filter(function(option){
+      var selected = Array.prototype.filter.call(this.options, function(option){
         return option._selectedness;
       });
 
       // size = 1 is default if not multiple
       if ((!this.size || this.size === 1) && !selected.length) {
         // select the first option that is not disabled
-        for (var i = 0; i < options.length; ++i) {
-          var option = options[i];
+        for (var i = 0; i < this.options.length; ++i) {
+          var option = this.options[i];
           var disabled = option.disabled;
           const parentNode = domSymbolTree.parent(option);
           if (parentNode &&
@@ -723,7 +659,8 @@ define('HTMLSelectElement', {
       core.HTMLElement.prototype._attrModified.apply(this, arguments);
     },
     get options() {
-      return new core.HTMLOptionsCollection(this, mapper(this, function(n) {
+      // TODO: implement HTMLOptionsCollection
+      return createHTMLCollection(this, mapper(this, function(n) {
         return n.nodeName === 'OPTION';
       }));
     },
@@ -733,13 +670,13 @@ define('HTMLSelectElement', {
     },
 
     get selectedIndex() {
-      return this.options._toArray().reduceRight(function(prev, option, i) {
+      return Array.prototype.reduceRight.call(this.options, function(prev, option, i) {
         return option.selected ? i : prev;
       }, -1);
     },
 
     set selectedIndex(index) {
-      this.options._toArray().forEach(function(option, i) {
+      Array.prototype.forEach.call(this.options, function(option, i) {
         option.selected = i === index;
       });
     },
@@ -757,7 +694,7 @@ define('HTMLSelectElement', {
 
     set value(val) {
       var self = this;
-      this.options._toArray().forEach(function(option) {
+      Array.prototype.forEach.call(this.options, function(option) {
         if (option.value === val) {
           option.selected = true;
         } else {
@@ -788,7 +725,7 @@ define('HTMLSelectElement', {
     },
 
     remove: function(index) {
-      var opts = this.options._toArray();
+      var opts = this.options;
       if (index >= 0 && index < opts.length) {
         var el = opts[index];
         domSymbolTree.parent(el).removeChild(el);
@@ -879,7 +816,7 @@ define('HTMLOptionElement', {
       this.setAttribute('value', val);
     },
     get index() {
-      return closest(this, 'SELECT').options._toArray().indexOf(this);
+      return Array.prototype.indexOf.call(closest(this, 'SELECT').options, this);
     },
     get selected() {
       return this._selectedness;
@@ -951,14 +888,14 @@ define('HTMLInputElement', {
       }
 
       var name = this.name.toLowerCase();
-      var radios = new core.HTMLCollection(this, mapper(root, function(el) {
+      var radios = createHTMLCollection(this, mapper(root, function(el) {
         return el.type === 'radio' &&
                el.name &&
                el.name.toLowerCase() === name &&
                el._radioButtonGroupRoot === root;
       }));
 
-      radios._toArray().forEach(function(radio) {
+      Array.prototype.forEach.call(radios, function(radio) {
         if (radio !== this) {
           radio._checkedness = false;
         }
@@ -1620,8 +1557,15 @@ define('HTMLTableElement', {
     get rows() {
       if (!this._rows) {
         var table = this;
-        this._rows = new core.HTMLCollection(this._ownerDocument, function() {
-          var sections = [table.tHead].concat(table.tBodies._toArray(), table.tFoot).filter(function(s) { return !!s });
+        this._rows = createHTMLCollection(this._ownerDocument, function() {
+          const sections = [];
+          if (table.tHead) {
+            sections.push(table.tHead);
+          }
+          sections.push.apply(sections, table.tBodies);
+          if (table.tFoot) {
+            sections.push(table.tFoot);
+          }
 
           if (sections.length === 0) {
             return domSymbolTree.childrenToArray(table, {filter: function(el) {
@@ -1629,10 +1573,11 @@ define('HTMLTableElement', {
             }});
           }
 
-          return sections.reduce(function(prev, s) {
-            return prev.concat(s.rows._toArray());
-          }, []);
-
+          const rows = [];
+          for (const s of sections) {
+            rows.push.apply(rows, s.rows);
+          }
+          return rows;
         });
       }
       return this._rows;
@@ -1691,7 +1636,7 @@ define('HTMLTableElement', {
       if (!domSymbolTree.hasChildren(this)) {
         this.appendChild(this._ownerDocument.createElement('TBODY'));
       }
-      var rows = this.rows._toArray();
+      var rows = this.rows;
       if (index < -1 || index > rows.length) {
         throw new core.DOMException(core.DOMException.INDEX_SIZE_ERR);
       }
@@ -1709,7 +1654,7 @@ define('HTMLTableElement', {
       return tr;
     },
     deleteRow: function(index) {
-      var rows = this.rows._toArray(), l = rows.length;
+      var rows = this.rows, l = rows.length;
       if (index === -1) {
         index = l-1;
       }
@@ -1763,7 +1708,7 @@ define('HTMLTableSectionElement', {
     },
     insertRow: function(index) {
       var tr = this._ownerDocument.createElement('TR');
-      var rows = this.rows._toArray();
+      var rows = this.rows;
       if (index < -1 || index > rows.length) {
         throw new core.DOMException(core.DOMException.INDEX_SIZE_ERR);
       }
@@ -1777,7 +1722,7 @@ define('HTMLTableSectionElement', {
       return tr;
     },
     deleteRow: function(index) {
-      var rows = this.rows._toArray();
+      var rows = this.rows;
       if (index === -1) {
         index = rows.length-1;
       }
@@ -1801,7 +1746,7 @@ define('HTMLTableRowElement', {
   proto: {
     get cells() {
       if (!this._cells) {
-        this._cells = new core.HTMLCollection(this, mapper(this, function(n) {
+        this._cells = createHTMLCollection(this, mapper(this, function(n) {
           return n.nodeName === 'TD' || n.nodeName === 'TH';
         }, false));
       }
@@ -1809,15 +1754,15 @@ define('HTMLTableRowElement', {
     },
     get rowIndex() {
       var table = closest(this, 'TABLE');
-      return table ? table.rows._toArray().indexOf(this) : -1;
+      return table ? Array.prototype.indexOf.call(table.rows, this) : -1;
     },
 
     get sectionRowIndex() {
-      return domSymbolTree.parent(this).rows._toArray().indexOf(this);
+      return Array.prototype.indexOf.call(domSymbolTree.parent(this).rows, this);
     },
     insertCell: function(index) {
       var td = this._ownerDocument.createElement('TD');
-      var cells = this.cells._toArray();
+      var cells = this.cells;
       if (index < -1 || index > cells.length) {
         throw new core.DOMException(core.DOMException.INDEX_SIZE_ERR);
       }
@@ -1831,7 +1776,7 @@ define('HTMLTableRowElement', {
       return td;
     },
     deleteCell: function(index) {
-      var cells = this.cells._toArray();
+      var cells = this.cells;
       if (index === -1) {
         index = cells.length-1;
       }
@@ -1885,7 +1830,7 @@ define('HTMLTableCellElement', {
       return headings.join(' ');
     },
     get cellIndex() {
-      return closest(this, 'TR').cells._toArray().indexOf(this);
+      return Array.prototype.indexOf.call(closest(this, 'TR').cells, this);
     }
   },
   attributes: [

--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -260,7 +260,8 @@ exports.getAttributeByName = function (element, name) {
 };
 
 exports.getAttributeValue = function (element, name) {
-  return exports.getAttributeByName(element, name).value; // TODO Attr: do not use public API
+  const attr = exports.getAttributeByName(element, name);
+  return attr && attr.value; // TODO Attr: do not use public API
 };
 
 exports.getAttributeByNameNS = function (element, namespace, localName) {

--- a/lib/jsdom/living/html-collection.js
+++ b/lib/jsdom/living/html-collection.js
@@ -1,0 +1,86 @@
+"use strict";
+const lengthFromProperties = require("../utils").lengthFromProperties;
+const getAttributeValue = require("./attributes").getAttributeValue;
+
+const privates = Symbol("HTMLCollection internal slots");
+
+class HTMLCollection {
+  constructor(secret, element, query) {
+    if (secret !== privates) {
+      throw new TypeError("Invalid constructor");
+    }
+
+    this[privates] = { element, query, snapshot: undefined, keys: [], length: 0, version: -1 };
+    updateHTMLCollection(this);
+  }
+
+  get length() {
+    updateHTMLCollection(this);
+    return this[privates].length;
+  }
+
+  item(index) {
+    updateHTMLCollection(this);
+    return this[index] || null;
+  }
+
+  namedItem(name) {
+    updateHTMLCollection(this);
+
+    if (Object.prototype.hasOwnProperty.call(this, name)) {
+      return this[name];
+    }
+    return null;
+  }
+}
+
+function updateHTMLCollection(collection) {
+  if (collection[privates].version < collection[privates].element._version) {
+    collection[privates].snapshot = collection[privates].query();
+    resetHTMLCollectionTo(collection, collection[privates].snapshot);
+    collection[privates].version = collection[privates].element._version;
+  }
+}
+
+function resetHTMLCollectionTo(collection, els) {
+  const startingLength = lengthFromProperties(collection);
+  for (let i = 0; i < startingLength; ++i) {
+    delete collection[i];
+  }
+
+  for (let i = 0; i < els.length; ++i) {
+    collection[i] = els[i];
+  }
+  collection[privates].length = els.length;
+
+  const keys = collection[privates].keys;
+  for (let i = 0; i < keys.length; ++i) {
+    delete collection[keys[i]];
+  }
+  keys.length = 0;
+
+  for (let i = 0; i < els.length; ++i) {
+    addIfAttrPresent(els[i], "name");
+  }
+  for (let i = 0; i < els.length; ++i) {
+    addIfAttrPresent(els[i], "id");
+  }
+
+  function addIfAttrPresent(el, attr) {
+    const value = getAttributeValue(el, attr);
+    if (value) {
+      collection[value] = el;
+      keys.push(value);
+    }
+  }
+}
+
+module.exports = function (core) {
+  core.HTMLCollection = HTMLCollection;
+};
+
+module.exports.create = function (element, query) {
+  return new HTMLCollection(privates, element, query);
+};
+
+module.exports.update = updateHTMLCollection;

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -1,5 +1,5 @@
 "use strict";
-var core = module.exports = require("../level1/core");
+const core = module.exports = require("../level1/core");
 
 // These (because of how they were written) directly include level1/core and modify it.
 // ORDER IS IMPORTANT
@@ -19,8 +19,10 @@ require("./text")(core);
 require("./dom-implementation")(core);
 require("./document")(core);
 require("./element")(core);
+require("./html-collection")(core);
 require("./node-filter")(core);
 require("./node-iterator")(core);
+require("./node-list")(core);
 require("./node")(core);
 require("./selectors")(core);
 require("./parent-node")(core);

--- a/lib/jsdom/living/named-properties-window.js
+++ b/lib/jsdom/living/named-properties-window.js
@@ -2,6 +2,7 @@
 const hasOwnProp = Object.prototype.hasOwnProperty;
 const namedPropertiesTracker = require("../named-properties-tracker");
 const NODE_TYPE = require("./node-type");
+const createHTMLCollection = require("./html-collection").create;
 const treeOrderSorter = require("../utils").treeOrderSorter;
 
 function isNamedPropertyElement(element) {
@@ -50,7 +51,7 @@ function namedPropertyResolver(HTMLCollection, window, name, values) {
   }
 
   const document = window._document;
-  const objects = new HTMLCollection(document.documentElement, getResult);
+  const objects = createHTMLCollection(document.documentElement, getResult);
 
   const length = objects.length;
   for (let i = 0; i < length; ++i) {

--- a/lib/jsdom/living/node-list.js
+++ b/lib/jsdom/living/node-list.js
@@ -1,0 +1,81 @@
+"use strict";
+const lengthFromProperties = require("../utils").lengthFromProperties;
+
+const privates = Symbol("NodeList internal slots");
+
+class NodeList {
+  constructor(secret, config) {
+    if (secret !== privates) {
+      throw new TypeError("Invalid constructor");
+    }
+
+    if (config.nodes) {
+      this[privates] = {
+        isLive: false,
+        length: config.nodes.length
+      };
+
+      for (let i = 0; i < config.nodes.length; ++i) {
+        this[i] = config.nodes[i];
+      }
+    } else {
+      this[privates] = {
+        isLive: true,
+        element: config.element,
+        query: config.query,
+        snapshot: undefined,
+        length: 0,
+        version: -1
+      };
+      updateNodeList(this);
+    }
+  }
+
+  get length() {
+    updateNodeList(this);
+    return this[privates].length;
+  }
+
+  item(index) {
+    updateNodeList(this);
+    return this[index] || null;
+  }
+}
+
+function updateNodeList(nodeList) {
+  if (nodeList[privates].isLive) {
+    if (nodeList[privates].version < nodeList[privates].element._version) {
+      nodeList[privates].snapshot = nodeList[privates].query();
+      resetNodeListTo(nodeList, nodeList[privates].snapshot);
+      nodeList[privates].version = nodeList[privates].element._version;
+    }
+  } else {
+    nodeList[privates].length = lengthFromProperties(nodeList);
+  }
+}
+
+function resetNodeListTo(nodeList, nodes) {
+  const startingLength = lengthFromProperties(nodeList);
+  for (let i = 0; i < startingLength; ++i) {
+    delete nodeList[i];
+  }
+
+  for (let i = 0; i < nodes.length; ++i) {
+    nodeList[i] = nodes[i];
+  }
+  nodeList[privates].length = nodes.length;
+}
+
+module.exports = function (core) {
+  core.NodeList = NodeList;
+};
+
+module.exports.createLive = function (element, query) {
+  return new NodeList(privates, { element, query });
+};
+
+module.exports.createStatic = function (nodes) {
+  return new NodeList(privates, { nodes });
+};
+
+module.exports.update = updateNodeList;

--- a/lib/jsdom/living/parent-node.js
+++ b/lib/jsdom/living/parent-node.js
@@ -1,8 +1,10 @@
 "use strict";
 
 const defineGetter = require("../utils").defineGetter;
-const domSymbolTree = require("../living/helpers/internal-constants").domSymbolTree;
-const NODE_TYPE = require("../living/node-type");
+const domSymbolTree = require("./helpers/internal-constants").domSymbolTree;
+const NODE_TYPE = require("./node-type");
+const createHTMLCollection = require("./html-collection").create;
+const updateHTMLCollection = require("./html-collection").update;
 
 module.exports = function (core) {
   // https://dom.spec.whatwg.org/#interface-parentnode
@@ -14,13 +16,14 @@ module.exports = function (core) {
     defineGetter(Constructor.prototype, "children", function () {
       if (!this._childrenList) {
         const self = this;
-        this._childrenList = new core.HTMLCollection(this, function () {
+        this._childrenList = createHTMLCollection(this, function () {
           return domSymbolTree.childrenToArray(self, {filter: function (node) {
             return node.nodeType === NODE_TYPE.ELEMENT_NODE;
           }});
         });
+      } else {
+        updateHTMLCollection(this._childrenList);
       }
-      this._childrenList._update();
       return this._childrenList;
     });
 

--- a/lib/jsdom/living/selectors.js
+++ b/lib/jsdom/living/selectors.js
@@ -1,7 +1,8 @@
 "use strict";
-var nwmatcher = require("nwmatcher/src/nwmatcher-noqsa");
-var memoizeQuery = require("../utils").memoizeQuery;
+const nwmatcher = require("nwmatcher/src/nwmatcher-noqsa");
+const memoizeQuery = require("../utils").memoizeQuery;
 const domSymbolTree = require("./helpers/internal-constants").domSymbolTree;
+const createStaticNodeList = require("../living/node-list").createStatic;
 
 module.exports = function (core) {
   [core.Document, core.DocumentFragment, core.Element].forEach(function (Class) {
@@ -10,7 +11,7 @@ module.exports = function (core) {
     });
 
     Class.prototype.querySelectorAll = memoizeQuery(function (selectors) {
-      return new core.NodeList(addNwmatcher(this).select(String(selectors), this));
+      return createStaticNodeList(addNwmatcher(this).select(String(selectors), this));
     });
   });
 

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -250,3 +250,27 @@ exports.treeOrderSorter = function (a, b) {
   // disconnected or equal:
   return 0;
 };
+
+exports.lengthFromProperties = function (arrayLike) {
+  let max = -1;
+  const keys = Object.keys(arrayLike);
+  const highestKeyIndex = keys.length - 1;
+
+  // Abuses a v8 implementation detail for a very fast case
+  // (if this implementation detail changes, this method will still
+  //  return correct results)
+  /*jshint -W116 */
+  if (highestKeyIndex == keys[highestKeyIndex]) { // not ===
+    /*jshint +W116 */
+    return keys.length;
+  }
+
+  for (let i = highestKeyIndex; i >= 0; --i) {
+    const asNumber = +keys[i];
+
+    if (!isNaN(asNumber) && asNumber > max) {
+      max = asNumber;
+    }
+  }
+  return max + 1;
+};

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -239,7 +239,7 @@ exports.tests = {
     body.appendChild(div);
     var span = doc.createElement("span");
     body.appendChild(span);
-    var index = body.childNodes._toArray().indexOf(span);
+    var index = Array.prototype.indexOf.call(body.childNodes, span);
     test.equal(index, 2, "indexOf 'span' in childNodes")
     test.done();
   },
@@ -253,8 +253,8 @@ exports.tests = {
     body.appendChild(p);
     var div = doc.createElement("div");
     p.appendChild(div);
-    var index = body.childNodes._toArray().indexOf(div);
-    test.equal(index, -1, "indexOf 'span' in childNodes")
+    var index = Array.prototype.indexOf.call(body.childNodes, div);
+    test.equal(index, -1, "indexOf 'div' in childNodes")
     test.done();
   },
 

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -16720,7 +16720,6 @@ exports.tests = {
     var doc = extra.extra();
     var element = doc.createElement('test');
     test.strictEqual(element.children.length, 0);
-    test.strictEqual(element.children._toArray().length, 0);
     test.done();
   },
 

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -10788,7 +10788,7 @@ exports.tests = {
     var doc;
     doc = load("option");
     var select = doc.getElementsByName('select2').item(0);
-    select.options._toArray().forEach(function(option, idx) {
+    Array.prototype.forEach.call(select.options, function(option, idx) {
       if (idx === 0) {
         test.ok(option.selected);
       } else {
@@ -10810,7 +10810,7 @@ exports.tests = {
 
     select.options.item(3).selected = true;
 
-    select.options._toArray().forEach(function(option, idx) {
+    Array.prototype.forEach.call(select.options, function(option, idx) {
       if (idx === 3) {
         test.ok(option.selected);
       } else {

--- a/test/living-dom/node-list.js
+++ b/test/living-dom/node-list.js
@@ -1,0 +1,10 @@
+"use strict";
+const jsdom = require("../..");
+
+exports["Object.keys on a NodeList gives the correct keys"] = function (t) {
+  const document = jsdom.jsdom("<p>1</p><p>2</p><p>3</p>");
+  const nodeList = document.querySelectorAll("p");
+
+  t.deepEqual(Object.keys(nodeList), ["0", "1", "2"]);
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -42,6 +42,7 @@ var files = [
   "living-dom/event-target.js",
   "living-dom/node-clone-node.js",
   "living-dom/node-contains.js",
+  "living-dom/node-list.js",
   "living-dom/node-owner-document.js",
   "living-dom/node-parent-element.js",
   "living-dom/query-selector.js",

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -36,6 +36,7 @@ self.onmessage = function (e) {
     "living-dom/event-target.js": require("../test/living-dom/event-target.js"), // ok
     "living-dom/node-clone-node.js": require("../test/living-dom/node-clone-node.js"), // ok
     "living-dom/node-contains.js": require("../test/living-dom/node-contains.js"), // 0/20
+    "living-dom/node-list.js": require("../test/living-dom/node-list.js"), // ok
     "living-dom/node-parent-element.js": require("../test/living-dom/node-parent-element.js"), // 0/11
     "living-dom/non-document-type-child-node.js": require("../test/living-dom/non-document-type-child-node.js"),
 
@@ -93,6 +94,7 @@ self.onmessage = function (e) {
     "living-dom/class-list.js",
     "living-dom/event-target.js",
     "living-dom/node-clone-node.js",
+    "living-dom/node-list.js",
     "living-dom/non-document-type-child-node.js",
     "living-html/htmlanchorelement.js",
     "living-html/htmlbuttonelement.js",


### PR DESCRIPTION
- Removes all non-public properties and methods, in the process fixing #1224.
- Removes NodeList's no-op length setter, fixing #859. It was only used so that we could call Array.prototype.push on it; instead we manually copy over nodes.
- Removes their public constructors.
- Removes the inheritance relationship between them, which is incorrect.
- Removes HTMLOptionsCollection, which was just an alias for HTMLCollection. We'll use HTMLCollection instead, for now.