### PR TITLE
Some work on DOMParser; needs help

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,7 @@ test/level2
 test/level3
 test/sizzle
 test/web-platform-tests/tests
+test/web-platform-tests/to-upstream/domparsing/DOMParser-dont-upstream.html
 test/window/files
 test/window/frame.js
 test/window/script.js

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -8,8 +8,6 @@ const path = require("path");
 const CookieJar = require("tough-cookie").CookieJar;
 
 const toFileUrl = require("./jsdom/utils").toFileUrl;
-const defineGetter = require("./jsdom/utils").defineGetter;
-const defineSetter = require("./jsdom/utils").defineSetter;
 const parseContentType = require("./jsdom/living/helpers/headers").parseContentType;
 const documentFeatures = require("./jsdom/browser/documentfeatures");
 const domToHtml = require("./jsdom/browser/domtohtml").domToHtml;
@@ -67,15 +65,17 @@ exports.changeURL = function (window, urlString) {
   doc._origin = whatwgURL.serializeURLToUnicodeOrigin(doc._URL);
 };
 
-exports.debugMode = false;
-
-// Proxy feature functions to features module.
-for (const propName of ["availableDocumentFeatures", "defaultDocumentFeatures", "applyDocumentFeatures"]) {
-  defineGetter(exports, propName, () => documentFeatures[propName]);
-  defineSetter(exports, propName, val => {
-    documentFeatures[propName] = val;
-  });
-}
+// Proxy to features module
+Object.defineProperty(exports, "defaultDocumentFeatures", {
+  enumerable: true,
+  configurable: true,
+  get() {
+    return documentFeatures.defaultDocumentFeatures;
+  },
+  set(v) {
+    documentFeatures.defaultDocumentFeatures = v;
+  }
+});
 
 exports.jsdom = function (html, options) {
   if (options === undefined) {

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -127,7 +127,8 @@ exports.jsdom = function (html, options) {
     userAgent: options.userAgent
   });
 
-  documentFeatures.applyDocumentFeatures(window.document, options.features);
+  const documentImpl = idlUtils.implForWrapper(window.document);
+  documentFeatures.applyDocumentFeatures(documentImpl, options.features);
 
   if (options.created) {
     options.created(null, window.document.defaultView);
@@ -141,7 +142,6 @@ exports.jsdom = function (html, options) {
     window.document.write(html);
   } else if (options.parsingMode === "xml") {
     if (html !== undefined) {
-      const documentImpl = idlUtils.implForWrapper(window.document);
       documentImpl._htmlToDom.appendHtmlToDocument(html, documentImpl);
     }
   }

--- a/lib/jsdom/browser/documentfeatures.js
+++ b/lib/jsdom/browser/documentfeatures.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const idlUtils = require("../living/generated/utils");
-
 exports.availableDocumentFeatures = [
   "FetchExternalResources",
   "ProcessExternalResources",
@@ -14,7 +12,7 @@ exports.defaultDocumentFeatures = {
   SkipExternalResources: false
 };
 
-exports.applyDocumentFeatures = function (doc, features) {
+exports.applyDocumentFeatures = (documentImpl, features) => {
   features = features || {};
 
   for (let i = 0; i < exports.availableDocumentFeatures.length; ++i) {
@@ -33,7 +31,7 @@ exports.applyDocumentFeatures = function (doc, features) {
       continue;
     }
 
-    const implImpl = idlUtils.implForWrapper(doc.implementation);
+    const implImpl = documentImpl._implementation;
     implImpl._removeFeature(featureName);
 
     if (featureSource !== undefined) {

--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -105,6 +105,7 @@ class HtmlToDom {
   _parseWithsax(html, fragment, element) {
     const SaxParser = this.parser.parser;
     const parser = new SaxParser(/* strict = */true, { xmlns: true });
+    parser.noscript = false;
     parser.looseCase = "toString";
     const openStack = [element];
     parser.ontext = text => {

--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -178,7 +178,17 @@ class HtmlToDom {
         name: "!doctype",
         data: "!doctype " + dt
       });
+
+      const entityMatcher = /<!ENTITY ([^ ]+) "([^"]+)">/g;
+      let result;
+      while ((result = entityMatcher.exec(dt))) {
+        const [, name, value] = result;
+        if (!(name in parser.ENTITIES)) {
+          parser.ENTITIES[name] = value;
+        }
+      }
     };
+
     parser.onerror = err => {
       throw err;
     };

--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -104,7 +104,7 @@ class HtmlToDom {
 
   _parseWithsax(html, fragment, element) {
     const SaxParser = this.parser.parser;
-    const parser = new SaxParser(false, { xmlns: true });
+    const parser = new SaxParser(/* strict = */true, { xmlns: true });
     parser.looseCase = "toString";
     const openStack = [element];
     parser.ontext = text => {
@@ -178,6 +178,9 @@ class HtmlToDom {
         name: "!doctype",
         data: "!doctype " + dt
       });
+    };
+    parser.onerror = err => {
+      throw err;
     };
     parser.write(html).close();
   }

--- a/lib/jsdom/living/domparsing/DOMParser-impl.js
+++ b/lib/jsdom/living/domparsing/DOMParser-impl.js
@@ -1,0 +1,48 @@
+"use strict";
+const Document = require("../generated/Document");
+const core = require("..");
+const applyDocumentFeatures = require("../../browser/documentfeatures").applyDocumentFeatures;
+
+exports.implementation = class DOMParserImpl {
+  parseFromString(string, contentType) {
+    switch (String(contentType)) {
+      case "text/html": {
+        return createScriptingDisabledDocument("html", contentType, string);
+      }
+
+      case "text/xml":
+      case "application/xml":
+      case "application/xhtml+xml":
+      case "image/svg+xml": {
+        // TODO: use a strict XML parser (sax's strict mode might work?) and create parsererror elements
+        return createScriptingDisabledDocument("xml", contentType, string);
+      }
+
+      default:
+        throw new TypeError("Invalid contentType");
+    }
+  }
+};
+
+function createScriptingDisabledDocument(parsingMode, contentType, string) {
+  const document = Document.createImpl([], {
+    core,
+    options: {
+      parsingMode,
+      encoding: "UTF-8",
+      contentType
+      // TODO: somehow set URL to active document's URL
+    }
+  });
+
+  // "scripting enabled" set to false
+  applyDocumentFeatures(document, {
+    FetchExternalResources: [],
+    ProcessExternalResources: false,
+    SkipExternalResources: false
+  });
+
+  document._htmlToDom.appendHtmlToDocument(string, document);
+  document.close();
+  return document;
+}

--- a/lib/jsdom/living/domparsing/DOMParser-impl.js
+++ b/lib/jsdom/living/domparsing/DOMParser-impl.js
@@ -15,7 +15,18 @@ exports.implementation = class DOMParserImpl {
       case "application/xhtml+xml":
       case "image/svg+xml": {
         // TODO: use a strict XML parser (sax's strict mode might work?) and create parsererror elements
-        return createScriptingDisabledDocument("xml", contentType, string);
+        try {
+          return createScriptingDisabledDocument("xml", contentType, string);
+        } catch (error) {
+          const document = createScriptingDisabledDocument("xml", contentType);
+          const element = document.createElementNS(
+            "http://www.mozilla.org/newlayout/xml/parsererror.xml", "parsererror");
+
+          element.textContent = error.message;
+
+          document.appendChild(element);
+          return document;
+        }
       }
 
       default:
@@ -42,7 +53,9 @@ function createScriptingDisabledDocument(parsingMode, contentType, string) {
     SkipExternalResources: false
   });
 
-  document._htmlToDom.appendHtmlToDocument(string, document);
+  if (string !== undefined) {
+    document._htmlToDom.appendHtmlToDocument(string, document);
+  }
   document.close();
   return document;
 }

--- a/lib/jsdom/living/domparsing/DOMParser.idl
+++ b/lib/jsdom/living/domparsing/DOMParser.idl
@@ -1,0 +1,13 @@
+[Constructor]
+interface DOMParser {
+    [NewObject]
+    Document parseFromString(DOMString str, SupportedType type);
+};
+
+enum SupportedType {
+    "text/html",
+    "text/xml",
+    "application/xml",
+    "application/xhtml+xml",
+    "image/svg+xml"
+};

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -7,6 +7,7 @@ exports.Node = require("./generated/Node").interface;
 exports.Element = require("./generated/Element").interface;
 exports.DocumentFragment = require("./generated/DocumentFragment").interface;
 exports.Document = exports.HTMLDocument = require("./generated/Document").interface;
+exports.XMLDocument = require("./generated/XMLDocument").interface;
 exports.CharacterData = require("./generated/CharacterData").interface;
 exports.Comment = require("./generated/Comment").interface;
 exports.DocumentType = require("./generated/DocumentType").interface;
@@ -30,6 +31,8 @@ exports.EventTarget = require("./generated/EventTarget").interface;
 
 exports.Location = require("./generated/Location").interface;
 exports.History = require("./generated/History").interface;
+
+exports.DOMParser = require("./generated/DOMParser").interface;
 
 require("./register-elements")(exports);
 

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -14,9 +14,9 @@ const reflectURLAttribute = require("../../utils").reflectURLAttribute;
 
 function loadFrame(frame) {
   if (frame._contentDocument) {
-    if (frame._contentDocument.defaultView) {
+    if (frame._contentDocument._defaultView) {
       // close calls delete on its document.
-      frame._contentDocument.defaultView.close();
+      frame._contentDocument._defaultView.close();
     } else {
       delete frame._contentDocument;
     }
@@ -42,7 +42,7 @@ function loadFrame(frame) {
     parsingMode: "html",
     url: url.protocol === "javascript:" || url.href === "about:blank" ? parentDoc.URL : url.href,
     resourceLoader: parentDoc._customResourceLoader,
-    userAgent: parentDoc.defaultView.navigator.userAgent,
+    userAgent: parentDoc._defaultView.navigator.userAgent,
     cookieJar: parentDoc._cookieJar,
     pool: parentDoc._pool,
     encoding: parentDoc._encoding,
@@ -50,11 +50,11 @@ function loadFrame(frame) {
     strictSSL: parentDoc._strictSSL,
     proxy: parentDoc._proxy
   });
-  const contentDoc = frame._contentDocument = wnd.document;
-  applyDocumentFeatures(contentDoc, parentDoc.implementation._features);
+  const contentDoc = frame._contentDocument = idlUtils.implForWrapper(wnd._document);
+  applyDocumentFeatures(contentDoc, parentDoc._implementation._features);
 
-  const parent = parentDoc.defaultView;
-  const contentWindow = contentDoc.defaultView;
+  const parent = parentDoc._defaultView;
+  const contentWindow = contentDoc._defaultView;
   contentWindow._parent = parent;
   contentWindow._top = parent.top;
   contentWindow._virtualConsole = parent._virtualConsole;
@@ -80,11 +80,10 @@ function loadFrame(frame) {
         if (response) {
           const contentType = parseContentType(response.headers["content-type"]);
           if (contentType) {
-            const impl = idlUtils.implForWrapper(contentDoc);
             if (contentType.isXML()) {
-              impl._parsingMode = "xml";
+              contentDoc._parsingMode = "xml";
             }
-            impl._encoding = contentType.get("charset");
+            contentDoc._encoding = contentType.get("charset");
           }
         }
         contentDoc.write(html);
@@ -154,7 +153,7 @@ class HTMLFrameElementImpl extends HTMLElementImpl {
   }
 
   get contentWindow() {
-    return this.contentDocument ? this.contentDocument.defaultView : null;
+    return this.contentDocument ? this.contentDocument._defaultView : null;
   }
 
   get src() {

--- a/lib/jsdom/living/nodes/XMLDocument-impl.js
+++ b/lib/jsdom/living/nodes/XMLDocument-impl.js
@@ -1,0 +1,4 @@
+"use strict";
+const DocumentImpl = require("./Document-impl").implementation;
+
+exports.implementation = class XMLDocumentImpl extends DocumentImpl {};

--- a/lib/jsdom/living/nodes/XMLDocument.idl
+++ b/lib/jsdom/living/nodes/XMLDocument.idl
@@ -1,0 +1,1 @@
+interface XMLDocument : Document {};

--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -295,7 +295,12 @@ module.exports = function createXMLHttpRequest(window) {
         encoding: resText.encoding
       } });
       const resImpl = idlUtils.implForWrapper(res);
-      resImpl._htmlToDom.appendHtmlToDocument(resText.data, resImpl);
+      try {
+        resImpl._htmlToDom.appendHtmlToDocument(resText.data, resImpl);
+      } catch (e) {
+        properties.responseXMLCache = null;
+        return null;
+      }
       res.close();
       properties.responseXMLCache = res;
       return res;

--- a/scripts/webidl/convert.js
+++ b/scripts/webidl/convert.js
@@ -53,4 +53,5 @@ doConversion(path.resolve(__dirname, "../../lib/jsdom/living/traversal"))
   .then(() => doConversion(path.resolve(__dirname, "../../lib/jsdom/living/window")))
   .then(() => doConversion(path.resolve(__dirname, "../../lib/jsdom/living/nodes")))
   .then(() => doConversion(path.resolve(__dirname, "../../lib/jsdom/living/navigator")))
+  .then(() => doConversion(path.resolve(__dirname, "../../lib/jsdom/living/domparsing")))
   .done();

--- a/test/jsdom/parsing.js
+++ b/test/jsdom/parsing.js
@@ -117,15 +117,17 @@ describe("jsdom/parsing", () => {
 
   specify("prefix on attribute named 'hasOwnProperty' (GH-1444)", () => {
     const options = { parsingMode: "xml" };
-    const document = jsdom.jsdom("<element prefix:hasOwnProperty='value'></element>", options);
+    const document = jsdom.jsdom(
+      `<element xmlns:prefix="https://example.com/" prefix:hasOwnProperty='value'></element>`, options);
 
     const els = document.getElementsByTagName("element");
 
     assert.equal(els.length, 1);
-    assert.equal(els[0].attributes.length, 1);
-    assert.equal(els[0].attributes[0].prefix, "prefix");
+    assert.equal(els[0].attributes.length, 2);
+    assert.equal(els[0].attributes[1].prefix, "prefix");
     assert.equal(els[0].getAttribute("prefix:hasOwnProperty"), "value");
-    assert.equal(els[0].outerHTML, "<element prefix:hasOwnProperty=\"value\"></element>");
+    assert.equal(els[0].outerHTML,
+                 `<element xmlns:prefix="https://example.com/" prefix:hasOwnProperty="value"></element>`);
   });
 
   specify("CDATA should parse as bogus comments (GH-618)", () => {

--- a/test/level1/core/files/hc_nodtdstaff.xml.js
+++ b/test/level1/core/files/hc_nodtdstaff.xml.js
@@ -3,7 +3,7 @@ var jsdom = require("../../../..");
 
 exports.hc_nodtdstaff = function () {
   return jsdom.jsdom(`
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><title>hc_nodtdstaff</title></head><body>
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/><title>hc_nodtdstaff</title></head><body>
  <p>
   <em>EMP0001</em>
   <strong>Margaret Martin</strong>

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -74,7 +74,7 @@ describe("Web Platform Tests", () => {
     "dom/traversal/TreeWalker-walking-outside-a-tree.html",
     "dom/traversal/TreeWalker.html",
     // "domparsing/DOMParser-parseFromString-html.html", // needs to get "the active document's URL", which is not possible with one DOMParser shared across all windows
-    // "domparsing/DOMParser-parseFromString-xml.html", // needs a stricter XML parser, and XMLDocument
+    // "domparsing/DOMParser-parseFromString-xml.html", // same problem
     "domparsing/insert-adjacent.html",
     // "html/browsers/browsing-the-web/history-traversal/PopStateEvent.html", // https://github.com/w3c/web-platform-tests/pull/2964
     "html/browsers/browsing-the-web/history-traversal/hashchange_event.html",

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -73,6 +73,8 @@ describe("Web Platform Tests", () => {
     "dom/traversal/TreeWalker-traversal-skip.html",
     "dom/traversal/TreeWalker-walking-outside-a-tree.html",
     "dom/traversal/TreeWalker.html",
+    // "domparsing/DOMParser-parseFromString-html.html", // needs to get "the active document's URL", which is not possible with one DOMParser shared across all windows
+    // "domparsing/DOMParser-parseFromString-xml.html", // needs a stricter XML parser, and XMLDocument
     "domparsing/insert-adjacent.html",
     // "html/browsers/browsing-the-web/history-traversal/PopStateEvent.html", // https://github.com/w3c/web-platform-tests/pull/2964
     "html/browsers/browsing-the-web/history-traversal/hashchange_event.html",

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -18,6 +18,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "dom/nodes/getElementsByClassName-32.html",
     "dom/nodes/Node-isEqualNode.html",
     "dom/nodes/Node-mutation-adoptNode.html",
+    "domparsing/DOMParser-dont-upstream.html",
     "domparsing/insert-adjacent.html",
     "encoding/meta/meta-charset-no-quotes.html",
     "encoding/meta/meta-charset-simple-quotes.html",

--- a/test/web-platform-tests/to-upstream/domparsing/DOMParser-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/domparsing/DOMParser-dont-upstream.html
@@ -95,15 +95,14 @@ allowedTypes.forEach(function(type) {
     assert_false(doc instanceof XMLDocument, "Should not be XMLDocument");
   }, "XMLDocument interface for correctly parsed document with type " + type);
 
-  // Fail because we don't have a strict XML parser (?)
-  // test(function() {
-  //   var p = new DOMParser();
-  //   var doc = p.parseFromString("<foo>", type);
-  //   checkMetadata(doc, type);
-  //   assert_equals(doc.documentElement.namespaceURI, "http://www.mozilla.org/newlayout/xml/parsererror.xml");
-  //   assert_equals(doc.documentElement.localName, "parsererror");
-  //   assert_equals(doc.documentElement.tagName, "parsererror");
-  // }, "Should return an error document for XML wellformedness errors in type " + type);
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo>", type);
+    checkMetadata(doc, type);
+    assert_equals(doc.documentElement.namespaceURI, "http://www.mozilla.org/newlayout/xml/parsererror.xml");
+    assert_equals(doc.documentElement.localName, "parsererror");
+    assert_equals(doc.documentElement.tagName, "parsererror");
+  }, "Should return an error document for XML wellformedness errors in type " + type);
 
   test(function() {
     var p = new DOMParser();

--- a/test/web-platform-tests/to-upstream/domparsing/DOMParser-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/domparsing/DOMParser-dont-upstream.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<title>DOMParser tests that we pass so far, despite not passing any of the files</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// |expected| should be an object indicating the expected type of node.
+function assert_node(actual, expected) {
+    assert_true(actual instanceof expected.type,
+                'Node type mismatch: actual = ' + actual.nodeType + ', expected = ' + expected.nodeType);
+    if (typeof(expected.id) !== 'undefined')
+        assert_equals(actual.id, expected.id, expected.idMessage);
+    if (typeof(expected.nodeValue) !== 'undefined')
+        assert_equals(actual.nodeValue, expected.nodeValue, expected.nodeValueMessage);
+}
+
+var doc;
+setup(function() {
+    var parser = new DOMParser();
+    var input = '<html id="root"><head></head><body></body></html>';
+    doc = parser.parseFromString(input, 'text/html');
+});
+
+test(function() {
+    var root = doc.documentElement;
+    assert_node(root, { type: HTMLHtmlElement, id: 'root',
+                        idMessage: 'documentElement id attribute should be root.' });
+}, 'Parsing of id attribute');
+
+test(function() {
+    assert_equals(doc.contentType, "text/html")
+}, 'contentType');
+
+test(function() {
+    assert_equals(doc.characterSet, "UTF-8")
+}, 'characterSet');
+
+test(function() {
+    assert_equals(doc.inputEncoding, "UTF-8")
+}, 'inputEncoding');
+
+test(function() {
+    assert_equals(doc.charset, "UTF-8")
+}, 'charset');
+
+// Fail due to our lack of multi-global setup
+// test(function() {
+//     var url = document.URL;
+//     assert_equals(doc.documentURI, url,
+//                   'The document must have a URL value equal to the URL of the active document.');
+//     assert_equals(doc.URL, url,
+//                   'The document must have a URL value equal to the URL of the active document.');
+// }, 'URL value');
+
+test(function() {
+    assert_equals(doc.location, null,
+                  'The document must have a location value of null.');
+}, 'Location value');
+
+test(function() {
+    var soup = "<!DOCTYPE foo></><foo></multiple></>";
+    var htmldoc = new DOMParser().parseFromString(soup, "text/html");
+    assert_equals(htmldoc.documentElement.localName, "html");
+    assert_equals(htmldoc.documentElement.namespaceURI, "http://www.w3.org/1999/xhtml");
+}, "DOMParser parses HTML tag soup with no problems");
+
+/////////////////////////////
+
+function checkMetadata(doc, contentType) {
+  assert_true(doc instanceof Document, "Should be Document");
+//  assert_equals(doc.URL, document.URL, "URL");
+//  assert_equals(doc.documentURI, document.URL, "documentURI");
+  assert_equals(doc.characterSet, "UTF-8", "characterSet");
+  assert_equals(doc.charset, "UTF-8", "charset");
+  assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
+  assert_equals(doc.contentType, contentType, "contentType");
+  assert_equals(doc.location, null, "location");
+}
+
+var allowedTypes = ["text/xml", "application/xml", "application/xhtml+xml", "image/svg+xml"];
+
+allowedTypes.forEach(function(type) {
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo/>", type);
+    assert_true(doc instanceof Document, "Should be Document");
+    checkMetadata(doc, type);
+    assert_equals(doc.documentElement.namespaceURI, null);
+    assert_equals(doc.documentElement.localName, "foo");
+    assert_equals(doc.documentElement.tagName, "foo");
+  }, "Should parse correctly in type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo/>", type);
+    assert_false(doc instanceof XMLDocument, "Should not be XMLDocument");
+  }, "XMLDocument interface for correctly parsed document with type " + type);
+
+  // Fail because we don't have a strict XML parser (?)
+  // test(function() {
+  //   var p = new DOMParser();
+  //   var doc = p.parseFromString("<foo>", type);
+  //   checkMetadata(doc, type);
+  //   assert_equals(doc.documentElement.namespaceURI, "http://www.mozilla.org/newlayout/xml/parsererror.xml");
+  //   assert_equals(doc.documentElement.localName, "parsererror");
+  //   assert_equals(doc.documentElement.tagName, "parsererror");
+  // }, "Should return an error document for XML wellformedness errors in type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo>", type);
+    assert_false(doc instanceof XMLDocument, "Should not be XMLDocument");
+  }, "XMLDocument interface for incorrectly parsed document with type " + type);
+});
+</script>


### PR DESCRIPTION
@Sebmaster I was hoping you could take a look at this. The problem comes with the "add strict parsing errors when parsing XML documents" commit. Flipping that causes a bunch of tests to start failing for weird reasons having to do with tree construction in htmltodom.js. The last commit modifies the web platform tests manifest so that it only runs the tests which have shown failures.

What's weird is that the failures are due to stuff that should have nothing to do with strict vs. non-strict XML parsing. It's something about how nodes are emitted and what's on the stack at that time. I figure since you plugged in sax in the first place maybe you had some ideas.