### PR TITLE
Take away JSON.stringify calls from the cycles in xpath.js

### DIFF
--- a/lib/jsdom/level3/xpath.js
+++ b/lib/jsdom/level3/xpath.js
@@ -600,9 +600,10 @@ module.exports = core => {
     finalize: function() {
       if (null == this.nextPos) return this;
       console.assert(0 === this.nextPos.length);
+      var lastsJSON = JSON.stringify(this.lasts);
       for (var i = 0; i < this.lasts.length; ++i) {
         for (var j = 0; j < this.lasts[i].length; ++j) {
-          console.assert(null != this.lasts[i][j], i + ',' + j + ':' + JSON.stringify(this.lasts));
+          console.assert(null != this.lasts[i][j], i + ',' + j + ':' + lastsJSON);
         }
       }
       this.pushSeries = this.popSeries = this.addNode = function() {


### PR DESCRIPTION
`JSON.stringify` calls in two nested cycles are very resource-intensive.
However, the returned value of these calls is the same during cycles.
It seems they could be taken away from cycles safely.

fixes #1473