### PR TITLE
Fix #1382: this inside event listener object handleEvent was wrong

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -16,9 +16,7 @@ class EventTargetImpl {
     // webidl2js currently can't handle neither optional arguments nor callback interfaces
     if (callback === undefined || callback === null) {
       callback = null;
-    } else if (typeof callback === "object") {
-      callback = callback.handleEvent;
-    } else if (typeof callback !== "function") {
+    } else if (typeof callback !== "object" && typeof callback !== "function") {
       throw new TypeError("Only undefined, null, an object, or a function are allowed for the callback parameter");
     }
 
@@ -50,9 +48,7 @@ class EventTargetImpl {
   removeEventListener(type, callback, capture) {
     if (callback === undefined || callback === null) {
       callback = null;
-    } else if (typeof callback === "object") {
-      callback = callback.handleEvent;
-    } else if (typeof callback !== "function") {
+    } else if (typeof callback !== "object" && typeof callback !== "function") {
       throw new TypeError("Only undefined, null, an object, or a function are allowed for the callback parameter");
     }
 
@@ -205,7 +201,13 @@ function invokeEventListeners(listeners, target, eventImpl) {
     }
 
     try {
-      listener.callback.call(idlUtils.wrapperForImpl(eventImpl.currentTarget), idlUtils.wrapperForImpl(eventImpl));
+      if (typeof listener.callback === "object") {
+        if (typeof listener.callback.handleEvent === "function") {
+          listener.callback.handleEvent(idlUtils.wrapperForImpl(eventImpl));
+        }
+      } else {
+        listener.callback.call(idlUtils.wrapperForImpl(eventImpl.currentTarget), idlUtils.wrapperForImpl(eventImpl));
+      }
     } catch (e) {
       let window = null;
       if (wrapper && wrapper._document) {

--- a/test/web-platform-tests/to-upstream/dom/events/EventTarget-this-of-listener.html
+++ b/test/web-platform-tests/to-upstream/dom/events/EventTarget-this-of-listener.html
@@ -33,4 +33,150 @@ test(() => {
 
 }, "the this value inside the event listener callback should be the node");
 
+test(() => {
+
+  const nodes = [
+    document.createElement("p"),
+    document.createTextNode("some text"),
+    document.createDocumentFragment(),
+    document.createComment("a comment"),
+    document.createProcessingInstruction("target", "data")
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    const handler = {
+      handleEvent() {
+        ++callCount;
+        assert_equals(this, handler);
+      }
+    };
+
+    node.addEventListener("someevent", handler);
+
+    node.dispatchEvent(new CustomEvent("someevent"));
+  }
+
+  assert_equals(callCount, nodes.length);
+
+}, "the this value inside the event listener object handleEvent should be the object");
+
+test(() => {
+
+  const nodes = [
+    document.createElement("p"),
+    document.createTextNode("some text"),
+    document.createDocumentFragment(),
+    document.createComment("a comment"),
+    document.createProcessingInstruction("target", "data")
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    const handler = {
+      handleEvent() {
+        assert_unreached("should not call the old handleEvent method");
+      }
+    };
+
+    node.addEventListener("someevent", handler);
+    handler.handleEvent = function () {
+      ++callCount;
+      assert_equals(this, handler);
+    };
+
+    node.dispatchEvent(new CustomEvent("someevent"));
+  }
+
+  assert_equals(callCount, nodes.length);
+
+}, "dispatchEvent should invoke the current handleEvent method of the object");
+
+test(() => {
+
+  const nodes = [
+    document.createElement("p"),
+    document.createTextNode("some text"),
+    document.createDocumentFragment(),
+    document.createComment("a comment"),
+    document.createProcessingInstruction("target", "data")
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    const handler = {};
+
+    node.addEventListener("someevent", handler);
+    handler.handleEvent = function () {
+      ++callCount;
+      assert_equals(this, handler);
+    };
+
+    node.dispatchEvent(new CustomEvent("someevent"));
+  }
+
+  assert_equals(callCount, nodes.length);
+
+}, "addEventListener should not require handleEvent to be defined on object listeners");
+
+test(() => {
+
+  const nodes = [
+    document.createElement("p"),
+    document.createTextNode("some text"),
+    document.createDocumentFragment(),
+    document.createComment("a comment"),
+    document.createProcessingInstruction("target", "data")
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    function handler() {
+      ++callCount;
+      assert_equals(this, node);
+    }
+
+    handler.handleEvent = () => {
+      assert_unreached("should not call the handleEvent method on a function");
+    };
+
+    node.addEventListener("someevent", handler);
+
+    node.dispatchEvent(new CustomEvent("someevent"));
+  }
+
+  assert_equals(callCount, nodes.length);
+
+}, "handleEvent properties added to a function before addEventListener are not reached");
+
+test(() => {
+
+  const nodes = [
+    document.createElement("p"),
+    document.createTextNode("some text"),
+    document.createDocumentFragment(),
+    document.createComment("a comment"),
+    document.createProcessingInstruction("target", "data")
+  ];
+
+  let callCount = 0;
+  for (const node of nodes) {
+    function handler() {
+      ++callCount;
+      assert_equals(this, node);
+    }
+
+    node.addEventListener("someevent", handler);
+
+    handler.handleEvent = () => {
+      assert_unreached("should not call the handleEvent method on a function");
+    };
+
+    node.dispatchEvent(new CustomEvent("someevent"));
+  }
+
+  assert_equals(callCount, nodes.length);
+
+}, "handleEvent properties added to a function after addEventListener are not reached");
+
 </script>


### PR DESCRIPTION
Leave `callback` a reference to the object, and only check for `handleEvent` method at invoke time.