### PR TITLE
fix getElementsByTagName

### DIFF
--- a/lib/jsdom/living/html-collection.js
+++ b/lib/jsdom/living/html-collection.js
@@ -5,13 +5,28 @@ const idlUtils = require("./generated/utils");
 
 const privates = Symbol("HTMLCollection internal slots");
 
+// workaround for element keys that conflicts with property and method name
+const conflictKeys = {
+  length: 1,
+  item: 1,
+  namedItem: 1
+};
+
 class HTMLCollection {
   constructor(secret, element, query) {
     if (secret !== privates) {
       throw new TypeError("Invalid constructor");
     }
 
-    this[privates] = { element, query, snapshot: undefined, keys: [], length: 0, version: -1 };
+    this[privates] = {
+      element,
+      query,
+      snapshot: undefined,
+      version: -1,
+      keys: [],
+      length: 0,
+      conflictElements: {}    // elements with conflict keys
+    };
     updateHTMLCollection(this);
   }
 
@@ -28,6 +43,9 @@ class HTMLCollection {
   namedItem(name) {
     updateHTMLCollection(this);
 
+    if (name in conflictKeys) {
+      return this[privates].conflictElements[name] || null;
+    }
     if (Object.prototype.hasOwnProperty.call(this, name)) {
       return this[name];
     }
@@ -57,7 +75,11 @@ function resetHTMLCollectionTo(collection, els) {
 
   const keys = collection[privates].keys;
   for (let i = 0; i < keys.length; ++i) {
-    delete collection[keys[i]];
+    if (keys[i] in conflictKeys) {
+      delete collection[privates].conflictElements[keys[i]];
+    } else {
+      delete collection[keys[i]];
+    }
   }
   keys.length = 0;
 
@@ -71,20 +93,26 @@ function resetHTMLCollectionTo(collection, els) {
   function addIfAttrPresent(el, attr) {
     const impl = idlUtils.implForWrapper(el);
     const toTest = impl ? impl : el;
-    const value = getAttributeValue(toTest, attr);
+    const key = getAttributeValue(toTest, attr);
 
-    if (value === null || value === "") {
+    const wrapped = idlUtils.wrapperForImpl(el);
+
+    if (key === null || key === "") {
       return;
     }
 
     // Don't overwrite numeric indices with named ones.
-    const valueAsNumber = Number(value);
-    if (!Number.isNaN(valueAsNumber) && valueAsNumber >= 0) {
+    const keyAsNumber = Number(key);
+    if (!Number.isNaN(keyAsNumber) && keyAsNumber >= 0) {
       return;
     }
 
-    collection[value] = el;
-    keys.push(value);
+    if (key in conflictKeys) {
+      collection[privates].conflictElements[key] = wrapped ? wrapped : el;
+    } else {
+      collection[key] = wrapped ? wrapped : el;
+    }
+    keys.push(key);
   }
 }
 

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -10,7 +10,6 @@ const memoizeQuery = require("../../utils").memoizeQuery;
 const mapper = require("../../utils").mapper;
 const whatwgURL = require("whatwg-url");
 const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
-const createLiveNodeList = require("../node-list").createLive;
 const DOMException = require("../../web-idl/DOMException");
 const HtmlToDom = require("../../browser/htmltodom").HtmlToDom;
 const History = require("../generated/History");
@@ -487,7 +486,7 @@ class DocumentImpl extends NodeImpl {
       return false;
     }
 
-    return createLiveNodeList(this.ownerDocument || this, mapper(this, filterByTagName));
+    return createHTMLCollection(this.ownerDocument || this, mapper(this, filterByTagName));
   }
   get referrer() {
     return this._referrer || "";
@@ -796,7 +795,7 @@ DocumentImpl.prototype.getElementsByTagName = memoizeQuery(function (name) {
     }
     return false;
   }
-  return createLiveNodeList(this.documentElement || this, mapper(this, filterByTagName, true));
+  return createHTMLCollection(this.documentElement || this, mapper(this, filterByTagName, true));
 });
 
 DocumentImpl.prototype.getElementsByClassName = memoizeQuery(function getElementsByClassName(classNames) {

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -14,7 +14,7 @@ const mapper = require("../../utils").mapper;
 const clone = require("../node").clone;
 const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
 const resetDOMTokenList = require("../dom-token-list").reset;
-const createLiveNodeList = require("../node-list").createLive;
+const createHTMLCollection = require("../html-collection").create;
 const DOMException = require("../../web-idl/DOMException");
 const createDOMTokenList = require("../dom-token-list").create;
 const attrGenerated = require("../generated/Attr");
@@ -469,7 +469,7 @@ ElementImpl.prototype.getElementsByTagName = memoizeQuery(function (name) {
 
     return false;
   }
-  return createLiveNodeList(this._ownerDocument || this, mapper(this, filterByTagName, true));
+  return createHTMLCollection(this._ownerDocument || this, mapper(this, filterByTagName, true));
 });
 
 ElementImpl.prototype.getElementsByTagNameNS = memoizeQuery(function (/* String */ namespaceURI,
@@ -486,7 +486,7 @@ ElementImpl.prototype.getElementsByTagNameNS = memoizeQuery(function (/* String 
     return false;
   }
 
-  return createLiveNodeList(this.ownerDocument || this, mapper(this, filterByTagName));
+  return createHTMLCollection(this.ownerDocument || this, mapper(this, filterByTagName));
 });
 
 ElementImpl.prototype.getElementsByClassName = memoizeQuery(function getElementsByClassName(classNames) {

--- a/test/living-dom/html-collection.js
+++ b/test/living-dom/html-collection.js
@@ -1,0 +1,52 @@
+"use strict";
+const jsdom = require("../..");
+
+exports["HTMLCollection: access by indices"] = t => {
+  const document = jsdom.jsdom("<p id='p1'>1</p><p id='p2'>2</p><p id='p3'>3</p>");
+  const collection = document.getElementsByTagName("p");
+
+  t.strictEqual(collection[0], document.getElementById("p1"));
+  t.strictEqual(collection[2], document.getElementById("p3"));
+
+  t.done();
+};
+
+exports["HTMLCollection: access by id"] = t => {
+  const document = jsdom.jsdom("<p id='p1'>1</p><p id='p2'>2</p><p id='p3'>3</p>");
+  const collection = document.getElementsByTagName("p");
+
+  t.strictEqual(collection.p1, document.getElementById("p1"));
+  t.strictEqual(collection.p3, document.getElementById("p3"));
+
+  t.done();
+};
+
+exports["HTMLCollection: access by name"] = t => {
+  const document = jsdom.jsdom("<p id='e1' name='p1'>1</p><p id='e2' name='p2'>2</p><p>3</p>");
+  const collection = document.getElementsByTagName("p");
+
+  t.strictEqual(collection.p1, document.getElementById("e1"));
+  t.strictEqual(collection.p2, document.getElementById("e2"));
+
+  t.done();
+};
+
+exports["HTMLCollection: conflict keys"] = t => {
+  const document = jsdom.jsdom("<p id='length'>1</p><p>2</p><p>3</p>");
+  const collection = document.getElementsByTagName("p");
+
+  t.strictEqual(collection.length, 3);
+
+  t.done();
+};
+
+
+exports["HTMLCollection: conflict keys accessible by namedItem()"] = t => {
+  const document = jsdom.jsdom("<p id='length'>1</p><p id='namedItem'>2</p><p>3</p>");
+  const collection = document.getElementsByTagName("p");
+
+  t.strictEqual(collection.namedItem("length"), document.getElementById("length"));
+  t.strictEqual(collection.namedItem("namedItem"), document.getElementById("namedItem"));
+
+  t.done();
+};

--- a/test/runner
+++ b/test/runner
@@ -47,6 +47,7 @@ var files = [
   "living-dom/node-iterator.js",
   "living-dom/parent-node.js",
   "living-dom/non-document-type-child-node.js",
+  "living-dom/html-collection.js",
   "living-html/cookie.js",
   "living-html/current-script.js",
   "living-html/htmlanchorelement.js",


### PR DESCRIPTION
in latest standard, getElementsBy* should return `HTMLCollection`

reference: https://dom.spec.whatwg.org/#concept-getelementsbytagname

`createLiveNodeList` is removed because it is no longer used in the file.