### PR TITLE
Add Attr.nodeName

### DIFF
--- a/lib/jsdom/living/attributes/Attr-impl.js
+++ b/lib/jsdom/living/attributes/Attr-impl.js
@@ -27,9 +27,15 @@ exports.implementation = class AttrImpl {
     return exports.getAttrImplQualifiedName(this);
   }
 
+  // Delegate to name
+  get nodeName() {
+    return this.name;
+  }
+
   get value() {
     return this._value;
   }
+
   set value(v) {
     if (this._element === null) {
       this._value = v;


### PR DESCRIPTION
Similar to `Attr.nodeValue`, it's a passthrough to `name`.

Test added on the web platform side: https://github.com/w3c/web-platform-tests/pull/2590