### PR TITLE
Button label children

### DIFF
--- a/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
@@ -5,11 +5,10 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const closest = require("../helpers/traversal").closest;
 
 class HTMLButtonElementImpl extends HTMLElementImpl {
-  _activationBehavior(event) {
-    const target = event.target;
-    const form = target.form;
+  _activationBehavior() {
+    const form = this.form;
     if (form) {
-      if (target.type === "submit") {
+      if (this.type === "submit") {
         form._dispatchSubmitEvent();
       }
     }

--- a/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLButtonElement-impl.js
@@ -5,7 +5,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const closest = require("../helpers/traversal").closest;
 
 class HTMLButtonElementImpl extends HTMLElementImpl {
-  _preClickActivationSteps(event) {
+  _activationBehavior(event) {
     const target = event.target;
     const form = target.form;
     if (form) {

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -4,6 +4,7 @@ const ElementImpl = require("./Element-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const focusing = require("../helpers/focusing.js");
 const conversions = require("webidl-conversions");
+const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
 
 class HTMLElementImpl extends ElementImpl {
   constructor(args, privateData) {
@@ -31,12 +32,15 @@ class HTMLElementImpl extends ElementImpl {
     const outcome = super.dispatchEvent(event);
 
     if (event.type === "click") {
-      callEventBehaviorHook(event, "_preClickActivationSteps");
+      const target = nearestActivatableElement(event.target);
+      if (target) {
+        callEventBehaviorHook(target, "_preClickActivationSteps");
 
-      if (event.defaultPrevented) {
-        callEventBehaviorHook(event, "_canceledActivationSteps");
-      } else {
-        callEventBehaviorHook(event, "_activationBehavior");
+        if (event.defaultPrevented) {
+          callEventBehaviorHook(target, "_canceledActivationSteps");
+        } else {
+          callEventBehaviorHook(target, "_activationBehavior");
+        }
       }
     }
 
@@ -122,10 +126,18 @@ class HTMLElementImpl extends ElementImpl {
   }
 }
 
-function callEventBehaviorHook(event, name) {
-  if (event && event.target && typeof event.target[name] === "function") {
-    event.target[name]();
+function callEventBehaviorHook(target, name) {
+  if (typeof target[name] === "function") {
+    target[name]();
   }
+}
+
+// See https://html.spec.whatwg.org/multipage/interaction.html#nearest-activatable-element
+function nearestActivatableElement(target) {
+  while (target && typeof target._activationBehavior !== "function") {
+    target = domSymbolTree.parent(target);
+  };
+  return target;
 }
 
 module.exports = {

--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -124,7 +124,7 @@ class HTMLElementImpl extends ElementImpl {
 
 function callEventBehaviorHook(event, name) {
   if (event && event.target && typeof event.target[name] === "function") {
-    event.target[name](event);
+    event.target[name]();
   }
 }
 

--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -45,40 +45,34 @@ class HTMLInputElementImpl extends HTMLElementImpl {
     this._preCancelState = null;
   }
 
-  _preClickActivationSteps(event) {
-    const target = event.target;
-
-    if (target.type === "checkbox") {
-      target.checked = !target.checked;
-    } else if (target.type === "radio") {
-      this._preCancelState = target.checked;
-      target.checked = true;
+  _preClickActivationSteps() {
+    if (this.type === "checkbox") {
+      this.checked = !this.checked;
+    } else if (this.type === "radio") {
+      this._preCancelState = this.checked;
+      this.checked = true;
     }
   }
 
-  _canceledActivationSteps(event) {
-    const target = event.target;
-
-    if (target.type === "checkbox") {
-      target.checked = !target.checked;
-    } else if (target.type === "radio") {
+  _canceledActivationSteps() {
+    if (this.type === "checkbox") {
+      this.checked = !this.checked;
+    } else if (this.type === "radio") {
       if (this._preCancelState !== null) {
-        target.checked = this._preCancelState;
+        this.checked = this._preCancelState;
         this._preCancelState = null;
       }
     }
   }
 
-  _activationBehavior(event) {
-    const target = event.target;
-
-    if (target.type === "checkbox") {
+  _activationBehavior() {
+    if (this.type === "checkbox") {
       const inputEvent = Event.createImpl(["input", { bubbles: true, cancelable: true }], {});
       this.dispatchEvent(inputEvent);
 
       const changeEvent = Event.createImpl(["change", { bubbles: true, cancelable: true }], {});
       this.dispatchEvent(changeEvent);
-    } else if (target.type === "submit") {
+    } else if (this.type === "submit") {
       const form = this.form;
       if (form) {
         form._dispatchSubmitEvent();

--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -46,7 +46,7 @@ function sendClickToAssociatedNode(node) {
 }
 
 class HTMLLabelElementImpl extends HTMLElementImpl {
-  _preClickActivationSteps() {
+  _activationBehavior() {
     if (this.hasAttribute("for")) {
       const node = this.ownerDocument.getElementById(this.getAttribute("for"));
       if (node && isLabelable(node)) {

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-button-element/button-click-submits.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-button-element/button-click-submits.html
@@ -53,4 +53,20 @@ async_test(t => {
 
 }, "clicking a button that prevents the event's default should not trigger a submit");
 
+async_test(t => {
+
+  const form = document.createElement("form");
+  const button = document.createElement("button");
+  const span = document.createElement("span");
+  button.appendChild(span);
+  form.appendChild(button);
+
+  form.addEventListener("submit", t.step_func_done(ev => {
+    assert_equals(ev.target, form);
+  }));
+
+  span.click();
+
+}, "clicking a button's child with .click() should trigger a submit");
+
 </script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-button-element/button-click-submits.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-button-element/button-click-submits.html
@@ -38,4 +38,19 @@ async_test(t => {
 
 }, "clicking a button by dispatching an event should trigger a submit");
 
+async_test(t => {
+
+  const form = document.createElement("form");
+  const button = document.createElement("button");
+  form.appendChild(button);
+
+  form.addEventListener("submit", t.unreached_func('Form should not be submitted'));
+  button.addEventListener("click", t.step_func(ev => {
+    ev.preventDefault();
+    t.step_timeout(function() { t.done(); }, 500);
+  }));
+  button.click();
+
+}, "clicking a button that prevents the event's default should not trigger a submit");
+
 </script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/proxy-click-to-associated-element.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/proxy-click-to-associated-element.html
@@ -13,6 +13,9 @@
         <input id="bar" type="checkbox" /> bar
         <input id="baz" type="checkbox" /> baz
     </label>
+
+    <input id="baz" type="checkbox" />
+    <label id="baz-label" for="baz">baz</label>
 </form>
 <script>
   "use strict";
@@ -46,5 +49,20 @@
     label.click();
 
   }, "label without for attribute should proxy click events to the first labelable child");
+
+  async_test(t => {
+
+    const label = document.getElementById("baz-label");
+    const input = document.getElementById("baz");
+
+    input.addEventListener("click", t.unreached_func('Input should not receive click'));
+    label.addEventListener("click", t.step_func(ev => {
+      ev.preventDefault();
+      t.step_timeout(function() { t.done(); }, 500);
+    }));
+
+    label.click();
+
+  }, "clicking a label that prevents the event's default should not proxy click events");
 
 </script>

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/proxy-click-to-associated-element.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/proxy-click-to-associated-element.html
@@ -16,6 +16,9 @@
 
     <input id="baz" type="checkbox" />
     <label id="baz-label" for="baz">baz</label>
+
+    <input id="parent-input" type="checkbox" />
+    <label id="parent-label" for="parent-input"><div id="child">x</div></label>
 </form>
 <script>
   "use strict";
@@ -64,5 +67,16 @@
     label.click();
 
   }, "clicking a label that prevents the event's default should not proxy click events");
+
+async_test(t => {
+
+    const child = document.getElementById("child");
+    const input = document.getElementById("parent-input");
+
+    input.addEventListener("click", t.step_func_done());
+
+    child.click();
+
+  }, "clicking a label's child should proxy click events");
 
 </script>


### PR DESCRIPTION
`<button>` and `<label>` can have children, and clicking on those should also submit a form / proxy clicks. Currently, nothing happens...

This PR attempts to address this issue.
First, I simplify the interface to the event behavior hooks. I found the mix of `event.target` and `this` to be confusing (when they were always the same). This makes the fix easier, otherwise an alternative solution would have been to use `currentTarget` instead of `target` everywhere and set that property before calling them. I see no point to that, these methods are internal only and `currentTarget` would always be `this` anyways.

The fix then consists of finding the first element with event behavior hooks, if any and call them on that element.

This builds on #1521 and #1522 

It's probably pretty clear that clicking on children should fire the activation behavior, but here's an excerpt [from the spec](https://html.spec.whatwg.org/multipage/interaction.html#activation):
> Let *e* be the nearest activatable element of target (defined below), if any [...], run pre-click activation steps on it [...] if the click event is not canceled, run post-click activation steps [...]

I called the utility function `nearestActivatableElement`, as it aims to follow [the spec](https://html.spec.whatwg.org/multipage/interaction.html#nearest-activatable-element)
