### PR TITLE
Remove document event listeners before setting readyState to complete

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -252,7 +252,7 @@ function Window(options) {
       if (this._document.close) {
         // It's especially important to clear out the listeners here because document.close() causes a "load" event to
         // fire.
-        this._document._listeners = Object.create(null);
+        idlUtils.implForWrapper(this._document)._eventListeners = Object.create(null);
         this._document.close();
       }
       const doc = idlUtils.implForWrapper(this._document);

--- a/test/window/script.js
+++ b/test/window/script.js
@@ -105,6 +105,19 @@ exports.tests = {
     test.strictEqual(window.DONE, 1);
     test.done();
   },
+  
+  script_should_ignore_DOMContentLoaded_after_window_close: function(test){
+    var window = jsdom.jsdom('<html><head>\
+      <script>\
+        var a = 0;\
+        function handle(){ a++; };\
+        document.addEventListener("DOMContentLoaded", handle, false);\
+      </script>\
+      </head><body></body></html>').defaultView;
+    window.close();
+    test.strictEqual(window.a, 1);
+    test.done();
+  },
 
   script_execution_in_body : function(test) {
     var window, caught = false;


### PR DESCRIPTION
Hi.

Test scenario: 
1) load page with \<script\>document.addEventListener("DOMContentLoaded", function() {})\</script\>
2) close window.

Problem: On window close, document implementation fires DOMContentLoaded event, which in turn executes function added within addEventListener.

Proposed solution: clear document eventListeners before setting it to readyState.

Tests added to test/window/script.js. If pull request is accepted and there is a requirement to write tests in Mocha please tell me in which file it should be rewritten.

Best regards,
Wojciech Nowak