### PR TITLE
Add click proxy behavior for label elements

### DIFF
--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -1,9 +1,69 @@
 "use strict";
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+const MouseEvent = require("../generated/MouseEvent");
 const closest = require("../helpers/traversal").closest;
+const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
+
+function isLabelable(node) {
+  /* labelable logic defined at: https://html.spec.whatwg.org/multipage/forms.html#category-label */
+  if (node.nodeType !== 1) { return false; }
+
+  switch (node.tagName) {
+  case "BUTTON":
+  case "KEYGEN":
+  case "METER":
+  case "OUTPUT":
+  case "PROGRESS":
+  case "SELECT":
+  case "TEXTAREA":
+    return true;
+
+  case "INPUT":
+    return node.type !== "hidden" ? true : false;
+  }
+
+  return false;
+}
+
+function sendClickToAssociatedNode(node) {
+  node.dispatchEvent(
+    MouseEvent.createImpl(["click", {
+      bubbles: true,
+      cancelable: true,
+      view: node.ownerDocument ? node.ownerDocument.defaultView : null,
+      screenX: 0,
+      screenY: 0,
+      clientX: 0,
+      clientY: 0,
+      button: 0,
+      detail: 1,
+      relatedTarget: null
+    }])
+  );
+}
 
 class HTMLLabelElementImpl extends HTMLElementImpl {
+  constructor(args, privateData) {
+    super(args, privateData);
+
+    this._eventDefaults.click = () => {
+      if (this.hasAttribute("for")) {
+        const node = this.ownerDocument.getElementById(this.getAttribute("for"));
+        if (node && isLabelable(node)) {
+          sendClickToAssociatedNode(node);
+        }
+      } else {
+        for (const descendant of domSymbolTree.treeIterator(this)) {
+          if (isLabelable(descendant)) {
+            sendClickToAssociatedNode(descendant);
+            break;
+          }
+        }
+      }
+    };
+  }
+
   get form() {
     return closest(this, "form");
   }

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/proxy-click-to-associated-element.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/proxy-click-to-associated-element.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<title>label element click proxying via "for" attribute or nested labelable element</title>
+<link rel="author" title="yaycmyk" href="mailto:evan@yaycmyk.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#the-label-element:the-label-element-10">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<form id="test">
+    <input id="foo" type="checkbox" />
+    <label id="foo-label" for="foo">foo</label>
+
+    <label id="bar-label">
+        <input id="bar" type="checkbox" /> bar
+        <input id="baz" type="checkbox" /> baz
+    </label>
+</form>
+<script>
+  "use strict";
+
+  async_test(t => {
+    const label = document.getElementById('foo-label');
+    const input = document.getElementById('foo');
+
+    input.addEventListener("click", () => {
+      t.step(() => {
+        assert_true(true);
+        t.done();
+      });
+    });
+
+    label.click();
+
+  }, "label with for attribute should proxy click events to the associated element");
+
+  async_test(t => {
+    const label = document.getElementById('bar-label');
+    const input = document.getElementById('bar');
+
+    input.addEventListener("click", () => {
+      t.step(() => {
+        assert_true(true);
+        t.done();
+      });
+    });
+
+    label.click();
+
+  }, "label without for attribute should proxy click events to the first labelable child");
+
+</script>


### PR DESCRIPTION
Clicking on a label element should trigger activation on an associated element via the `for` attribute linking, or simple nesting (if the associated element meets the [labeling criteria](https://html.spec.whatwg.org/multipage/forms.html#the-label-element:the-label-element-10)).

I would also like to note that I tried very hard to get the `NodeIterator` API to work, but it doesn't seem to be hooked up, unfortunately.