### PR TITLE
Defer loading "request" module

### DIFF
--- a/lib/jsdom/browser/resource-loader.js
+++ b/lib/jsdom/browser/resource-loader.js
@@ -3,9 +3,8 @@
 const parseContentType = require("content-type-parser");
 const sniffHTMLEncoding = require("html-encoding-sniffer");
 const whatwgEncoding = require("whatwg-encoding");
-const parseDataUrl = require("../utils").parseDataUrl;
+const utils = require("../utils");
 const fs = require("fs");
-const request = require("request");
 const documentBaseURLSerialized = require("../living/helpers/document-base-url").documentBaseURLSerialized;
 const NODE_TYPE = require("../living/node-type");
 
@@ -92,7 +91,7 @@ exports.readFile = function (filePath, options, callback) {
 function readDataUrl(dataUrl, options, callback) {
   const defaultEncoding = options.defaultEncoding;
   try {
-    const data = parseDataUrl(dataUrl);
+    const data = utils.parseDataUrl(dataUrl);
     // If default encoding does not exist, pass on binary data.
     if (defaultEncoding) {
       const contentType = parseContentType(data.type) || parseContentType("text/plain");
@@ -124,6 +123,7 @@ function readDataUrl(dataUrl, options, callback) {
 // Therefore, to pass our cookie jar to the request, we need to create
 // request's wrapper and monkey patch it with our jar.
 function wrapCookieJarForRequest(cookieJar) {
+  const request = utils.getRequestModule();
   const jarWrapper = request.jar();
   jarWrapper._jar = cookieJar;
   return jarWrapper;
@@ -156,6 +156,7 @@ exports.enqueue = function (element, resourceUrl, callback) {
 };
 
 exports.download = function (url, options, callback) {
+  const request = utils.getRequestModule();
   const requestOptions = {
     pool: options.pool,
     agent: options.agent,

--- a/lib/jsdom/living/xhr-utils.js
+++ b/lib/jsdom/living/xhr-utils.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const request = require("request");
 const EventEmitter = require("events").EventEmitter;
 const fs = require("fs");
 const URL = require("whatwg-url").URL;
@@ -9,6 +8,7 @@ const utils = require("../utils");
 const xhrSymbols = require("./xmlhttprequest-symbols");
 
 function wrapCookieJarForRequest(cookieJar) {
+  const request = utils.getRequestModule();
   const jarWrapper = request.jar();
   jarWrapper._jar = cookieJar;
   return jarWrapper;
@@ -49,6 +49,7 @@ exports.simpleHeaders = simpleHeaders;
 // return a "request" client object or an event emitter matching the same behaviour for unsupported protocols
 // the callback should be called with a "request" response object or an event emitter matching the same behaviour too
 exports.createClient = function createClient(xhr) {
+  const request = utils.getRequestModule();
   const flag = xhr[xhrSymbols.flag];
   const properties = xhr[xhrSymbols.properties];
   const urlObj = new URL(flag.uri);

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -240,3 +240,11 @@ try {
 } catch (e) {
   exports.Canvas = null;
 }
+
+let requestModule;
+
+exports.getRequestModule = function getRequestModule() {
+  // Defer loading "request" until it's needed since it is an exceptionally big
+  // dependency.
+  return requestModule || require("request");
+};


### PR DESCRIPTION
`request` is `jsdom`'s largest dependency, accounting for ~20% of its load time. This PR adds a utility to defer requiring the `request` module until it's actually used - reducing load times by ~90ms. For many use cases (like [React](https://facebook.github.io/react/docs/test-utils.html) tests using [Jest](https://facebook.github.io/jest/)), XHR support is not needed (so neither is `request`).

```
# before
$ for i in {1..5}; do node -p "s=Date.now();require('./');Date.now()-s"; done
480
488
478
479
477

# after
$ for i in {1..5}; do node -p "s=Date.now();require('./');Date.now()-s"; done
395
398
381
385
390
```

cc: @cpojer 