### PR TITLE
`FetchExternalResources: ["script"]` causes jsdom to pass different window instances to its callbacks

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -96,11 +96,11 @@ exports.jsdom = function (html, options) {
     virtualConsole: options.virtualConsole
   });
 
-  if (options.created) {
-    options.created(null, window);
-  }
-
   documentFeatures.applyDocumentFeatures(window.document, options.features);
+
+  if (options.created) {
+    options.created(null, window.document.defaultView);
+  }
 
   if (options.parsingMode === "html") {
     if (html === undefined || html === "") {

--- a/test/jsdom/env.js
+++ b/test/jsdom/env.js
@@ -560,3 +560,60 @@ exports["done should be called only once, after all src scripts have executed"] 
     }
   });
 };
+
+exports["window instances should be initialized when provided to callbacks"] = t => {
+  t.expect(5);
+
+  env({
+    html: "<div></div>",
+    features: {
+      ProcessExternalResources: ["script"]
+    },
+    created(err, window) {
+      t.ifError(err);
+      t.notEqual(window.Array, undefined);
+    },
+    onload(window) {
+      t.notEqual(window.Array, undefined);
+    },
+    done(err, window) {
+      t.ifError(err);
+      t.notEqual(window.Array, undefined);
+      t.done();
+    }
+  });
+};
+
+exports["window instances provided to callbacks always refer to the same object"] = t => {
+  t.expect(3 + 2);
+
+  const instances = [];
+
+  function finish() {
+    for (let i = 0; i < instances.length; ++i) {
+      for (let j = 0; j < i; ++j) {
+        t.strictEqual(instances[i], instances[j], `instances ${i} and ${j} should be equal`);
+      }
+    }
+    t.done();
+  }
+
+  env({
+    html: "<div></div>",
+    features: {
+      ProcessExternalResources: ["script"]
+    },
+    created(err, window) {
+      t.ifError(err);
+      instances.push(window);
+    },
+    onload(window) {
+      instances.push(window);
+    },
+    done(err, window) {
+      t.ifError(err);
+      instances.push(window);
+      finish();
+    }
+  });
+};


### PR DESCRIPTION
### Versions

jsdom: 6.5.1
node: 4.1.0

### What steps will reproduce the problem?

1. Save this code to a file:

    ```
var jsdom = require("jsdom");
var assert = require("chai").assert;

var instances = {};
jsdom.env({
    html: "",
    features: {
        FetchExternalResources: ["script"],
    },
    created: function (error, w) {
        assert.isNull(error);
        assert.isTrue(!!w);
        instances["created"] = w;
    },
    onload: function (w) {
        assert.isTrue(!!w);
        instances["onload"] = w;
    },
    done: function (error, w) {
        assert.isNull(error);
        assert.isTrue(!!w);
        instances["done"] = w;
        var keys = Object.keys(instances);
        for (var i = 0, key1; (key1 = keys[i]); ++i) {
            for (var j = i + 1, key2; (key2 = keys[j]); ++j) {
                console.log(key1 + " === " + key2 + ": " +
                            (instances[key1] === instances[key2]));
            }
        }
    }
});
```

2. Install jsdom and Chai.

3. Run the code.

### What is the expected output?

```
created === onload: true
created === done: true
onload === done: true
```

### What do you see instead?

```
created === onload: false
created === done: false
onload === done: true
```

### Observations

1. The expected output is obtained if this is removed from the configuration:

    ```
    features: {
        FetchExternalResources: ["script"],
    },
```

2. `html:""` is not a factor. I can reproduce the same problem with complex pages.

3. This issue is a problem if the window instance passed to `created` is saved for future use, as this appears to be a `Window` instance which is not fully formed. (For instance, `Array` is not defined on it.) The solution is to save the window instance passed to `onload` or `done` instead.