### PR TITLE
Added ability to update window.location via _URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,14 @@ jsdom.reconfigureWindow(window, { top: myFakeTopForTesting });
 
 In the future we may expand `reconfigureWindow` to allow overriding other `[Unforgeable]` properties. Let us know if you need this capability.
 
+#### Changing the URL of an existing jsdom window instance
+
+At present jsdom does not handle navigation (such as setting ```window.location.href === 'http://my/new/url'```) and the subsequent events. However if you need to change the URL of an existing window instance use the ```jsdom.changeURL``` method.
+
+```js
+jsdom.changeURL(window, "http://localhost/my/new/url");
+```
+
 ## What Standards Does jsdom Support, Exactly?
 
 Our mission is to get something very close to a headless browser, with emphasis more on the DOM/HTML side of things than the CSS side. As such, our primary goals are supporting [The DOM Standard](http://dom.spec.whatwg.org/) and [The HTML Standard](http://www.whatwg.org/specs/web-apps/current-work/multipage/). We only support some subset of these so far; in particular we have the subset covered by the outdated DOM 2 spec family down pretty well. We're slowly including more and more from the modern DOM and HTML specs, including some `Node` APIs, `querySelector(All)`, attribute semantics, the history and URL APIs, and the HTML parsing algorithm.

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -20,6 +20,8 @@ const locationInfo = require("./jsdom/living/helpers/internal-constants").locati
 const idlUtils = require("./jsdom/living/generated/utils");
 const blobSymbols = require("./jsdom/living/blob-symbols");
 
+const whatwgURL = require("whatwg-url");
+
 require("./jsdom/living"); // Enable living standard features
 
 /* eslint-disable no-restricted-modules */
@@ -49,6 +51,19 @@ exports.nodeLocation = function (node) {
 exports.reconfigureWindow = function (window, newProps) {
   if ("top" in newProps) {
     window._top = newProps.top;
+  }
+};
+
+exports.changeURL = function (window, urlString) {
+  const pattern = /^((https?|file):\/\/)([\da-z\.-]+)(\.?([a-z\.]{2,6})([\/\w \.-]*)*)?(:[0-9]*)?\/?$/;
+
+  if (typeof urlString === "string" && pattern.test(urlString)) {
+    const doc = idlUtils.implForWrapper(window._document);
+
+    doc._URL = whatwgURL.parseURL(urlString);
+    doc._origin = whatwgURL.serializeURLToUnicodeOrigin(doc._URL);
+  } else {
+    throw new Error(urlString + " is not a valid URL. URL is still " + window._document.URL + ".");
   }
 };
 

--- a/test/jsdom/misc.js
+++ b/test/jsdom/misc.js
@@ -320,6 +320,39 @@ describe("jsdom/miscellaneous", () => {
     testBase();
   });
 
+  specify("change URL", () => {
+    const window = jsdom.jsdom("", { url: "http://example.com/" }).defaultView;
+    assert.strictEqual(window.document.URL, "http://example.com/");
+
+    function testPass(urlString) {
+      const suffix = urlString.slice(-1) === "/" ? "" : "/";
+
+      jsdom.changeURL(window, urlString);
+      assert.strictEqual(window.document.URL, urlString + suffix);
+    }
+
+    function testFail(urlString, expected) {
+      assert.throws(() => {
+        jsdom.changeURL(window, urlString);
+      });
+      assert.strictEqual(window.document.URL, expected);
+    }
+
+    testPass("http://localhost");
+    testPass("http://www.localhost");
+    testPass("http://www.localhost.com");
+    testPass("https://localhost/");
+    testPass("file://path/to/my/location/");
+    testPass("http://localhost.subdomain.subdomain/");
+    testPass("http://localhost:3000/");
+    testPass("http://localhost/");
+
+    // "Expected" based on current window,document.URL, so last successful changeURL()
+    testFail("fail", "http://localhost/");
+    testFail("/fail", "http://localhost/");
+    testFail("fail.com", "http://localhost/");
+  });
+
   specify("numeric_values", () => {
     const html = `<html><body><td data-year="2011" data-month="0" data-day="9">
                   <a href="#" class=" ">9</a>


### PR DESCRIPTION
changeURL fix for #1388 

This works, however you may be unhappy with reproducing the setup from document-impl to window.js > update method. Happy to rework this, but I couldn't see an easy way to DRY the set logic in the document-impl constructor so it could be reused. Glad for any pointers.

The history API is broken. Based on your comment:

> And jsdom is trying to behave like a browser. (Although it doesn't do the navigation part yet.)

I assume this is okay until jsdom accepts updating of the window.location object directly. Given we are calling it via changeURL this will hopefully be clear to users.

I called the window method update as this in theory could be used by other update functions. However it checks for and only updates _URL, and is called by the specific changeURL method.