### PR TITLE
Swallowing errors in invokeEventListeners

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -220,6 +220,9 @@ function invokeEventListeners(listeners, target, eventImpl) {
       if (window) {
         reportException(window, e);
       }
+      else {
+        throw e;
+      }
       // Errors in window-less documents just get swallowed... can you think of anything better?
     }
   }

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -223,7 +223,7 @@ function invokeEventListeners(listeners, target, eventImpl) {
       else {
         throw e;
       }
-      // Errors in window-less documents just get swallowed... can you think of anything better?
+      // Errors in window-less documents are not swallowed cause debugging becomes problematic
     }
   }
 }


### PR DESCRIPTION
Hi!
I've had some problem using jsdom with simple _jQuery.ajax.then_. There was an error inside _then_ callback and it was swallowed. So everything was fine, no errors, but I had never received any data. So I started debugging and found that piece of code. I think it it misleading to just swallow errors without any warning. Maybe it has some purpose in the big picture, but for my use case it was destructive.