### PR TITLE
Clarify that document.origin is now set/evaluated based on config.url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ jsdom.env(config);
 
 - `config.html`: a HTML fragment
 - `config.file`: a file which jsdom will load HTML from; the resulting window's `location.href` will be a `file://` URL.
-- `config.url`: sets the resulting window's `location.href`; if `config.html` and `config.file` are not provided, jsdom will load HTML from this URL.
+- `config.url`: sets the resulting window's `location.href` and, as of version >=8.2.0, `document.origin` (used for cross-origin request rules); if `config.html` and `config.file` are not provided, jsdom will load HTML from this URL.
 - `config.scripts`: see `scripts` above.
 - `config.src`: an array of JavaScript strings that will be evaluated against the resulting document. Similar to `scripts`, but it accepts JavaScript instead of paths/URLs.
 - `config.cookieJar`: cookie jar which will be used by document and related resource requests. Can be created by `jsdom.createCookieJar()` method. Useful to share cookie state among different documents as browsers does.


### PR DESCRIPTION
This bit me in a package upgrade, hence making a quick note in case others encounter the same issue :)