### PR TITLE
Fix undefined location access in Window.startTimer

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -421,11 +421,13 @@ function matchesDontThrow(el, selector) {
 }
 
 function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
-  const sourceURL = window.location.href;
+  if (!window.document) {
+    return;
+  }
 
   if (typeof callback !== "function") {
     const code = String(callback);
-    callback = window._globalProxy.eval.bind(window, code + `\n//# sourceURL=${sourceURL}`);
+    callback = window._globalProxy.eval.bind(window, code + `\n//# sourceURL=${window.location.href}`);
   }
 
   const oldCallback = callback;
@@ -433,7 +435,7 @@ function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
     try {
       oldCallback.apply(window._globalProxy, args);
     } catch (e) {
-      reportException(window, e, sourceURL);
+      reportException(window, e, window.location.href);
     }
   };
 

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -421,9 +421,11 @@ function matchesDontThrow(el, selector) {
 }
 
 function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
+  const sourceURL = window.location.href;
+
   if (typeof callback !== "function") {
     const code = String(callback);
-    callback = window._globalProxy.eval.bind(window, code + `\n//# sourceURL=${window.location.href}`);
+    callback = window._globalProxy.eval.bind(window, code + `\n//# sourceURL=${sourceURL}`);
   }
 
   const oldCallback = callback;
@@ -431,7 +433,7 @@ function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
     try {
       oldCallback.apply(window._globalProxy, args);
     } catch (e) {
-      reportException(window, e, window.location.href);
+      reportException(window, e, sourceURL);
     }
   };
 


### PR DESCRIPTION
I have encountered some instances where if an error occurs on a timer callback after the window has been closed (from the `done` callback of `jsdom.env`), accessing the `href` property of `window.location` throws an error because location is undefined.

The thing is that stopAllTimers is called, but this callback is still being called. You can test this with `http://www.github.com`