### PR TITLE
Adds logic for retrieval of items by name and includes a test for it

### DIFF
--- a/lib/jsdom/living/node-list.js
+++ b/lib/jsdom/living/node-list.js
@@ -64,6 +64,11 @@ function resetNodeListTo(nodeList, nodes) {
 
   for (let i = 0; i < nodes.length; ++i) {
     nodeList[i] = nodes[i];
+    if (typeof nodes[i].getAttribute !== "undefined") {
+      if (nodes[i].getAttribute("name")) {
+        nodeList[nodes[i].getAttribute("name")] = nodes[i];
+      }
+    }
   }
   nodeList[privates].length = nodes.length;
 }

--- a/test/level2/html.js
+++ b/test/level2/html.js
@@ -19931,5 +19931,17 @@ exports.tests = {
     doc.close();
     test.ok(doc === docOpen, 'doc.open() should return the Document on which the method was invoked');
     test.done();
+  },
+
+  getNodeByName: function (test) {
+    jsdom.env(
+      {
+      html: '<html><head lang="en"></head><body><form name="name"></form></body></html>',
+      done: function (err, window) {
+            test.equal(typeof window.document.forms['name'], 'object');
+            test.equal(window.document.forms.length, 1);
+            test.done();
+        }
+      });
   }
 };


### PR DESCRIPTION
document.form['someName'] was not possible.
I added this functionality to the nodeList class and keep the length to the original.
This reflects the browser behavior.

I was not sure where to put the test so i just added it to level2.

Hopefully your going fine with that as we have some legacy js which uses this alot.
Also for document.images['name'].