### PR TITLE
Make base64 contents optional in data urls

### DIFF
--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -281,7 +281,7 @@ exports.parseDataUrl = function parseDataUrl(url) {
   const urlParts = url.match(/^data:(.+?)(?:;(base64))?,(.*)$/);
   let buffer;
   if (urlParts[2] === "base64") {
-    if (!base64Regexp.test(urlParts[3])) {
+    if (urlParts[3] && !base64Regexp.test(urlParts[3])) {
       throw new Error("Not a base64 string");
     }
     buffer = new Buffer(urlParts[3], "base64");

--- a/test/jsdom/resource-loading.js
+++ b/test/jsdom/resource-loading.js
@@ -71,3 +71,8 @@ exports["<frame> loading errors show up as jsdomErrors in the virtual console"] 
   jsdom.jsdom(`<frameset><frame src="http://localhost:12345/foo.html"></frameset>`,
     { virtualConsole, features: { FetchExternalResources: ["frame"] } });
 };
+
+exports["empty base64 data urls should be blank"] = t => {
+  jsdom.jsdom(`<link rel="stylesheet" href="data:text/css;base64,">`);
+  t.done();
+};

--- a/test/jsdom/utils.js
+++ b/test/jsdom/utils.js
@@ -224,3 +224,8 @@ exports["isValidTargetOrigin properly validates target origin"] = t => {
 
   t.done();
 };
+
+exports["parseDataUrl should handle empty base64 data urls"] = t => {
+  t.strictEqual(utils.parseDataUrl("data:text/css;base64,").buffer.toString(), "");
+  t.done();
+};


### PR DESCRIPTION
I wasn't sure where to put a test so I created a new `misc/utils` file. Let me know if there's a more appropriate place.