### PR TITLE
Implement loose cooking parsing

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -36,7 +36,7 @@ exports.getVirtualConsole = function (window) {
 };
 
 exports.createCookieJar = function () {
-  return new CookieJar();
+  return new CookieJar(null, { looseMode: true });
 };
 
 exports.nodeLocation = function (node) {
@@ -200,7 +200,7 @@ exports.env = exports.jsdom.env = function () {
       proxy: config.proxy || null
     };
 
-    config.cookieJar = config.cookieJar || new CookieJar();
+    config.cookieJar = config.cookieJar || exports.createCookieJar();
 
     resourceLoader.download(config.url, options, config.cookieJar, null, (err, responseText, res) => {
       if (err) {

--- a/lib/jsdom/level1/core.js
+++ b/lib/jsdom/level1/core.js
@@ -753,7 +753,7 @@ core.Document = function Document(options) {
   this._attached = true;
   this._readonly = false;
   this._currentScript = null;
-  this._cookieJar = options.cookieJar === undefined ? new CookieJar() : options.cookieJar;
+  this._cookieJar = options.cookieJar === undefined ? new CookieJar(null, { looseMode: true }) : options.cookieJar;
 
   this._contentType = options.contentType;
   if (this._contentType === undefined) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "parse5": "^1.4.2",
     "request": "^2.55.0",
     "symbol-tree": ">= 3.1.0 < 4.0.0",
-    "tough-cookie": "^2.0.0",
+    "tough-cookie": "^2.2.0",
     "webidl-conversions": "^2.0.0",
     "whatwg-url-compat": "~0.6.5",
     "xml-name-validator": ">= 2.0.1 < 3.0.0",

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -2488,7 +2488,7 @@ exports.tests = {
 
     var ret = doc.cookie = null;
     test.equal(ret, null, "cookieLink");
-    test.equal(doc.cookie, vcookie, "cookieLink");
+    test.equal(doc.cookie, vcookie + "; null", "cookieLink"); // yes, this is actually how this should behave
 
 
     test.done();

--- a/test/living-html/cookie.js
+++ b/test/living-html/cookie.js
@@ -17,7 +17,8 @@ const testCookies = [
   "Test7=Secure; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/; Secure",
   "Test8=Expired; expires=Wed, 13-Jan-1977 22:23:01 GMT; path=/",
   "Test9=Duplicate; One=More; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/",
-  "Test10={\"prop1\":5,\"prop2\":\"value\"}; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/"
+  "Test10={\"prop1\":5,\"prop2\":\"value\"}; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/",
+  "Malformed; expires=Wed, 13-Jan-2051 22:23:01 GMT; path=/"
 ];
 
 function assertCookies(t, actualCookieStr, expectedCookies) {
@@ -104,7 +105,8 @@ exports["Set cookie by client"] = t => {
         "Test1=Basic",
         "Test2=PathMatch",
         "Test9=Duplicate",
-        "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+        "Malformed"
       ]);
       t.done();
     }
@@ -121,7 +123,8 @@ exports["Set cookie by page request"] = t => {
         "Test1=Basic",
         "Test2=PathMatch",
         "Test9=Duplicate",
-        "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+        "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+        "Malformed"
       ]);
       t.done();
     }
@@ -145,7 +148,8 @@ exports["Set cookie by resource request"] = t => {
           "Test1=Basic",
           "Test2=PathMatch",
           "Test9=Duplicate",
-          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+          "Malformed"
         ]);
         t.done();
       };
@@ -168,7 +172,8 @@ exports["Set cookie by XHR"] = t => {
           "Test1=Basic",
           "Test2=PathMatch",
           "Test9=Duplicate",
-          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+          "Malformed"
         ]);
         t.done();
       };
@@ -212,7 +217,8 @@ exports["Send Cookies header via resource request"] = t => {
           "Test2=PathMatch",
           "Test6=HttpOnly",
           "Test9=Duplicate",
-          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+          "Malformed"
         ]);
         t.done();
       };
@@ -236,7 +242,8 @@ exports["Send Cookies header via XHR"] = t => {
           "Test2=PathMatch",
           "Test6=HttpOnly",
           "Test9=Duplicate",
-          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+          "Malformed"
         ]);
         t.done();
       };
@@ -265,7 +272,8 @@ exports["Share cookies with <iframe>"] = t => {
           "Test1=Basic",
           "Test2=PathMatch",
           "Test9=Duplicate",
-          "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+          "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+          "Malformed"
         ]);
         t.done();
       };
@@ -326,14 +334,16 @@ exports["options.cookieJar"] = t => {
             "Test2=PathMatch",
             "Test6=HttpOnly",
             "Test9=Duplicate",
-            "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+            "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+            "Malformed"
           ]);
 
           assertCookies(t, window.document.cookie, [
             "Test1=Basic",
             "Test2=PathMatch",
             "Test9=Duplicate",
-            "Test10={\"prop1\":5,\"prop2\":\"value\"}"
+            "Test10={\"prop1\":5,\"prop2\":\"value\"}",
+            "Malformed"
           ]);
 
           t.done();


### PR DESCRIPTION
This enables correct execution of code like `document.cookie = 'foo'`.

Blocked on either https://github.com/request/request/pull/1811 or https://github.com/SalesforceEng/tough-cookie/pull/56.