### PR TITLE
1157 remove style elem fix

### DIFF
--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -891,7 +891,12 @@ inheritFrom(core.Node, core.Document, {
   },
 
   _descendantRemoved: function(parent, child) {
-    core.Node.prototype._descendantRemoved.apply(this, arguments);
+    if(child.tagName === 'STYLE') {
+      var index = this.styleSheets.indexOf(child.sheet);
+      if(index > -1) {
+        this.styleSheets.splice(index, 1);
+      }
+    }
   },
 
   /* returns NodeList */

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -890,6 +890,10 @@ inheritFrom(core.Node, core.Document, {
     return ret;
   },
 
+  _descendantRemoved: function(parent, child) {
+    core.Node.prototype._descendantRemoved.apply(this, arguments);
+  },
+
   /* returns NodeList */
   getElementsByTagName: memoizeQuery(function(/* string */ name) {
     function filterByTagName(child) {

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -149,8 +149,6 @@ core.HTMLLinkElement._init = function() {
       fetchStylesheet.call(this, this.href, this.sheet);
     }
   });
-  this.addEventListener('DOMNodeRemovedFromDocument', function() {
-  });
 };
 
 assert.equal(undefined, core.HTMLStyleElement._init);

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -174,14 +174,14 @@ core.HTMLStyleElement._init = function() {
     evaluateStylesheet.call(this, content, this.sheet, this._ownerDocument.URL);
   });
 
-  this.addEventListener('DOMNodeRemovedFromDocument', function() {
+  this.ownerDocument.addEventListener('_descendantRemoved', function(e) {
     var index = this.ownerDocument.styleSheets.indexOf(this.sheet);
     if(index > -1) {
-      this.ownerDocument.styleSheets = this.ownerDocument.styleSheets.splice(index, 1);
+      this.ownerDocument.styleSheets.splice(index, 1);
     }
   });
-};
 
+};
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement:
 // HTMLLinkElement implements LinkStyle

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -174,13 +174,6 @@ core.HTMLStyleElement._init = function() {
     evaluateStylesheet.call(this, content, this.sheet, this._ownerDocument.URL);
   });
 
-  this.ownerDocument.addEventListener('_descendantRemoved', function(e) {
-    var index = this.ownerDocument.styleSheets.indexOf(this.sheet);
-    if(index > -1) {
-      this.ownerDocument.styleSheets.splice(index, 1);
-    }
-  });
-
 };
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement:

--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -173,6 +173,13 @@ core.HTMLStyleElement._init = function() {
 
     evaluateStylesheet.call(this, content, this.sheet, this._ownerDocument.URL);
   });
+
+  this.addEventListener('DOMNodeRemovedFromDocument', function() {
+    var index = this.ownerDocument.styleSheets.indexOf(this.sheet);
+    if(index > -1) {
+      this.ownerDocument.styleSheets = this.ownerDocument.styleSheets.splice(index, 1);
+    }
+  });
 };
 
 

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -19,6 +19,23 @@ exports.tests = {
     });
   },
 
+  HTMLStyleElement02: function(test) {
+    var pageHTML = '<!doctype html><html><head>' +
+        '<style>p { color: green; }</style><style>div { color: red; }</style>' +
+        '</head><body></body></html>';
+    var removeScript = "var style2 = document.getElementsByTagName('style')[1]; " +
+        "style2.parentNode.removeChild(style2);";
+    jsdom.env({
+      html: pageHTML,
+      src: removeScript,
+      done: function(err, window) {
+        test.equal(1, window.document.getElementsByTagName("style").length);
+        test.equal(1, window.document.styleSheets.length);
+        test.done();
+      }
+    });
+  },
+
   HTMLStyleAttribute01: function (test) {
     jsdom.env(
         "<html><body><p style=\"color:red; background-color: blue\">",

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -29,6 +29,7 @@ exports.tests = {
       html: pageHTML,
       src: removeScript,
       done: function(err, window) {
+        test.ifError(err);
         test.equal(1, window.document.getElementsByTagName("style").length);
         test.equal(1, window.document.styleSheets.length);
         test.done();


### PR DESCRIPTION
Handling the `DOMNodeRemovedFromDocument` for `HTMLStyleElement`s.

This is resolving #1157 