### PR TITLE
Implement the cloning steps for input elements

### DIFF
--- a/lib/jsdom/living/nodes/HTMLInputElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLInputElement-impl.js
@@ -7,7 +7,9 @@ const Event = require("../generated/Event");
 const mapper = require("../../utils").mapper;
 const createHTMLCollection = require("../../living/html-collection").create;
 const DOMException = require("../../web-idl/DOMException");
-const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
+const internalConstants = require("../helpers/internal-constants");
+const domSymbolTree = internalConstants.domSymbolTree;
+const cloningSteps = internalConstants.cloningSteps;
 const closest = require("../helpers/traversal").closest;
 const isDisabled = require("../helpers/form-controls").isDisabled;
 
@@ -379,6 +381,13 @@ class HTMLInputElementImpl extends HTMLElementImpl {
       throw new DOMException(DOMException.INDEX_SIZE_ERR);
     }
     this.setAttribute("size", String(value));
+  }
+
+  [cloningSteps](copy, node) {
+    copy._value = node._value;
+    copy._checkedness = node._checkedness;
+    copy._dirtyValue = node._dirtyValue;
+    copy._dirtyCheckedness = node._dirtyCheckedness;
   }
 }
 

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -66,7 +66,8 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "html/webappapis/timers/errors.html",
     "html/webappapis/timers/settimeout-setinterval-handles.html",
     "XMLHttpRequest/formdata-constructor.html",
-    "XMLHttpRequest/thrown-error-in-events.html"
+    "XMLHttpRequest/thrown-error-in-events.html",
+    "dom/nodes/Node-cloneNode-input.html"
   ]
   .forEach(runWebPlatformTest);
 });

--- a/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-input.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-input.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Node.cloneNode</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-node-clonenode">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+"use strict";
+
+test(() => {
+  const input = document.createElement("input");
+  input.value = "foo bar";
+
+  const copy = input.cloneNode();
+  assert_equals(copy.value, "foo bar");
+}, "input element 'value'");
+
+test(() => {
+  const input = document.createElement("input");
+  input.value = "foo bar";
+
+  const copy = input.cloneNode();
+  copy.setAttribute("value", "something else");
+
+  assert_equals(copy.value, "foo bar");
+}, "input element's dirty value is also cloned, so setAttribute doesn't affect the cloned input's value");
+
+test(() => {
+  const input = document.createElement("input");
+  input.setAttribute("type", "radio");
+  input.checked = true;
+
+  const copy = input.cloneNode();
+  assert_equals(copy.checked, true);
+}, "input element 'checkedness'");
+
+test(() => {
+  const input = document.createElement("input");
+  input.setAttribute("type", "radio");
+  input.checked = false;
+
+  const copy = input.cloneNode();
+  copy.setAttribute("checked", "checked");
+
+  assert_equals(copy.checked, false);
+}, "input element's dirty checkedness is also cloned, so setAttribute doesn't affect the cloned input's checkedness");
+
+</script>


### PR DESCRIPTION
This implements the cloning steps for input elements by copying over the
value, checkedness, dirty value, and dirty checkedness properties to the
cloned input.

Closes #946