### PR TITLE
Fix getter references

### DIFF
--- a/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLOptionElement-impl.js
@@ -97,14 +97,14 @@ class HTMLOptionElementImpl extends HTMLElementImpl {
     if (this.hasAttribute("label")) {
       return this.getAttribute("label");
     }
-    const select = this._selectNode();
+    const select = this._selectNode;
     if (select) {
       return select.getAttribute("label");
     }
   }
 
   set label(V) {
-    const select = this._selectNode();
+    const select = this._selectNode;
     if (select) {
       select.setAttribute("label", V);
     }


### PR DESCRIPTION
I ran into the error below when upgrading to jsdom `8.0.2`. From a quick look, it appears that the getter should be referenced without the parentheses as done so [here](https://github.com/tmpvar/jsdom/blob/6c47d47f8b486537e5df95101026f2980acc6875/lib/jsdom/living/nodes/HTMLOptionElement-impl.js#L20).

I did read that version 8 contains generated code, so if changing this file directly is the wrong way to go, let me know and I can do it a different way. Also, I noticed [the comment above the label getter](https://github.com/tmpvar/jsdom/blob/6c47d47f8b486537e5df95101026f2980acc6875/lib/jsdom/living/nodes/HTMLOptionElement-impl.js#L95) mentions that there is something wrong with the lines below, so maybe this is already a known issue.

```bash
TypeError: this._selectNode is not a function
      at HTMLOptionElementImpl.label (node_modules/jsdom/lib/jsdom/living/nodes/HTMLOptionElement-impl.js:100:25)
      at HTMLOptionElement.get [as label] (node_modules/jsdom/lib/jsdom/living/generated/HTMLOptionElement.js:47:46)
      at updateOptionElement (bower_components/angular/angular.js:26566:37)
      at updateOption (bower_components/angular/angular.js:26686:13)

# ...

```