### PR TITLE
Named access nested context revision

### DIFF
--- a/lib/jsdom/living/named-properties-window.js
+++ b/lib/jsdom/living/named-properties-window.js
@@ -58,7 +58,8 @@ function namedPropertyResolver(HTMLCollection, window, name, values) {
   for (let i = 0; i < length; ++i) {
     const node = objects[i];
 
-    if ("contentWindow" in node && !hasOwnProp.call(node, "contentWindow")) {
+    if ("contentWindow" in node && !hasOwnProp.call(node, "contentWindow") &&
+       node.getAttribute("name") === name) {
       return node.contentWindow;
     }
   }

--- a/test/jsdom/env.js
+++ b/test/jsdom/env.js
@@ -242,7 +242,7 @@ describe("jsdom/env", () => {
     };
 
     env({
-      html: "<html><head></head><body><iframe id='bar' src='http://localhost/iframe.html'></iframe></body></html>",
+      html: "<html><head></head><body><iframe name='bar' src='http://localhost/iframe.html'></iframe></body></html>",
       resourceLoader(resource, callback) {
         const response = routes[resource.url.path];
         assert.ok(response, `Not found: ${resource.url.path}`);

--- a/test/web-platform-tests/to-upstream/html/named-access-on-window/nested-context.html
+++ b/test/web-platform-tests/to-upstream/html/named-access-on-window/nested-context.html
@@ -20,5 +20,14 @@ test(() => {
   assert_equals(window.foo, iframe.contentWindow);
 }, "A named property that matches any element that contains a nested " +
   "browsing context, should return the WindowProxy of that context");
+
+test(() => {
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("id", "bar");
+  document.body.appendChild(iframe);
+
+  assert_equals(window.bar, iframe);
+}, "A named property that matches an element that contains a nested " +
+  "browsing context should return the element if using id");
 </script>
 </body>


### PR DESCRIPTION
This updates the "named access on the window object" feature to only
return the nested browsing context (the `contentWindow`) when the
browsing context name is set. Since the browsing context name is not set
by the `id` property, the iframe element should be returned when the id
is the name being used.

In summary:

* `id`: return the element.
* `name`: return the WindowProxy.

This is based on findings from a Firefox issue:
https://bugzilla.mozilla.org/show_bug.cgi?id=1281604

Closes #1532