### PR TITLE
Kill WPT server with SIGINT instead of SIGTERM

### DIFF
--- a/test/web-platform-tests/run-web-platform-test.js
+++ b/test/web-platform-tests/run-web-platform-test.js
@@ -57,7 +57,7 @@ module.exports = function (testDir) {
     pollForServer(() => urlPrefix).then(serverHasStarted);
 
     process.on("exit", () => {
-      python.kill();
+      python.kill("SIGINT");
     });
   });
 


### PR DESCRIPTION
After running `npm run test`, several python processes are left behind. This is because the WPT web server isn't shutdown properly.

Python doesn't register a default handler for SIGTERM and it doesn't run `__exit__()` methods of context managers when it gets that signal. Using SIGINT avoids this problem

I've tested this on Linux and Windows. It doesn't make a difference on Windows but it doesn't break anything either