### PR TITLE
Use the "request" module instead of "browser-request"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "abab": "^1.0.0",
     "acorn": "^2.4.0",
     "acorn-globals": "^1.0.4",
-    "browser-request": ">= 0.3.1 < 0.4.0",
     "cssom": ">= 0.3.0 < 0.4.0",
     "cssstyle": ">= 0.2.29 < 0.3.0",
     "escodegen": "^1.6.1",
@@ -54,8 +53,7 @@
   },
   "browser": {
     "canvas": false,
-    "vm": "./lib/jsdom/vm-shim.js",
-    "request": "browser-request"
+    "vm": "./lib/jsdom/vm-shim.js"
   },
   "scripts": {
     "prepublish": "npm run convert-idl",

--- a/test/jsdom/env-browser.js
+++ b/test/jsdom/env-browser.js
@@ -1,0 +1,19 @@
+/* global location */
+
+"use strict";
+
+// This suite tests env() within a WebWorker
+
+const env = require("../..").env;
+const testServerLocation = location.origin; // WorkerLocation
+
+exports["should be able to fetch a html document"] = t => {
+  env({
+    url: testServerLocation + "/test/jsdom/files/reddit.html",
+    done(err, window) {
+      t.ifError(err);
+      t.strictEqual(window.document.getElementById("header-bottom-left").nodeName, "DIV");
+      t.done();
+    }
+  });
+};

--- a/test/worker-runner.js
+++ b/test/worker-runner.js
@@ -65,6 +65,7 @@ self.onmessage = function (e) {
     "jsdom/parsing": require("../test/jsdom/parsing"), // 0/11
     "jsdom/serialization": require("../test/jsdom/serialization"),
     "jsdom/env": require("../test/jsdom/env"), // 9/25
+    "jsdom/env-browser": require("../test/jsdom/env-browser"),
     "jsdom/utils": require("../test/jsdom/utils"), // ok
     "jsdom/inside-worker-smoke-tests": require("../test/jsdom/inside-worker-smoke-tests"),
     "jsdom/named-properties-tracker.js": require("../test/jsdom/named-properties-tracker"),
@@ -113,6 +114,7 @@ self.onmessage = function (e) {
     "window/base64",
     "window/history",
     "window/console",
+    "jsdom/env-browser",
     "jsdom/utils",
     "jsdom/inside-worker-smoke-tests",
     "jsdom/serialization",


### PR DESCRIPTION
Currently, fetching files within the browser is broken because `browser-request` does not support `request.jar()`, also we are passing arguments to `request()` in such a way that it is not compatible with `browser-request`. The `request` library seems to support browsers just fine nowadays

This fixes #1285 @czardoz

I am going to try to update this PR with a simple test case to prevent regressions.