### PR TITLE
Allow style changes using shorthands to set all the sub-styles properly

### DIFF
--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -14,9 +14,9 @@ class HTMLElementImpl extends ElementImpl {
 
     this._style = new this._core.CSSStyleDeclaration(newCssText => {
       if (!this._settingCssText) {
-	this._settingCssText = true;
+        this._settingCssText = true;
         this.setAttribute("style", newCssText);
-	this._settingCssText = false;
+        this._settingCssText = false;
       }
     });
   }

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -14,7 +14,9 @@ class HTMLElementImpl extends ElementImpl {
 
     this._style = new this._core.CSSStyleDeclaration(newCssText => {
       if (!this._settingCssText) {
+	this._settingCssText = true;
         this.setAttribute("style", newCssText);
+	this._settingCssText = false;
       }
     });
   }

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -110,6 +110,23 @@ exports.tests = {
     });
   },
 
+  StyleShorthandProperties: function (test) {
+    jsdom.env(
+        "",
+        function (err, win) {
+      var p = win.document.createElement("p");
+      p.style.border = "1px solid black";
+      test.equal(1, p.style.length);
+      test.equal("1px solid black", p.style.border);
+      test.equal("1px", p.style.borderWidth);
+      test.equal("solid", p.style.borderStyle);
+      test.equal("black", p.style.borderColor);
+      test.equal("border: 1px solid black;", p.style.cssText);
+      test.equal('<p style="border: 1px solid black;"></p>', p.outerHTML);
+      test.done();
+    });
+  },
+
   retainOriginalStyleAttributeUntilStyleGetter: function (test) {
     jsdom.env(
         "",


### PR DESCRIPTION
This pull request resolves issue #1241.  To test, use

```
var jsdom = require("jsdom").jsdom;
var doc = jsdom("");
var el = doc.createElement("div");
el.style.border = "1px solid black";
console.log(el.style.border);          // should be "1px solid black"
console.log(el.style.cssText);         // should be  "border: 1px solid black"
console.log(el.outerHTML);             // should be '<div style="border: 1px solid black"></div>'
el.style = "border: 1px solid black";
console.log(el.style.border);          // should be "1px solid black"
console.log(el.style.cssText);         // should be  "border: 1px solid black"
console.log(el.outerHTML);             // should be '<div style="border: 1px solid black"></div>'
```

Without the patch the border would be reported as just `black` rather than `1px solid black`.