### PR TITLE
Commented out sandbox attribute for iFrame element

### DIFF
--- a/lib/jsdom/living/nodes/HTMLIFrameElement.idl
+++ b/lib/jsdom/living/nodes/HTMLIFrameElement.idl
@@ -2,7 +2,7 @@ interface HTMLIFrameElement : HTMLElement {
   attribute DOMString src;
   [Reflect] attribute DOMString srcdoc;
   [Reflect] attribute DOMString name;
-  [PutForwards=value] readonly attribute DOMSettableTokenList sandbox;
+  // [PutForwards=value] readonly attribute DOMSettableTokenList sandbox;
   attribute boolean seamless;
   [Reflect] attribute boolean allowFullscreen;
   [Reflect] attribute DOMString width;


### PR DESCRIPTION
Currently code such as this in your tests will fail when JSDom iFrame sandbox setter attempts to access this.sandbox.value.

```javascript
var sandboxParams = ['allow-top-navigation', 'allow-script'];
var iframe = document.createElement('iframe');
iframe.sandbox = sandboxParams.join(' ');
```