### PR TITLE
[Fix #1442] Explicitly enumerate direct node attributes

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -239,7 +239,7 @@ function setChild(core, parentImpl, node) {
   newNode[locationInfo] = node.__location;
 
   if (node.attribs) {
-    for (let localName in node.attribs) {
+    Object.keys(node.attribs).forEach(localName => {
       const value = node.attribs[localName];
       let prefix =
         node["x-attribsPrefix"] &&
@@ -255,7 +255,7 @@ function setChild(core, parentImpl, node) {
         prefix = null;
       }
       attributes.setAttributeValue(newNode, localName, value, prefix, namespace);
-    }
+    });
   }
 
   if (node.children) {

--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -241,8 +241,14 @@ function setChild(core, parentImpl, node) {
   if (node.attribs) {
     for (let localName in node.attribs) {
       const value = node.attribs[localName];
-      let prefix = node["x-attribsPrefix"] && node["x-attribsPrefix"][localName] || null;
-      const namespace = node["x-attribsNamespace"] && node["x-attribsNamespace"][localName] || null;
+      let prefix =
+        node["x-attribsPrefix"] &&
+        node["x-attribsPrefix"].hasOwnProperty(localName) &&
+        node["x-attribsPrefix"][localName] || null;
+      const namespace =
+        node["x-attribsNamespace"] &&
+        node["x-attribsNamespace"].hasOwnProperty(localName) &&
+        node["x-attribsNamespace"][localName] || null;
       if (prefix === "xmlns" && localName === "") {
          // intended weirdness in node-sax, see https://github.com/isaacs/sax-js/issues/165
         localName = prefix;

--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -243,11 +243,11 @@ function setChild(core, parentImpl, node) {
       const value = node.attribs[localName];
       let prefix =
         node["x-attribsPrefix"] &&
-        node["x-attribsPrefix"].hasOwnProperty(localName) &&
+        Object.prototype.hasOwnProperty.call(node["x-attribsPrefix"], localName) &&
         node["x-attribsPrefix"][localName] || null;
       const namespace =
         node["x-attribsNamespace"] &&
-        node["x-attribsNamespace"].hasOwnProperty(localName) &&
+        Object.prototype.hasOwnProperty.call(node["x-attribsNamespace"], localName) &&
         node["x-attribsNamespace"][localName] || null;
       if (prefix === "xmlns" && localName === "") {
          // intended weirdness in node-sax, see https://github.com/isaacs/sax-js/issues/165

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -100,6 +100,20 @@ describe("jsdom/parsing", () => {
     assert.equal(els[0].outerHTML, "<element constructor=\"Hello\"></element>");
   });
 
+  specify("attribute inherited from Object (GH-1442)", () => {
+    Object.prototype.attribute = "value";
+
+    const document = jsdom.jsdom("<element></element>");
+
+    delete Object.prototype.attribute;
+    const els = document.getElementsByTagName("element");
+
+    assert.equal(els.length, 1);
+    assert.equal(els[0].getAttribute("attribute"), undefined);
+    assert.equal(els[0].attributes.length, 0);
+    assert.equal(els[0].outerHTML, "<element></element>");
+  });
+
   specify("CDATA should parse as bogus comments (GH-618)", () => {
     const document = jsdom.jsdom("<html><head></head><body><div><![CDATA[test]]></div></body></html>");
 

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -114,6 +114,19 @@ describe("jsdom/parsing", () => {
     assert.equal(els[0].outerHTML, "<element></element>");
   });
 
+  specify("prefix on attribute named 'hasOwnProperty' (GH-1444)", () => {
+    const options = { parsingMode: "xml" };
+    const document = jsdom.jsdom("<element prefix:hasOwnProperty='value'></element>", options);
+
+    const els = document.getElementsByTagName("element");
+
+    assert.equal(els.length, 1);
+    assert.equal(els[0].attributes.length, 1);
+    assert.equal(els[0].attributes[0].prefix, "prefix");
+    assert.equal(els[0].getAttribute("prefix:hasOwnProperty"), "value");
+    assert.equal(els[0].outerHTML, "<element prefix:hasOwnProperty=\"value\"></element>");
+  });
+
   specify("CDATA should parse as bogus comments (GH-618)", () => {
     const document = jsdom.jsdom("<html><head></head><body><div><![CDATA[test]]></div></body></html>");
 


### PR DESCRIPTION
The issue in #1442 is caused by directly accessing properties and using the `in` operator on an object that is meant to be a dictionary or map. These operations traverse the object's prototype chain which makes them unsuitable for enumerating the members of a collection.

 1. The attribute name shows up as `value:name`, because `node["x-attribsPrefix"]["name"]` will always equal `"value"` when `Object.prototype.name = "value";` has been set. The fix is a more explicit check of the object's _direct properties_ using [`Object.prototype.hasOwnProperty()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty).
 2. The attribute is added to the node's attribute map, because `for (let localName in node.attribs) {` will always iterate over `"name"` even when `node.attribs` is an "empty" object. The fix is a more explicit enumeration of the object's _direct properties_ using [`Object.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys).

 > Note: This pitfall is a byproduct of JavaScript mixing the concepts of objects and dictionaries. Python separates these concepts into the `Object` class and the `dict` type, and provides dynamic access to object properties using the `{get,set,has,del}attr()` built-in functions.