### PR TITLE
Fix setTimeout for string attributes

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -18,6 +18,7 @@ const internalConstants = require("../living/helpers/internal-constants");
 const createFileReader = require("../living/file-reader");
 const createXMLHttpRequest = require("../living/xmlhttprequest");
 const Document = require("../living/generated/Document");
+const reportException = require("../living/helpers/runtime-script-errors");
 
 // NB: the require() must be after assigning `module.exports` because this require() is circular
 // TODO: this above note might not even be true anymore... figure out the cycle and document it, or clean up.
@@ -136,10 +137,18 @@ function Window(options) {
   let latestTimerId = 0;
 
   this.setTimeout = function (fn, ms) {
-    return startTimer(window, setTimeout, clearTimeout, latestTimerId++, fn, ms);
+    const args = [];
+    for (let i = 2; i < arguments.length; ++i) {
+      args[i - 2] = arguments[i];
+    }
+    return startTimer(window, setTimeout, clearTimeout, latestTimerId++, fn, ms, args);
   };
   this.setInterval = function (fn, ms) {
-    return startTimer(window, setInterval, clearInterval, latestTimerId++, fn, ms);
+    const args = [];
+    for (let i = 2; i < arguments.length; ++i) {
+      args[i - 2] = arguments[i];
+    }
+    return startTimer(window, setInterval, clearInterval, latestTimerId++, fn, ms, args);
   };
   this.clearInterval = stopTimer.bind(this, window);
   this.clearTimeout = stopTimer.bind(this, window);
@@ -404,7 +413,21 @@ function matchesDontThrow(el, selector) {
   }
 }
 
-function startTimer(window, startFn, stopFn, timerId, callback, ms) {
+function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
+  if (typeof callback !== "function") {
+    const code = String(callback);
+    callback = window._globalProxy.eval.bind(window, code + `\n//# sourceURL=${window.location.href}`);
+  }
+
+  const oldCallback = callback;
+  callback = () => {
+    try {
+      oldCallback.apply(window._globalProxy, args);
+    } catch (e) {
+      reportException(window, e, window.location.href);
+    }
+  };
+
   const res = startFn(callback, ms);
   window.__timers[timerId] = [res, stopFn];
   return timerId;

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -103,6 +103,7 @@ const runWebPlatformTest = require("./run-web-platform-test")(exports, path.reso
   "html/syntax/parsing/template/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-row-context.html",
   // "html/syntax/parsing/template/creating-an-element-for-the-token/template-owner-document.html", // template content owner document semantics not yet implemented
   "html/webappapis/atob/base64.html",
+  "html/webappapis/timers/evil-spec-example.html",
 
   "dom/events/Event-constants.html",
   "dom/events/Event-defaultPrevented.html",

--- a/test/web-platform-tests/run-to-upstream-web-platform-test.js
+++ b/test/web-platform-tests/run-to-upstream-web-platform-test.js
@@ -35,6 +35,8 @@ function createJsdom(urlPrefix, testPath, t) {
             t.ok(false, "Failed in \"" + test.name + "\": \n" + test.message + "\n\n" + test.stack);
           } else if (test.status === 2) {
             t.ok(false, "Timout in \"" + test.name + "\": \n" + test.message + "\n\n" + test.stack);
+          } else if (test.status === 3) {
+            t.ok(false, "Uncompleted test in \"" + test.name + "\": \n" + test.message + "\n\n" + test.stack);
           } else {
             t.ok(true, test.name);
           }

--- a/test/web-platform-tests/run-web-platform-test.js
+++ b/test/web-platform-tests/run-web-platform-test.js
@@ -37,6 +37,8 @@ function createJsdom(urlPrefix, testPath, t) {
             t.ok(false, "Failed in \"" + test.name + "\": \n" + test.message + "\n\n" + test.stack);
           } else if (test.status === 2) {
             t.ok(false, "Timout in \"" + test.name + "\": \n" + test.message + "\n\n" + test.stack);
+          } else if (test.status === 3) {
+            t.ok(false, "Uncompleted test in \"" + test.name + "\": \n" + test.message + "\n\n" + test.stack);
           } else {
             t.ok(true, test.name);
           }

--- a/test/web-platform-tests/to-upstream/html/webappapis/timers/arguments.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/timers/arguments.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<title>setTimeout/setInterval with additional arguments</title>
+<link rel="author" title="Sebstian Mayr" href="mailto:wpt@smayr.name">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+async_test(t => {
+  setTimeout((a, b, c) => {
+    assert_equals(a, 1);
+    assert_equals(b, 2);
+    assert_equals(c, 3);
+    t.done();
+  }, 100, 1, 2, 3);
+}, "setTimeout");
+
+async_test(t => {
+  setInterval((a, b, c) => {
+    assert_equals(a, 1);
+    assert_equals(b, 2);
+    assert_equals(c, 3);
+    t.done();
+  }, 100, 1, 2, 3);
+}, "setInterval");
+</script>

--- a/test/web-platform-tests/to-upstream/html/webappapis/timers/errors.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/timers/errors.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<title>setTimeout/setInterval with throwing code</title>
+<link rel="author" title="Sebstian Mayr" href="mailto:wpt@smayr.name">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+setup({ allow_uncaught_exception: true });
+
+promise_test(t => {
+  return new Promise(resolve => {
+    window.onerror = message => {
+      window.onerror = null;
+
+      assert_equals(message, "test1");
+
+      resolve();
+      return true;
+    };
+
+    setTimeout("throw new Error('test1')", 100);
+  });
+}, "setTimeout, string argument");
+
+promise_test(t => {
+  return new Promise(resolve => {
+    window.onerror = message => {
+      window.onerror = null;
+
+      assert_equals(message, "test2");
+
+      resolve();
+      return true;
+    };
+
+    setTimeout(() => { throw new Error('test2'); }, 100);
+  });
+}, "setTimeout, function argument");
+
+promise_test(t => {
+  return new Promise(resolve => {
+    window.onerror = message => {
+      window.onerror = null;
+      clearInterval(i);
+
+      assert_equals(message, "test3");
+
+      resolve();
+      return true;
+    };
+
+    const i = setInterval("throw new Error('test3')", 100);
+  });
+}, "setInterval, string argument");
+
+promise_test(t => {
+  return new Promise(resolve => {
+    window.onerror = message => {
+      window.onerror = null;
+      clearInterval(i);
+
+      assert_equals(message, "test4");
+
+      resolve();
+      return true;
+    };
+
+    const i = setInterval(() => { throw new Error('test4'); }, 100);
+  });
+}, "setInterval, function argument");
+</script>


### PR DESCRIPTION
Only read up on the spec a tiny bit (until I dive into the Window rework), but this should be a pretty nice fix for #1291, going mostly by rudimentary behaviour here.

Spec says
> Create a script using script source as the script source, the URL where script source can be found, and settings object as the environment settings object.

I'm not sure if the url there means that stack traces should spit out that url as the source, but added that with a nice trick. We'll never get the stacktrace as a whole correct I think, sadly.

@domenic You think this would suffice? 