### PR TITLE
Compatibility with ZoneJS (and Angular 2)

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -237,7 +237,7 @@ const wrappedListener = Symbol("inline event listener wrapper");
 function getListenerForInlineEventHandler(target, type) {
   const callback = target["on" + type];
 
-  if (!callback) { // TODO event handlers: only check null
+  if (!callback || callback === true) { // TODO event handlers: only check null
     return null;
   }
 

--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -151,9 +151,9 @@ module.exports = function createXMLHttpRequest(window) {
         error: "",
         uploadComplete: true,
         abortError: false,
-        cookieJar: this._ownerDocument._cookieJar
+        cookieJar: this._ownerDocument._cookieJar,
+        onreadystatechange: null
       };
-      this.onreadystatechange = null;
     }
     get readyState() {
       return this[xhrSymbols.properties].readyState;


### PR DESCRIPTION
I'm really not sure about the code itself, as I'm new to the source of jsdom. It's more about opening the discussion for working on the Angular 2 compatibility and showing that the gap is really thin.

I'm not a huge fan of ZoneJS but I have to work with Angular 2 and jsdom is currently not able to make it works because of ZoneJS.

After some digging, I found that there is only two blocking points for jsdom to work with ZoneJS : `onreadystatechange` to be writable and events callback which seems to happend to be valued at `true` instead of a function.

This PR contains the fixes I use to make Angular 2 apps fully working. I used my branch on my project and it works.

It could be a workaround or a fix for https://github.com/tmpvar/jsdom/issues/1513