### PR TITLE
removeEventListener doesn't work when useCapture is specified

### DIFF
--- a/lib/jsdom/living/events/Event-impl.js
+++ b/lib/jsdom/living/events/Event-impl.js
@@ -7,13 +7,7 @@ class EventImpl {
     const type = args[0]; // TODO: Replace with destructuring
     const eventInitDict = args[1] || EventInit.convert(undefined);
 
-    if (privateData.noInitialize) {
-      this.type = "";
-      this._initializedFlag = false;
-    } else {
-      this.type = type;
-      this._initializedFlag = true;
-    }
+    this.type = type;
 
     const wrapper = privateData.wrapper;
     for (const key in eventInitDict) {
@@ -26,6 +20,7 @@ class EventImpl {
     this.currentTarget = null;
     this.eventPhase = 0;
 
+    this._initializedFlag = true;
     this._stopPropagationFlag = false;
     this._stopImmediatePropagationFlag = false;
     this._canceledFlag = false;

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -26,6 +26,10 @@ class EventTargetImpl {
       return;
     }
 
+    if (capture === undefined) {
+      capture = false;
+    }
+
     if (!this._eventListeners[type]) {
       this._eventListeners[type] = [];
     }
@@ -55,6 +59,10 @@ class EventTargetImpl {
     if (callback === null) {
       // Optimization, not in the spec.
       return;
+    }
+
+    if (capture === undefined) {
+      capture = false;
     }
 
     if (!this._eventListeners[type]) {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -546,7 +546,9 @@ class DocumentImpl extends NodeImpl {
         "The provided event type (\"" + type + "\") is invalid");
     }
 
-    return eventWrapper.createImpl([""], { noInitialize: true });
+    const impl = eventWrapper.createImpl([""]);
+    impl._initializedFlag = false;
+    return impl;
   }
 
   createProcessingInstruction(target, data) {

--- a/test/web-platform-tests/to-upstream/dom/events/EventTarget-add-remove-listener.html
+++ b/test/web-platform-tests/to-upstream/dom/events/EventTarget-add-remove-listener.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>EventTarget.addEventListener</title>
+<link rel="author" title="Sebastian Mayr" href="mailto:wpt@smayr.name">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+function listener(evt) {
+  evt.preventDefault();
+  return false;
+}
+
+test(() => {
+  document.addEventListener("x", listener, false);
+  let event = new Event("x", { cancelable: true });
+  let ret = document.dispatchEvent(event);
+  assert_false(ret);
+
+  document.removeEventListener("x", listener);
+  event = new Event("x", { cancelable: true });
+  ret = document.dispatchEvent(event);
+  assert_true(ret);
+}, "Removing an event listener without explicit capture arg should succeed");
+</script>


### PR DESCRIPTION
```javascript
var jsdom = require("jsdom");

jsdom.env(
  "<p id='test'></p>",
  function (err, window) {
	var ticks = 0,
		listener = function() { ticks++ },
		elm = window.document.getElementById('test');
	
	// Attach 
    elm.addEventListener('test', listener, false);
    
    // Dispatch
	event = new window.CustomEvent('test');
    elm.dispatchEvent(event);
    
    console.log(ticks); // 1
    
    // Detach
    elm.removeEventListener('test', listener);
    
    // Dispatch
	event = new window.CustomEvent('test');
    elm.dispatchEvent(event);
    
    console.log(ticks); // 2 (should be 1)
  }
);
```

Bad behavior with those values:

```javascript
elm.addEventListener('test', listener, false);
elm.removeEventListener('test', listener);

elm.addEventListener('test', listener);
elm.removeEventListener('test', listener, false);

elm.addEventListener('test', listener, undefined);
elm.removeEventListener('test', listener, false);

elm.addEventListener('test', listener, false);
elm.removeEventListener('test', listener, undefined);
```

Correct behavior with those values:

```javascript
elm.addEventListener('test', listener);
elm.removeEventListener('test', listener);

elm.addEventListener('test', listener, true);
elm.removeEventListener('test', listener, true);

elm.addEventListener('test', listener, false);
elm.removeEventListener('test', listener, false);

elm.addEventListener('test', listener, null);
elm.removeEventListener('test', listener, null);

elm.addEventListener('test', listener, undefined);
elm.removeEventListener('test', listener, undefined);
```

jsdom 7.2.1
node 4.1.2