### PR TITLE
Implement and use adoptNode

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -657,9 +657,8 @@ class DocumentImpl extends NodeImpl {
     if (node.nodeType === NODE_TYPE.DOCUMENT_NODE) {
       throw new DOMException(DOMException.NOT_SUPPORTED_ERR, "Cannot adopt a document node");
     }
-    if (node.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
-      throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR, "Cannot adopt a shadow root node");
-    }
+    // TODO: Determine correct way to detect a shadow root
+    // See also https://github.com/w3c/webcomponents/issues/182
 
     if (node.parentNode) {
       node.parentNode.removeChild(node);

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -650,6 +650,28 @@ class DocumentImpl extends NodeImpl {
     return clone(this._core, node, this, deep);
   }
 
+  adoptNode(node) {
+    if (!("_ownerDocument" in node)) {
+      throw new TypeError("First argument to adoptNode must be a Node");
+    }
+    if (node.nodeType === NODE_TYPE.DOCUMENT_NODE) {
+      throw new DOMException(DOMException.NOT_SUPPORTED_ERR, "Cannot adopt a document node");
+    }
+    if (node.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT_NODE) {
+      throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR, "Cannot adopt a shadow root node");
+    }
+
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+    node._ownerDocument = this;
+    for (const descendant of domSymbolTree.treeIterator(node)) {
+      descendant._ownerDocument = this;
+    }
+
+    return node;
+  }
+
   get cookie() {
     return this._cookieJar.getCookieStringSync(this._URL, { http: false });
   }

