### PR TITLE
INPUT tag of type 'file' should return an array for files

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -875,6 +875,7 @@ define('HTMLOptionElement', {
 });
 
 const filesSymbol = Symbol("files");
+const fileListSymbol = require("../living/filelist-symbols")
 
 define('HTMLInputElement', {
   tagName: 'INPUT',
@@ -1004,7 +1005,7 @@ define('HTMLInputElement', {
       } else {
         this[filesSymbol] = null;
       }
-      return this[filesSymbol];
+      return this[filesSymbol] ? this[filesSymbol][fileListSymbol.list] : null
     },
     get type() {
         var type = this.getAttribute('type');


### PR DESCRIPTION
The INPUT tag of type 'file' returns a FileList object for the files property at the moment. This is not correct, it should return an array of Files.
Change the method so that it returns the Array backing the FileList instead of returning the FileList itself.