### PR TITLE
Make button[type=submit]'s default preventable

### DIFF
--- a/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
@@ -5,7 +5,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const closest = require("../helpers/traversal").closest;
 
 class HTMLButtonElementImpl extends HTMLElementImpl {
-  _preClickActivationSteps(event) {
+  _activationBehavior(event) {
     const target = event.target;
     const form = target.form;
     if (form) {

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-button-element/button-click-submits.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-button-element/button-click-submits.html
@@ -38,4 +38,19 @@ async_test(t => {
 
 }, "clicking a button by dispatching an event should trigger a submit");
 
+async_test(t => {
+
+  const form = document.createElement("form");
+  const button = document.createElement("button");
+  form.appendChild(button);
+
+  form.addEventListener("submit", t.unreached_func('Form should not be submitted'));
+  button.addEventListener("click", t.step_func(ev => {
+    ev.preventDefault();
+    t.step_timeout(function() { t.done(); }, 500);
+  }));
+  button.click();
+
+}, "clicking a button that prevents the event's default should not trigger a submit");
+
 </script>


### PR DESCRIPTION
If a click on a submit button has its default prevented, the `submit` event should not be fired. This PR fixes that and adds a test.

*Note*: `input[type=submit]` already uses `_activationStep` and thus only works fine, only `button` is affected by this bug.