### PR TITLE
Regression with serialisation of <math>

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -242,7 +242,7 @@ function setChild(core, parent, node) {
   if (node.attribs) {
     for (let localName in node.attribs) {
       const value = node.attribs[localName];
-      let prefix = node["x-attribsPrefix"] && node["x-attribsPrefix"][localName];
+      let prefix = node["x-attribsPrefix"] && node["x-attribsPrefix"][localName] || null;
       const namespace = node["x-attribsNamespace"] && node["x-attribsNamespace"][localName] || null;
       if (prefix === "xmlns" && localName === "") {
          // intended weirdness in node-sax, see https://github.com/isaacs/sax-js/issues/165

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -369,3 +369,14 @@ exports["<%= stuff %> inside <script> tags (GH-58)"] = t => {
   t.strictEqual(document.head.childNodes[0].innerHTML, content);
   t.done();
 };
+
+exports["xmlns doesn't cause empty prefix"] = t => {
+  const html = "<!DOCTYPE html><math xmlns=\"http://www.w3.org/1998/Math/MathML\"></math>";
+  const expected = "<!DOCTYPE html><html><head></head>" +
+    "<body><math xmlns=\"http://www.w3.org/1998/Math/MathML\"></math></body></html>";
+  jsdom.env(html, (err, window) => {
+    t.ifError(err);
+    t.strictEqual(jsdom.serializeDocument(window.document), expected);
+    t.done();
+  });
+};


### PR DESCRIPTION
Serialising `math` elements generates a namespace declaration with `:xmlns` instead of `xmlns`.

Example code:

```js
var jsdom = require('jsdom');
var html = '<!DOCTYPE html><math xmlns="http://www.w3.org/1998/Math/MathML"></math>';
jsdom.env(html, (err, window) => {
  if (err) return console.error('ERROR: ' + err);
  console.log(jsdom.serializeDocument(window.document));
});
```

Output:

```html
<!DOCTYPE html><html><head></head><body><math :xmlns="http://www.w3.org/1998/Math/MathML"></math></body></html>
```