### PR TITLE
Use strict Boolean comparisons for inline handler return values

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -252,10 +252,10 @@ function getListenerForInlineEventHandler(target, type) {
       }
 
       if (type === "mouseover" || isWindowError) {
-        if (returnValue===true) {
+        if (returnValue === true) {
           E.preventDefault();
         }
-      } else if (returnValue===false) {
+      } else if (returnValue === false) {
         E.preventDefault();
       }
     };

--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -252,10 +252,10 @@ function getListenerForInlineEventHandler(target, type) {
       }
 
       if (type === "mouseover" || isWindowError) {
-        if (returnValue) {
+        if (returnValue===true) {
           E.preventDefault();
         }
-      } else if (!returnValue) {
+      } else if (returnValue===false) {
         E.preventDefault();
       }
     };

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -63,7 +63,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "html/semantics/scripting-1/the-script-element/script-languages-dont-upstream.html",
     "html/semantics/scripting-1/the-script-element/changing-src.html",
     "html/semantics/tabular-data/the-table-element/parentless-props.html",
-    "html/webappapis/scripting/events/event-handler-processing-algorithm-non-booleans.html",
+    "html/webappapis/events/event-handler-processing-algorithm-non-booleans.html",
     "html/webappapis/timers/arguments.html",
     "html/webappapis/timers/errors.html",
     "html/webappapis/timers/settimeout-setinterval-handles.html",

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -63,6 +63,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "html/semantics/scripting-1/the-script-element/script-languages-dont-upstream.html",
     "html/semantics/scripting-1/the-script-element/changing-src.html",
     "html/semantics/tabular-data/the-table-element/parentless-props.html",
+    "html/webappapis/scripting/events/event-handler-processing-algorithm-non-booleans.html",
     "html/webappapis/timers/arguments.html",
     "html/webappapis/timers/errors.html",
     "html/webappapis/timers/settimeout-setinterval-handles.html",

--- a/test/web-platform-tests/to-upstream/html/webappapis/events/event-handler-processing-algorithm-non-booleans.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/events/event-handler-processing-algorithm-non-booleans.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Inline handlers returning non-boolean values</title>
+<link rel="author" title="Dave Methvin" href="mailto:dave@methvin.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(() => {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  const e = new MouseEvent("mouseover", { bubbles: true, cancelable: true });
+
+  assert_equals(e.defaultPrevented, false);
+  div.onmouseover = () => 42;
+  div.dispatchEvent(e);
+  assert_equals(e.defaultPrevented, false);
+
+}, "returning non-Boolean truthy from a mouseover inline event handler property does nothing");
+
+test(() => {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  const e = new MouseEvent("click", { bubbles: true, cancelable: true });
+
+  assert_equals(e.defaultPrevented, false);
+  div.onclick = () => undefined;
+  div.dispatchEvent(e);
+  assert_equals(e.defaultPrevented, false);
+
+}, "returning undefined from a click inline event handler does nothing");
+
+</script>


### PR DESCRIPTION
This avoids the event handler seeing an `undefined` as `false` and calling `preventDefault()`.

Fixes #1577