### PR TITLE
✏️ ✅ 🚀🔧💄 [Fix #1642] `document.createCDATASection` missing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,6 +18,7 @@ test/level2
 test/level3
 test/sizzle
 test/web-platform-tests/tests
+test/web-platform-tests/to-upstream/dom/nodes/Document-createComment-createTextNode.js
 test/web-platform-tests/to-upstream/domparsing/DOMParser-dont-upstream.html
 test/window/files
 test/window/frame.js

--- a/benchmark/dom/construction.js
+++ b/benchmark/dom/construction.js
@@ -29,3 +29,6 @@ exports.createProcessingInstruction = suite(document => {
   document.createProcessingInstruction("php", "echo 123; ?");
 });
 
+exports.createCDATASection = suite(document => {
+  document.createCDATASection("foo");
+});

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -9,11 +9,12 @@ exports.DocumentFragment = require("./generated/DocumentFragment").interface;
 exports.Document = exports.HTMLDocument = require("./generated/Document").interface;
 exports.XMLDocument = require("./generated/XMLDocument").interface;
 exports.CharacterData = require("./generated/CharacterData").interface;
+exports.Text = require("./generated/Text").interface;
+exports.CDATASection = require("./generated/CDATASection").interface;
+exports.ProcessingInstruction = require("./generated/ProcessingInstruction").interface;
 exports.Comment = require("./generated/Comment").interface;
 exports.DocumentType = require("./generated/DocumentType").interface;
 exports.DOMImplementation = require("./generated/DOMImplementation").interface;
-exports.ProcessingInstruction = require("./generated/ProcessingInstruction").interface;
-exports.Text = require("./generated/Text").interface;
 
 exports.Event = require("./generated/Event").interface;
 exports.CustomEvent = require("./generated/CustomEvent").interface;

--- a/lib/jsdom/living/node.js
+++ b/lib/jsdom/living/node.js
@@ -41,6 +41,10 @@ module.exports.clone = function (core, node, document, cloneChildren) {
       copy = document.createTextNode(node._data);
       break;
 
+    case NODE_TYPE.CDATA_SECTION_NODE:
+      copy = document.createCDATASection(node._data);
+      break;
+
     case NODE_TYPE.COMMENT_NODE:
       copy = document.createComment(node._data);
       break;

--- a/lib/jsdom/living/nodes/CDATASection-impl.js
+++ b/lib/jsdom/living/nodes/CDATASection-impl.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const TextImpl = require("./Text-impl").implementation;
+const NODE_TYPE = require("../node-type");
+
+class CDATASectionImpl extends TextImpl {
+  constructor(args, privateData) {
+    super(args, privateData);
+
+    this.nodeType = NODE_TYPE.CDATA_SECTION_NODE;
+  }
+}
+
+module.exports = {
+  implementation: CDATASectionImpl
+};

--- a/lib/jsdom/living/nodes/CDATASection.idl
+++ b/lib/jsdom/living/nodes/CDATASection.idl
@@ -1,0 +1,4 @@
+[Constructor(optional DOMString data = ""),
+ Exposed=Window]
+interface CDATASection : Text {
+};

--- a/lib/jsdom/living/nodes/CDATASection.idl
+++ b/lib/jsdom/living/nodes/CDATASection.idl
@@ -1,4 +1,3 @@
-[Constructor(optional DOMString data = ""),
- Exposed=Window]
+[Exposed=Window]
 interface CDATASection : Text {
 };

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -648,18 +648,15 @@ class DocumentImpl extends NodeImpl {
 
   // https://dom.spec.whatwg.org/#dom-document-createcdatasection
   createCDATASection(data) {
+    if (this._parsingMode === "html") {
+      throw new DOMException(DOMException.NOT_SUPPORTED_ERR,
+        "Cannot create CDATA sections in HTML documents");
+    }
+
     if (data.includes("]]>")) {
       throw new DOMException(DOMException.INVALID_CHARACTER_ERR,
         "CDATA section data cannot contain the string \"]]>\"");
     }
-
-// TODO: Check for html (encoding) of document
-//  if (HTML document) {
-//     throw new DOMException(DOMException.NOT_SUPPORTED_ERROR,
-//      "Processing instruction data cannot contain the string \"?>\"");
-    // https://dom.spec.whatwg.org/#html-document
-    // https://dom.spec.whatwg.org/#concept-document-type
-//  }
 
     return CDATASection.createImpl([], {
       core: this._core,

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -29,6 +29,7 @@ const listOfElementsWithNamespaceAndLocalName = require("../node").listOfElement
 const listOfElementsWithClassNames = require("../node").listOfElementsWithClassNames;
 const Comment = require("../generated/Comment");
 const ProcessingInstruction = require("../generated/ProcessingInstruction");
+const CDATASection = require("../generated/CDATASection");
 const Text = require("../generated/Text");
 const DocumentFragment = require("../generated/DocumentFragment");
 const DOMImplementation = require("../generated/DOMImplementation");
@@ -641,6 +642,28 @@ class DocumentImpl extends NodeImpl {
       core: this._core,
       ownerDocument: this,
       target,
+      data
+    });
+  }
+
+  // https://dom.spec.whatwg.org/#dom-document-createcdatasection
+  createCDATASection(data) {
+    if (data.includes("]]>")) {
+      throw new DOMException(DOMException.INVALID_CHARACTER_ERR,
+        "CDATA section data cannot contain the string \"]]>\"");
+    }
+
+// TODO: Check for html (encoding) of document
+//  if (HTML document) {
+//     throw new DOMException(DOMException.NOT_SUPPORTED_ERROR,
+//      "Processing instruction data cannot contain the string \"?>\"");
+    // https://dom.spec.whatwg.org/#html-document
+    // https://dom.spec.whatwg.org/#concept-document-type
+//  }
+
+    return CDATASection.createImpl([], {
+      core: this._core,
+      ownerDocument: this,
       data
     });
   }

--- a/lib/jsdom/living/nodes/Document.idl
+++ b/lib/jsdom/living/nodes/Document.idl
@@ -21,6 +21,7 @@ interface Document : Node {
   [NewObject] Element createElementNS(DOMString? namespace, DOMString qualifiedName);
   [NewObject] DocumentFragment createDocumentFragment();
   [NewObject] Text createTextNode(DOMString data);
+  [NewObject] CDATASection createCDATASection(DOMString data);
   [NewObject] Comment createComment(DOMString data);
   [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
 

--- a/lib/jsdom/living/nodes/Node-impl.js
+++ b/lib/jsdom/living/nodes/Node-impl.js
@@ -19,6 +19,7 @@ function isObsoleteNodeType(node) {
   return node.nodeType === NODE_TYPE.ENTITY_NODE ||
     node.nodeType === NODE_TYPE.ENTITY_REFERENCE_NODE ||
     node.nodeType === NODE_TYPE.NOTATION_NODE ||
+//  node.nodeType === NODE_TYPE.ATTRIBUTE_NODE ||  // this is missing how do we handle?
     node.nodeType === NODE_TYPE.CDATA_SECTION_NODE;
 }
 
@@ -89,6 +90,7 @@ class NodeImpl extends EventTargetImpl {
   get nodeValue() {
     if (this.nodeType === NODE_TYPE.TEXT_NODE ||
       this.nodeType === NODE_TYPE.COMMENT_NODE ||
+      this.nodeType === NODE_TYPE.CDATA_SECTION_NODE ||
       this.nodeType === NODE_TYPE.PROCESSING_INSTRUCTION_NODE) {
       return this._data;
     }
@@ -99,6 +101,7 @@ class NodeImpl extends EventTargetImpl {
   set nodeValue(value) {
     if (this.nodeType === NODE_TYPE.TEXT_NODE ||
       this.nodeType === NODE_TYPE.COMMENT_NODE ||
+      this.nodeType === NODE_TYPE.CDATA_SECTION_NODE ||
       this.nodeType === NODE_TYPE.PROCESSING_INSTRUCTION_NODE) {
       this.replaceData(0, this.length, value);
     }
@@ -114,6 +117,8 @@ class NodeImpl extends EventTargetImpl {
         return this.tagName;
       case NODE_TYPE.TEXT_NODE:
         return "#text";
+      case NODE_TYPE.CDATA_SECTION_NODE:
+        return "#cdata-section";
       case NODE_TYPE.PROCESSING_INSTRUCTION_NODE:
         return this.target;
       case NODE_TYPE.COMMENT_NODE:
@@ -432,7 +437,7 @@ class NodeImpl extends EventTargetImpl {
       case NODE_TYPE.ELEMENT_NODE:
         text = "";
         for (const child of domSymbolTree.treeIterator(this)) {
-          if (child.nodeType === NODE_TYPE.TEXT_NODE) {
+          if (child.nodeType === NODE_TYPE.TEXT_NODE || child.nodeType === NODE_TYPE.CDATA_SECTION_NODE) {
             text += child.nodeValue;
           }
         }

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -1828,6 +1828,49 @@ describe("level1/core", () => {
 
   /**
    *
+   The "createTextNode(data)" method
+   creates a CDATASection node
+   given the specfied string.
+   Retrieve the entire DOM document and invoke its
+   "createCDATASection(data)" method.
+   It should create a new CDATASection node
+   whos "data" is the specified string
+   The data and type are retrieved and output.
+   The NodeName and NodeType are also checked.
+
+   * @author NIST
+   * @author Mary Brady
+   * @author Curt Arnold
+   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#
+   * @see http://lists.w3.org/Archives/Public/www-dom-ts/2001Apr/0020.html
+   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-667469212
+   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
+   */
+  specify("documentcreatecdatasectionnode", () => {
+    let doc;
+    let newCDATASection;
+    let newCDATASectionName;
+    let newCDATASectionValue;
+    let newCDATASectionType;
+
+    doc = staff.staff();
+
+    newCDATASection = doc.createCDATASection("This is a new CDATASection node");
+
+    assert.notEqual (newCDATASection, null, "createCDATASectionNotNull");
+    newCDATASectionName = newCDATASection.nodeName;
+
+    assert.equal(newCDATASectionName, "#cdata-section", "name");
+    newCDATASectionValue = newCDATASection.nodeValue;
+
+    assert.equal(newCDATASectionValue, "This is a new CDATASection node", "value");
+    newCDATASectionType = newCDATASection.nodeType;
+
+    assert.equal(newCDATASectionType, 4, "type");
+  });
+
+  /**
+   *
    The "createTextNode(data)" method creates a Text node
    given the specfied string.
    Retrieve the entire DOM document and invoke its

--- a/test/level1/core.js
+++ b/test/level1/core.js
@@ -1828,49 +1828,6 @@ describe("level1/core", () => {
 
   /**
    *
-   The "createTextNode(data)" method
-   creates a CDATASection node
-   given the specfied string.
-   Retrieve the entire DOM document and invoke its
-   "createCDATASection(data)" method.
-   It should create a new CDATASection node
-   whos "data" is the specified string
-   The data and type are retrieved and output.
-   The NodeName and NodeType are also checked.
-
-   * @author NIST
-   * @author Mary Brady
-   * @author Curt Arnold
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#
-   * @see http://lists.w3.org/Archives/Public/www-dom-ts/2001Apr/0020.html
-   * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core#ID-667469212
-   * @see http://www.w3.org/Bugs/Public/show_bug.cgi?id=249
-   */
-  specify("documentcreatecdatasectionnode", () => {
-    let doc;
-    let newCDATASection;
-    let newCDATASectionName;
-    let newCDATASectionValue;
-    let newCDATASectionType;
-
-    doc = staff.staff();
-
-    newCDATASection = doc.createCDATASection("This is a new CDATASection node");
-
-    assert.notEqual (newCDATASection, null, "createCDATASectionNotNull");
-    newCDATASectionName = newCDATASection.nodeName;
-
-    assert.equal(newCDATASectionName, "#cdata-section", "name");
-    newCDATASectionValue = newCDATASection.nodeValue;
-
-    assert.equal(newCDATASectionValue, "This is a new CDATASection node", "value");
-    newCDATASectionType = newCDATASection.nodeType;
-
-    assert.equal(newCDATASectionType, 4, "type");
-  });
-
-  /**
-   *
    The "createTextNode(data)" method creates a Text node
    given the specfied string.
    Retrieve the entire DOM document and invoke its

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -14,6 +14,8 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "dom/events/EventTarget-add-remove-listener.html",
     "dom/events/EventTarget-prototype-constructor.html",
     "dom/events/EventTarget-this-of-listener.html",
+    "dom/nodes/Document-createCDATASection.html",
+    "dom/nodes/Document-createCDATASection.xhtml",
     "dom/nodes/Element-hasAttribute.html",
     "dom/nodes/Element-removeAttribute.html",
     "dom/nodes/Element-setAttribute.html",

--- a/test/web-platform-tests/to-upstream/dom/nodes/Document-createCDATASection.html
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Document-createCDATASection.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>document.createCDATASection must throw in HTML documents</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-document-createcdatasection">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+assert_throws("NotSupportedError", () => document.createCDATASection("foo"));
+
+done();
+</script>

--- a/test/web-platform-tests/to-upstream/dom/nodes/Document-createCDATASection.xhtml
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Document-createCDATASection.xhtml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8"/>
+  <title>document.createCDATASection</title>
+  <link rel="help" href="https://dom.spec.whatwg.org/#dom-document-createcdatasection"/>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="Document-createComment-createTextNode.js"></script>
+</head>
+
+<body>
+  <script>
+  "use strict";
+  test_create("createCDATASection", CDATASection, 4, "#cdata-section");
+
+  test(() => {
+    assert_throws("InvalidCharacterError", () => document.createCDATASection(" ]]>  "));
+  }, "Creating a CDATA section containing the string \"]]>\" must throw");
+  </script>
+</body>
+</html>

--- a/test/web-platform-tests/to-upstream/dom/nodes/Document-createComment-createTextNode.js
+++ b/test/web-platform-tests/to-upstream/dom/nodes/Document-createComment-createTextNode.js
@@ -1,0 +1,22 @@
+function test_create(method, iface, nodeType, nodeName) {
+  ["\u000b", "a -- b", "a-", "-b", null, undefined].forEach(function(value) {
+    test(function() {
+      var c = document[method](value);
+      var expected = String(value);
+      assert_true(c instanceof iface);
+      assert_true(c instanceof CharacterData);
+      assert_true(c instanceof Node);
+      assert_equals(c.ownerDocument, document);
+      assert_equals(c.data, expected, "data");
+      assert_equals(c.nodeValue, expected, "nodeValue");
+      assert_equals(c.textContent, expected, "textContent");
+      assert_equals(c.length, expected.length);
+      assert_equals(c.nodeType, nodeType);
+      assert_equals(c.nodeName, nodeName);
+      assert_equals(c.hasChildNodes(), false);
+      assert_equals(c.childNodes.length, 0);
+      assert_equals(c.firstChild, null);
+      assert_equals(c.lastChild, null);
+    }, method + "(" + format_value(value) + ")");
+  });
+}


### PR DESCRIPTION
# 🔧 Closes #1642  
`document.createCDATASection` missing

## 📓 Tasks  (WIP until questions answered)
  - [x] 🚀 Benchmark for createCDATASection
  - [x] ✅ Specification createCDATASection
  - [x] ✏️ CDATASection IDL
  - [x] ✏️ Document IDL
  - [ ] 🔧 CDATASection Implementation
    - [ ] Throw NotSupportedError if document is not HTML https://github.com/snuggs/jsdom/blob/e6714f892af32c187ecfc9bd7a5e639b9bb019b8/lib/jsdom/living/nodes/Document-impl.js#L618
  - [x] 🔧(update) Document Implementation
  - [x] 🔧(update) Node Implementation
  - [x] 💄 Update Authors 😏

## ❓ Questions
1. Says in the spec _"Text that should not be parsed by a parser"_ Where should we test _(i.e. <> ?)_ ?
2. Spec MUST throw exception if NOT html doc. States should be able to derive HTML doc by encoding. How would we like to do this?
    - https://dom.spec.whatwg.org/#dom-document-createcdatasection
3. Any idea why MDN says this is deprecated? I DO realize whatwg != w3.org but double checking.
    - https://www.w3.org/TR/dom/#cdatasection
    - https://developer.mozilla.org/en-US/docs/Web/API/CDATASection

4. Does this mean we have to update web-platform-tests? :face_with_head_bandage:
    - (current submodule sha @ c51a023) https://github.com/w3c/web-platform-tests/blob/c51a023bcdf0bf800e46ccfd002a9cf7fcf4f65a/html/dom/interfaces.html#L240
    - (current submodule sha @ c51a023) https://github.com/w3c/web-platform-tests/blob/56ea52b8668ceee63ec196c59dd11ad7797e4f0d/dom/interfaces.html#L279

5. I notice only level1 tests are run. 'sup with _level2/3_? This is where may `CDATASection`s are located _(level3)_ 
    - https://github.com/tmpvar/jsdom/commit/baddb0000bb33814692d9680dd06f2a47404b300

6. Why is there _lib/(level2,level3,living)_ and _test/(level1, level2,level3,living-dom,living-html)_ I'm a little lost.

7. should we be testing in _staffNS.xml.js_? Where else should we test?
    - https://github.com/tmpvar/jsdom/blob/master/test/level1/core/files/staff.xml.js#L29
    - (Full repo search listing of _"CDATA"_) - https://github.com/tmpvar/jsdom/search?p=1&q=CDATA&utf8=%E2%9C%93

### 🙏 Thanks in advance @domenic !!