### PR TITLE
Fix typo in symbols file name

### DIFF
--- a/lib/jsdom/living/filelist.js
+++ b/lib/jsdom/living/filelist.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const filelistSymbols = require("./file-symbols");
+const filelistSymbols = require("./filelist-symbols");
 
 module.exports = function (core) {
   class FileList {


### PR DESCRIPTION
The correct file containing the symbols for filellist.js is filelist-symbols, not file-symbols.