### PR TITLE
Disable tests that now fail on Node 5.6.0

### DIFF
--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -196,14 +196,14 @@ const runWebPlatformTest = require("./run-web-platform-test")(exports, path.reso
   "XMLHttpRequest/event-upload-progress.htm",
   "XMLHttpRequest/formdata-blob.htm",
   "XMLHttpRequest/formdata.htm",
-  "XMLHttpRequest/getallresponseheaders-cookies.htm",
+  // "XMLHttpRequest/getallresponseheaders-cookies.htm", // https://github.com/nodejs/http-parser/issues/281
   "XMLHttpRequest/getallresponseheaders-status.htm",
-  "XMLHttpRequest/getresponseheader-case-insensitive.htm",
+  // "XMLHttpRequest/getresponseheader-case-insensitive.htm", // https://github.com/nodejs/http-parser/issues/281
   "XMLHttpRequest/getresponseheader-chunked-trailer.htm",
-  "XMLHttpRequest/getresponseheader-cookies-and-more.htm",
+  // "XMLHttpRequest/getresponseheader-cookies-and-more.htm", // https://github.com/nodejs/http-parser/issues/281
   "XMLHttpRequest/getresponseheader-error-state.htm",
-  "XMLHttpRequest/getresponseheader-server-date.htm",
-  "XMLHttpRequest/getresponseheader-special-characters.htm",
+  // "XMLHttpRequest/getresponseheader-server-date.htm", // https://github.com/nodejs/http-parser/issues/281
+  // "XMLHttpRequest/getresponseheader-special-characters.htm", // https://github.com/nodejs/http-parser/issues/281
   "XMLHttpRequest/getresponseheader-unsent-opened-state.htm",
   "XMLHttpRequest/open-after-abort.htm",
   "XMLHttpRequest/open-after-setrequestheader.htm",
@@ -235,7 +235,7 @@ const runWebPlatformTest = require("./run-web-platform-test")(exports, path.reso
   "XMLHttpRequest/response-invalid-responsetype.htm",
   "XMLHttpRequest/response-json.htm",
   "XMLHttpRequest/response-method.htm",
-  "XMLHttpRequest/responseText-status.html",
+  // "XMLHttpRequest/responseText-status.html", // https://github.com/nodejs/http-parser/issues/281
   "XMLHttpRequest/responsetype.html",
   "XMLHttpRequest/responsexml-non-document-types.htm",
   "XMLHttpRequest/send-accept-language.htm",

--- a/test/web-platform-tests/run-to-upstream-web-platform-test.js
+++ b/test/web-platform-tests/run-to-upstream-web-platform-test.js
@@ -43,8 +43,13 @@ function createJsdom(urlPrefix, testPath, t) {
         });
 
         window.add_completion_callback((tests, harnessStatus) => {
-          t.ok(harnessStatus.status !== 2, "test harness should not timeout");
-          window.close();
+          t.ok(harnessStatus.status !== 2, "test harness should not timeout: " + testPath);
+
+          // This needs to be delayed since some tests do things even after calling done().
+          process.nextTick(() => {
+            window.close();
+          });
+
           t.done();
         });
       };

--- a/test/web-platform-tests/run-web-platform-test.js
+++ b/test/web-platform-tests/run-web-platform-test.js
@@ -45,7 +45,7 @@ function createJsdom(urlPrefix, testPath, t) {
         });
 
         window.add_completion_callback((tests, harnessStatus) => {
-          t.ok(harnessStatus.status !== 2, "test harness should not timeout");
+          t.ok(harnessStatus.status !== 2, "test harness should not timeout: " + testPath);
 
           // This needs to be delayed since some tests do things even after calling done().
           process.nextTick(() => {


### PR DESCRIPTION
PRing this to see if Travis likes it:

This is due to a regression in Node's HTTP parser that makes it less capable than browsers: https://github.com/nodejs/http-parser/issues/281. Closes #1380. We probably won't be able to fix this until Node either fixes the regression or makes HTTP header parsing customizable.