### PR TITLE
Add extra request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ jsdom.env(config);
 - `config.virtualConsole`: a virtual console instance that can capture the window’s console output; see the "Capturing Console Output" examples.
 - `config.pool`: an object describing which agents to use for the requests; defaults to `{ maxSockets: 6 }`, see [request module](https://github.com/request/request#requestoptions-callback) for more details.
 - `config.agentOptions`: the agent options; defaults to `{ keepAlive: true, keepAliveMsecs: 115000 }`, see [http api](https://nodejs.org/api/http.html) for more details.
+- `config.request`: When loading HTML over the network (with `configu.url`) this option allows you to specify additional parameters for the [request](https://www.npmjs.com/package/request) module. This allows you to send POST and other more complicated requests. See all available addition parameters [here](https://www.npmjs.com/package/request#request-options-callback).
 
 Note that at least one of the callbacks (`done`, `onload`, or `created`) is required, as is one of `html`, `file`, or `url`.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ jsdom.env(config);
 - `config.virtualConsole`: a virtual console instance that can capture the window’s console output; see the "Capturing Console Output" examples.
 - `config.pool`: an object describing which agents to use for the requests; defaults to `{ maxSockets: 6 }`, see [request module](https://github.com/request/request#requestoptions-callback) for more details.
 - `config.agentOptions`: the agent options; defaults to `{ keepAlive: true, keepAliveMsecs: 115000 }`, see [http api](https://nodejs.org/api/http.html) for more details.
-- `config.request`: When loading HTML over the network (with `configu.url`) this option allows you to specify additional parameters for the [request](https://www.npmjs.com/package/request) module. This allows you to send POST and other more complicated requests. See all available addition parameters [here](https://www.npmjs.com/package/request#request-options-callback).
+- `config.request`: When loading HTML over the network (with `config.url`) this option allows you to specify additional parameters for the [request](https://www.npmjs.com/package/request) module. This allows you to send POST and other more complicated requests. See all available addition parameters [here](https://www.npmjs.com/package/request#request-options-callback).
 
 Note that at least one of the callbacks (`done`, `onload`, or `created`) is required, as is one of `html`, `file`, or `url`.
 

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -204,7 +204,8 @@ exports.env = exports.jsdom.env = function () {
       encoding: config.encoding || "utf8",
       headers: config.headers || {},
       pool: config.pool,
-      agentOptions: config.agentOptions
+      agentOptions: config.agentOptions,
+      request: config.request
     };
 
     if (config.proxy) {

--- a/lib/jsdom/browser/resource-loader.js
+++ b/lib/jsdom/browser/resource-loader.js
@@ -156,7 +156,8 @@ exports.download = function (url, options, cookieJar, referrer, callback) {
     options.headers["Accept-Language"] = "en";
   }
 
-  const req = request(url, options, (error, response, data) => callback(error, data, response));
+  const reqOptions = Object.assign({}, options.request || {}, options);
+  const req = request(url, reqOptions, (error, response, data) => callback(error, data, response));
   return {
     abort() {
       req.abort();

--- a/test/jsdom/env.js
+++ b/test/jsdom/env.js
@@ -179,6 +179,38 @@ exports["explicit config.url, invalid"] = t => {
   });
 };
 
+exports["explicit config.url with extra request options valid"] = t => {
+  const formData = "key1=value1&key2=value2&key3=value3";
+
+  const server = http.createServer((req, res) => {
+    t.equal(req.method, "POST");
+    t.equal(req.headers["content-type"], "application/x-www-form-urlencoded");
+    let reqBody = "";
+    req.on("data", data => reqBody += data.toString());
+    req.on("end", () => {
+      t.equal(reqBody, formData);
+      res.writeHead(200);
+      res.end();
+      server.close();
+    });
+  }).listen(8976);
+
+  env({
+    url: "http://localhost:8976/",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    request: {
+      method: "POST",
+      body: formData
+    },
+    done(err) {
+      t.ifError(err);
+      t.done();
+    }
+  });
+};
+
 exports["explicit config.file, valid"] = t => {
   const fileName = path.resolve(__dirname, "files/env.html");
 


### PR DESCRIPTION
I want to make `POST` requests using `jsdom.env`, so this pr adds the ability to define extra [request options](https://www.npmjs.com/package/request#request-options-callback) in `config.request`.

I can add tests if you want, I just need to know where to put those tests.