--- a/lib/jsdom/living/nodes/Document.idl
+++ b/lib/jsdom/living/nodes/Document.idl
@@ -25,7 +25,7 @@ interface Document : Node {
   [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
 
   [NewObject] Node importNode(Node node, optional boolean deep = false);
-//  Node adoptNode(Node node);
+  Node adoptNode(Node node);
 
   [NewObject] Attr createAttribute(DOMString localName);
   [NewObject] Attr createAttributeNS(DOMString? namespace, DOMString qualifiedName);

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -213,6 +213,11 @@ class NodeImpl extends EventTargetImpl {
         oldParentImpl.removeChild(newChildImpl);
       }
 
+      // adopt the node if it's not in this document
+      if (this._ownerDocument !== newChildImpl._ownerDocument) {
+        this._ownerDocument.adoptNode(newChildImpl);
+      }
+
       if (refChildImpl === null) {
         domSymbolTree.appendChild(this, newChildImpl);
       } else {

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -181,19 +181,19 @@ class NodeImpl extends EventTargetImpl {
       newChildImpl._ownerDocument = this._ownerDocument;
     }
 
-    // TODO - if (!newChild) then?
-    if (this.nodeName !== "#document" && newChildImpl._ownerDocument !== this._ownerDocument) {
-      throw new DOMException(DOMException.WRONG_DOCUMENT_ERR);
-    }
-
     if (newChildImpl.nodeType && newChildImpl.nodeType === NODE_TYPE.ATTRIBUTE_NODE) {
       throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR);
     }
 
-    // search for parents matching the newChild
-    for (const ancestor of domSymbolTree.ancestorsIterator(this)) {
-      if (ancestor === newChildImpl) {
-        throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR);
+    if (this._ownerDocument !== newChildImpl._ownerDocument) {
+      // adopt the node when it's not in this document
+      this._ownerDocument.adoptNode(newChildImpl);
+    } else {
+      // search for parents matching the newChild
+      for (const ancestor of domSymbolTree.ancestorsIterator(this)) {
+        if (ancestor === newChildImpl) {
+          throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR);
+        }
       }
     }
 
@@ -211,11 +211,6 @@ class NodeImpl extends EventTargetImpl {
       // if the newChild is already in the tree elsewhere, remove it first
       if (oldParentImpl) {
         oldParentImpl.removeChild(newChildImpl);
-      }
-
-      // adopt the node if it's not in this document
-      if (this._ownerDocument !== newChildImpl._ownerDocument) {
-        this._ownerDocument.adoptNode(newChildImpl);
       }
 
       if (refChildImpl === null) {

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -7066,53 +7066,6 @@ exports.tests = {
   /**
    *
    The "appendChild(newChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to append
-   a node created from a different document.   An attempt
-   to make such a replacement should raise the desired
-   exception.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-184E7107
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-184E7107')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-184E7107
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=247
-   */
-  hc_nodeappendchildnewchilddiffdocument: function(test) {
-    var success;
-    var doc1;
-    var doc2;
-    var newChild;
-    var elementList;
-    var elementNode;
-    var appendedChild;
-    doc1 = hc_staff.hc_staff();
-    doc2 = hc_staff.hc_staff();
-    newChild = doc1.createElement("br");
-    elementList = doc2.getElementsByTagName("p");
-    elementNode = elementList.item(1);
-
-    {
-      success = false;
-      try {
-        appendedChild = elementNode.appendChild(newChild);
-      }
-      catch(ex) {
-        success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-      }
-      test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    }
-
-    test.done();
-  },
-
-  /**
-   *
-   The "appendChild(newChild)" method raises a
    HIERARCHY_REQUEST_ERR DOMException if the node to
    append is one of this node's ancestors.
 
@@ -8656,56 +8609,6 @@ exports.tests = {
 
   /**
    *
-   The "insertBefore(newChild,refChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to insert a new
-   child that was created from a different document than the
-   one that created the second employee.   An attempt to
-   insert such a child should raise the desired exception.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='WRONG_DOCUMENT_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-952280727
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-952280727')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='WRONG_DOCUMENT_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-952280727
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=247
-   */
-  hc_nodeinsertbeforenewchilddiffdocument: function(test) {
-    var success;
-    var doc1;
-    var doc2;
-    var refChild;
-    var newChild;
-    var elementList;
-    var elementNode;
-    var insertedNode;
-    doc1 = hc_staff.hc_staff();
-    doc2 = hc_staff.hc_staff();
-    newChild = doc1.createElement("br");
-    elementList = doc2.getElementsByTagName("p");
-    elementNode = elementList.item(1);
-    refChild = elementNode.firstChild;
-
-
-    {
-      success = false;
-      try {
-        insertedNode = elementNode.insertBefore(newChild,refChild);
-      }
-      catch(ex) {
-        success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-      }
-      test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    }
-
-    test.done();
-  },
-
-  /**
-   *
    If the "newChild" is already in the tree, the
    "insertBefore(newChild,refChild)" method must first
    remove it before the insertion takes place.
@@ -9605,56 +9508,6 @@ exports.tests = {
     childName = child.nodeName;
 
     test.equal(childName, "br", 'element nodeName');
-
-    test.done();
-  },
-
-  /**
-   *
-   The "replaceChild(newChild,oldChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to replace one
-   of its children with a node created from a different
-   document.   An attempt to make such a replacement
-   should raise the desired exception.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-785887307
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-785887307')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-785887307
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=247
-   */
-  hc_nodereplacechildnewchilddiffdocument: function(test) {
-    var success;
-    var doc1;
-    var doc2;
-    var oldChild;
-    var newChild;
-    var elementList;
-    var elementNode;
-    var replacedChild;
-    doc1 = hc_staff.hc_staff();
-    doc2 = hc_staff.hc_staff();
-    newChild = doc1.createElement("br");
-    elementList = doc2.getElementsByTagName("p");
-    elementNode = elementList.item(1);
-    oldChild = elementNode.firstChild;
-
-
-    {
-      success = false;
-      try {
-        replacedChild = elementNode.replaceChild(newChild,oldChild);
-      }
-      catch(ex) {
-        success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-      }
-      test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    }
 
     test.done();
   },
@@ -11175,54 +11028,6 @@ exports.tests = {
     childName = appendNode.nodeName;
 
     test.equal(childName, "newChild", 'nodeAppendChildGetNodeNameAssert1');
-
-    test.done();
-  },
-
-  /**
-   *
-   The "appendChild(newChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to append
-   a node created from a different document.   An attempt
-   to make such a replacement should raise the desired
-   exception.
-
-   * @author NIST
-   * @author Mary Brady
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-184E7107
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-184E7107')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-184E7107
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  nodeappendchildnewchilddiffdocument: function(test) {
-    var success;
-    var doc1;
-    var doc2;
-    var newChild;
-    var elementList;
-    var elementNode;
-    var appendedChild;
-    doc1 = staff.staff();
-    doc2 = staff.staff();
-    newChild = doc1.createElement("newChild");
-    elementList = doc2.getElementsByTagName("employee");
-    elementNode = elementList.item(1);
-
-    {
-      success = false;
-      try {
-        appendedChild = elementNode.appendChild(newChild);
-      }
-      catch(ex) {
-        success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-      }
-      test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    }
 
     test.done();
   },
@@ -13004,56 +12809,6 @@ exports.tests = {
 
   /**
    *
-   The "insertBefore(newChild,refChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to insert a new
-   child that was created from a different document than the
-   one that created the second employee.   An attempt to
-   insert such a child should raise the desired exception.
-
-   * @author NIST
-   * @author Mary Brady
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='WRONG_DOCUMENT_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-952280727
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-952280727')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='WRONG_DOCUMENT_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-952280727
-   */
-  nodeinsertbeforenewchilddiffdocument: function(test) {
-    var success;
-    var doc1;
-    var doc2;
-    var refChild;
-    var newChild;
-    var elementList;
-    var elementNode;
-    var insertedNode;
-    doc1 = staff.staff();
-    doc2 = staff.staff();
-    newChild = doc1.createElement("newChild");
-    elementList = doc2.getElementsByTagName("employee");
-    elementNode = elementList.item(1);
-    refChild = elementNode.firstChild;
-
-
-    {
-      success = false;
-      try {
-        insertedNode = elementNode.insertBefore(newChild,refChild);
-      }
-      catch(ex) {
-        success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-      }
-      test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    }
-
-    test.done();
-  },
-
-  /**
-   *
    If the "newChild" is already in the tree, the
    "insertBefore(newChild,refChild)" method must first
    remove it before the insertion takes place.
@@ -14114,57 +13869,6 @@ exports.tests = {
     childName = child.nodeName;
 
     test.equal(childName, "newChild", 'nodeReplaceChildAssert1');
-
-    test.done();
-  },
-
-
-  /**
-   *
-   The "replaceChild(newChild,oldChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to replace one
-   of its children with a node created from a different
-   document.   An attempt to make such a replacement
-   should raise the desired exception.
-
-   * @author NIST
-   * @author Mary Brady
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-785887307
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-785887307')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-785887307
-   */
-  nodereplacechildnewchilddiffdocument: function(test) {
-    var success;
-    var doc1;
-    var doc2;
-    var oldChild;
-    var newChild;
-    var elementList;
-    var elementNode;
-    var replacedChild;
-    doc1 = staff.staff();
-    doc2 = staff.staff();
-    newChild = doc1.createElement("newChild");
-    elementList = doc2.getElementsByTagName("employee");
-    elementNode = elementList.item(1);
-    oldChild = elementNode.firstChild;
-
-
-    {
-      success = false;
-      try {
-        replacedChild = elementNode.replaceChild(newChild,oldChild);
-      }
-      catch(ex) {
-        success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-      }
-      test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    }
 
     test.done();
   },

--- a/test/level1/html.js
+++ b/test/level1/html.js
@@ -3297,40 +3297,6 @@ exports.tests = {
   /**
    *
    The "appendChild(newChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to append
-   a node created from a different document.   An attempt
-   to make such a replacement should raise the desired
-   exception.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-184E7107
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-184E7107')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-184E7107
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=247
-   */
-  hc_nodeappendchildnewchilddiffdocument: function(test) {
-    doc1 = hc_staff.hc_staff();
-    doc2 = hc_staff.hc_staff();
-    var newChild = doc1.createElement("br");
-    var elementNode = doc2.getElementsByTagName("p").item(1);
-    var success = false;
-    try {
-      elementNode.appendChild(newChild);
-    } catch(ex) {
-      success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-    }
-    test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    test.done();
-  },
-
-  /**
-   *
-   The "appendChild(newChild)" method raises a
    HIERARCHY_REQUEST_ERR DOMException if the node to
    append is one of this node's ancestors.
 
@@ -4731,41 +4697,6 @@ exports.tests = {
 
   /**
    *
-   The "insertBefore(newChild,refChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to insert a new
-   child that was created from a different document than the
-   one that created the second employee.   An attempt to
-   insert such a child should raise the desired exception.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='WRONG_DOCUMENT_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-952280727
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-952280727')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='WRONG_DOCUMENT_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-952280727
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=247
-   */
-  hc_nodeinsertbeforenewchilddiffdocument: function(test) {
-    var doc1 = hc_staff.hc_staff();
-    var doc2 = hc_staff.hc_staff();
-    var newChild = doc1.createElement("br");
-    var elementNode = doc2.getElementsByTagName("p").item(1);
-    var refChild = elementNode.firstChild;
-    var success = false;
-    try {
-      elementNode.insertBefore(newChild,refChild);
-    } catch(ex) {
-      success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-    }
-    test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
-    test.done();
-  },
-
-  /**
-   *
    If the "newChild" is already in the tree, the
    "insertBefore(newChild,refChild)" method must first
    remove it before the insertion takes place.
@@ -5376,42 +5307,6 @@ exports.tests = {
     employeeNode.replaceChild(newChild,oldChild);
     var child = employeeNode.childNodes.item(0);
     test.equal(child.nodeName, 'BR', 'element nodeName');
-    test.done();
-  },
-
-  /**
-   *
-   The "replaceChild(newChild,oldChild)" method raises a
-   WRONG_DOCUMENT_ERR DOMException if the "newChild" was
-   created from a different document than the one that
-   created this node.
-
-   Retrieve the second employee and attempt to replace one
-   of its children with a node created from a different
-   document.   An attempt to make such a replacement
-   should raise the desired exception.
-
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-258A00AF')/constant[@name='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-785887307
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#xpointer(id('ID-785887307')/raises/exception[@name='DOMException']/descr/p[substring-before(.,':')='NOT_FOUND_ERR'])
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-785887307
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=247
-   */
-  hc_nodereplacechildnewchilddiffdocument: function(test) {
-    var doc1 = hc_staff.hc_staff();
-    var doc2 = hc_staff.hc_staff();
-    var newChild = doc1.createElement("br");
-    var elementNode = doc2.getElementsByTagName("p").item(1);
-    var oldChild = elementNode.firstChild;
-    var success = false;
-    try {
-      elementNode.replaceChild(newChild,oldChild);
-    }
-    catch(ex) {
-      success = (typeof(ex.code) != 'undefined' && ex.code == 4);
-    }
-    test.ok(success, 'throw_WRONG_DOCUMENT_ERR');
     test.done();
   },
 

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -8,6 +8,7 @@ const runWebPlatformTest = require("./run-web-platform-test")(exports, path.reso
   "dom/nodes/CharacterData-deleteData.html",
   "dom/nodes/CharacterData-insertData.html",
   "dom/nodes/CharacterData-replaceData.html",
+  "dom/nodes/Document-adoptNode.html",
   "dom/nodes/Document-contentType/contentType/createHTMLDocument.html",
   "dom/nodes/Document-createComment.html",
   "dom/nodes/Document-createProcessingInstruction.html",

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-mutation-adoptNode.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-mutation-adoptNode.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Node-manipulation-adopted</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument">
+<link rel=help href="https://dom.spec.whatwg.org/#mutation-algorithms">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(() => {
+  const old = document.implementation.createHTMLDocument("");
+  const div = old.createElement("div");
+  div.appendChild(old.createTextNode("text"));
+  assert_equals(div.ownerDocument, old);
+  assert_equals(div.firstChild.ownerDocument, old);
+  document.body.appendChild(div);
+  assert_equals(div.ownerDocument, document);
+  assert_equals(div.firstChild.ownerDocument, document);
+}, "simple append of foreign div with text");
+
+</script>


### PR DESCRIPTION
Still a WIP at this point. It's passing all tests including the basic adoptNode tests as added but there are no tests yet that use the auto adoption steps. I see some in level3/core.js but that file as a whole can't be run. What's the best way to add tests? Should I write fresh ones for to-upstream, or instead try to rescue the ones in core.js somehow?