### PR TITLE
Dispatch focus and blur event when the methods are called on HTMLElement

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -336,6 +336,14 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     }
   }
 
+  focus() {
+    super.focus();
+
+    if (!this.getAttribute("disabled")) {
+      this.dispatchEvent(Event.createImpl(["focus"]));
+    }
+  }
+
   set maxLength(value) {
     if (value < 0) {
       throw new DOMException(DOMException.INDEX_SIZE_ERR);

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "st": "^0.5.5",
     "watchify": "^3.7.0",
     "wd": "0.3.12",
-    "webidl2js": "^4.3.0"
+    "webidl2js": "^4.3.3"
   },
   "browser": {
     "canvas": false,

--- a/test/living-html/htmlinputelement.js
+++ b/test/living-html/htmlinputelement.js
@@ -148,3 +148,32 @@ exports["an input's parsed type attribute should be reflected in both its proper
 
   t.done();
 };
+
+exports["should fire focus event when focus method is called"] = t => {
+  t.expect(2);
+  jsdom.env("<input>", (err, window) => {
+    t.ifError(err);
+    const doc = window.document;
+
+    const input = doc.querySelector("input");
+    input.addEventListener("focus", e => {
+      t.ok(e instanceof window.Event, "Fired event has to be an instance of Event");
+      t.done();
+    });
+    input.focus();
+  });
+};
+
+exports["should not fire focus event when focus method is called on a disabled input"] = t => {
+  t.expect(1);
+  jsdom.env("<input>", (err, window) => {
+    t.ifError(err);
+    const doc = window.document;
+
+    const input = doc.querySelector("input");
+    input.setAttribute("disabled", true);
+    input.addEventListener("focus", () => t.ok(false, "Should not trigger focus event on disabled input"));
+    input.focus();
+    t.done();
+  });
+};


### PR DESCRIPTION
Also, make sure the right version of webidl2js is installed.

This makes it so that:

```js
const input = document.createElement('input');
input.addEventListener('focus', () => console.log('Dispatching focus'));
input.focus();
```

Outputs `Dispatching focus`.