### PR TITLE
issue with babel compiled source and jsdom 7.0.1

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -177,9 +177,6 @@ function Window(options) {
 
   // TODO: necessary for Blob and FileReader due to different-globals weirdness; investigate how to avoid this.
   this.ArrayBuffer = ArrayBuffer;
-  this.Date = Date;
-  this.RegExp = RegExp;
-
   this.Int8Array = Int8Array;
   this.Uint8Array = Uint8Array;
   this.Uint8ClampedArray = Uint8ClampedArray;

--- a/test/misc/cancel-requests.js
+++ b/test/misc/cancel-requests.js
@@ -201,5 +201,3 @@ exports["stopping window should close xhr but abort event should be triggered"] 
     });
   });
 };
-
-


### PR DESCRIPTION
I'm trying to upgrade jsdom to 7.0.1 and I bisected a big issue to https://github.com/tmpvar/jsdom/commit/2c8933905e9b81436843fe8d429918876a277e54 although I'm not exactly sure *why* things are going wrong given that this change was so large.

Here is a repro for open source:
```
git clone https://github.com/facebook/relay.git
cd scripts/babel-relay-plugin
npm install
# cd into `node_modules/jest-cli`, edit the package.json to jsdom 7.0.1 and run npm update
npm test
```

test output: https://gist.github.com/cpojer/b15a99a7939cfe79c2f4

with jsdom 6.5 we didn't have any of these issues. At FB I have about 70 failing tests because of this, unfortunately.