### PR TITLE
Changing StyleSheetList.prototype.item to match specification

### DIFF
--- a/lib/jsdom/level2/style.js
+++ b/lib/jsdom/level2/style.js
@@ -62,7 +62,7 @@ module.exports = core => {
   StyleSheetList.prototype.__proto__ = Array.prototype;
 
   StyleSheetList.prototype.item = function item(i) {
-    return this[i];
+    return Object.prototype.hasOwnProperty.call(this, i) ? this[i] : null;
   };
 
   core.StyleSheetList = StyleSheetList;

--- a/test/level2/style.js
+++ b/test/level2/style.js
@@ -473,5 +473,11 @@ exports.tests = {
     }
 
     t.done();
+  },
+  'StyleSheetList.prototype.item returns null on index out of bounds': t => {
+    const document = jsdom.jsdom();
+    t.strictEqual(document.styleSheets[0], undefined);
+    t.strictEqual(document.styleSheets.item(0), null);
+    t.done();
   }
 };


### PR DESCRIPTION
Per [spec](https://drafts.csswg.org/cssom/#dom-stylesheetlist-item)
> The item(index) method must return the indexth CSS style sheet in the collection. If there is no indexth object in the collection, **then the method must return null.**
