### PR TITLE
Fix setting proxied inline event handlers without a browsing context

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -132,13 +132,16 @@ class ElementImpl extends NodeImpl {
       attachId(value, this, doc);
     }
 
+    const w = this._ownerDocument._global;
+
     // TODO event handlers:
     // The correct way to do this is lazy, and a bit more complicated; see
     // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes
     // It would only be possible if we had proper getters/setters for every event handler, which we don't right now.
     if (name.length > 2 && name[0] === "o" && name[1] === "n") {
-      if (value) {
-        const w = this._ownerDocument._global;
+      // If this document does not have a window, set IDL attribute to null
+      // step 2: https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler
+      if (value && w) {
         const self = proxiedWindowEventHandlers.has(name) && this._localName === "body" ? w : this;
         const vmOptions = { filename: this._ownerDocument.URL, displayErrors: false };
 

--- a/test/living-html/inline-event-handlers.js
+++ b/test/living-html/inline-event-handlers.js
@@ -299,3 +299,15 @@ exports["proxied body/window event handlers: setting on body as attributes refle
 
   t.done();
 };
+
+exports["proxied body/window event handlers: setting on body as attributes should not throw without a window"] = t => {
+  const doc = jsdom().implementation.createHTMLDocument();
+
+  for (const name of proxied) {
+    doc.body.setAttribute(name, "return 5;");
+    t.equal(doc.body[name], null, `${name} should be be null`);
+    doc.body.removeAttribute(name);
+  }
+
+  t.done();
+};


### PR DESCRIPTION
See issue #1460 

There are more issues with our handling of proxied inline event handlers. However there might be some gaps in the HTML LS spec, I'll have to do some more experimentation to be sure. At the very least, I've discovered some disagreement between the major browsers, so that might be worth submitting a WPT for.

So for now just a fix for the exception.