### PR TITLE
TypeError: str.replace is not a function

### DIFF
--- a/lib/jsdom/living/nodes/HTMLElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLElement-impl.js
@@ -118,7 +118,7 @@ class HTMLElementImpl extends ElementImpl {
   }
 
   set tabIndex(value) {
-    this.setAttribute("tabIndex", value);
+    this.setAttribute("tabIndex", String(value));
   }
 }
 


### PR DESCRIPTION
The following code works perfectly fine with versions of jsdom up to and including 9.0.0, but starting with version 9.1.0 it does not any more:

```javascript
var jsdom = require('jsdom').jsdom;
var noop = require('lodash/noop');
var constant = require('lodash/constant');

if ('undefined' === typeof navigator) {
  global.window = jsdom().defaultView;
  global.navigator = window.navigator;
  window.document.createRange = constant({setEnd: noop, setStart: noop, getBoundingClientRect: constant({})});
  global.document = window.document;
}

var cm = require('codemirror');

require('codemirror/mode/jsx/jsx');

var el = document.createElement('div');

cm(el, {
  value: 'function myScript(){return 100;}',
  mode: {name: 'jsx', typescript: true},
  scrollbarStyle: 'null',
  inputStyle: 'contenteditable'
});

console.log(el.innerHTML);
```

Starting with version 9.1.0, the last line of the code above results in the following error:

```
node_modules/parse5/lib/serialization/serializer.js:27
        .replace(AMP_REGEX, '&amp;')
         ^

TypeError: str.replace is not a function
    at escapeString (node_modules/parse5/lib/serialization/serializer.js:27:10)
    at Serializer._serializeAttributes (node_modules/parse5/lib/serialization/serializer.js:124:55)
    at Serializer._serializeElement (node_modules/parse5/lib/serialization/serializer.js:91:10)
    at Serializer._serializeChildNodes (node_modules/parse5/lib/serialization/serializer.js:72:22)
    at Serializer._serializeElement (node_modules/parse5/lib/serialization/serializer.js:114:14)
    at Serializer._serializeChildNodes (node_modules/parse5/lib/serialization/serializer.js:72:22)
    at Serializer._serializeElement (node_modules/parse5/lib/serialization/serializer.js:114:14)
    at Serializer._serializeChildNodes (node_modules/parse5/lib/serialization/serializer.js:72:22)
    at Serializer._serializeElement (node_modules/parse5/lib/serialization/serializer.js:114:14)
    at Serializer._serializeChildNodes (node_modules/parse5/lib/serialization/serializer.js:72:22)
```

Strictly speaking, the error is in the `parse5` library, however, its version hasn't changed since 9.0.0.