### PR TITLE
Implement frameElement for Window.

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -54,6 +54,7 @@ function Window(options) {
   // Set up the window as if it's a top level window.
   // If it's not, then references will be corrected by frame/iframe code.
   this._parent = this._top = this._globalProxy;
+  this._frameElement = null;
 
   // List options explicitly to be clear which are passed through
   this._document = Document.create([], {
@@ -108,6 +109,9 @@ function Window(options) {
     },
     get window() {
       return window._globalProxy;
+    },
+    get frameElement() {
+      return window._frameElement;
     },
     get frames() {
       return window._globalProxy;

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -49,6 +49,7 @@ function loadFrame(frame) {
   const contentWindow = contentDoc.defaultView;
   contentWindow._parent = parent;
   contentWindow._top = parent.top;
+  contentWindow._frameElement = frame;
   contentWindow._virtualConsole = parent._virtualConsole;
 
   // Handle about:blank with a simulated load of an empty document.


### PR DESCRIPTION
`frameElement` is currently `undefined ` for all `Window`s. This will set it to `null` for the top-level window, and as the `HTMLFrameElement` for attached frames.