### PR TITLE
Correct the logic as to uppercase if NOT xhtml AND html.

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -239,7 +239,7 @@ class ElementImpl extends NodeImpl {
   }
   get tagName() {
     let qualifiedName = this._prefix !== null ? this._prefix + ":" + this._localName : this._localName;
-    if (this.namespaceURI === "http://www.w3.org/1999/xhtml" && this._ownerDocument._parsingMode === "html") {
+    if (this.namespaceURI !== "http://www.w3.org/1999/xhtml" && this._ownerDocument._parsingMode === "html") {
       qualifiedName = qualifiedName.toUpperCase();
     }
     return qualifiedName;


### PR DESCRIPTION
Note that currently this breaks many, many tests.

From MDN:

In XML (and XML-based languages such as XHTML), tagName preserves case.
On HTML elements in DOM trees flagged as HTML documents, tagName returns
the element name in the uppercase form. The value of tagName is the same
as that of nodeName.