### PR TITLE
Rewrite Blob implementation

### DIFF
--- a/lib/jsdom/living/blob.js
+++ b/lib/jsdom/living/blob.js
@@ -1,37 +1,55 @@
 "use strict";
 
+const conversions = require("webidl-conversions");
 const blobSymbols = require("./blob-symbols");
 
+function getType(type) {
+  if (type === null || type === undefined) {
+    return "";
+  }
+
+  type = conversions.DOMString(type); // eslint-disable-line new-cap
+  if (/[^\u0020-\u007E]/.test(type)) {
+    type = "";
+  }
+  return type.toLowerCase();
+}
+
 module.exports = class Blob {
-  constructor() {
-    if (!(this instanceof Blob)) {
-      throw new TypeError("DOM object constructor cannot be called as a function.");
+  constructor(blobParts = undefined, options = undefined) {
+    this[blobSymbols.closed] = false;
+    this[blobSymbols.type] = "";
+
+    if (arguments.length === 0) {
+      this[blobSymbols.buffer] = new Buffer(0);
+      return;
     }
-    const parts = arguments[0];
-    const properties = arguments[1];
-    if (arguments.length > 0) {
-      if (!parts || typeof parts !== "object" || parts instanceof Date || parts instanceof RegExp) {
-        throw new TypeError("Blob parts must be objects that are not Dates or RegExps");
-      }
+
+    if (!Array.isArray(blobParts) && blobParts[Symbol.iterator]) {
+      blobParts = Array.from(blobParts);
+    }
+    if (!Array.isArray(blobParts)) {
+      throw new TypeError("Blob parts must be an iterable object");
     }
 
     const buffers = [];
 
-    if (parts) {
-      const l = Number(parts.length);
-      for (let i = 0; i < l; i++) {
-        const part = parts[i];
+    if (blobParts) {
+      const length = blobParts.length;
+      for (let i = 0; i < length; i++) {
+        const element = blobParts[i];
         let buffer;
-        if (part instanceof ArrayBuffer) {
-          buffer = new Buffer(new Uint8Array(part));
-        } else if (part instanceof Blob) {
-          buffer = part[blobSymbols.buffer];
-        } else if (ArrayBuffer.isView(part)) {
-          buffer = new Buffer(new Uint8Array(part.buffer, part.byteOffset, part.byteLength));
-        } else if (part instanceof Buffer) {
-          buffer = part;
+        if (element instanceof Buffer) {
+          buffer = element;
+        } else if (ArrayBuffer.isView(element)) {
+          buffer = new Buffer(new Uint8Array(element.buffer, element.byteOffset, element.byteLength));
+        } else if (element instanceof ArrayBuffer) {
+          buffer = new Buffer(new Uint8Array(element));
+        } else if (element instanceof Blob) {
+          buffer = element[blobSymbols.buffer];
         } else {
-          buffer = new Buffer(typeof part === "string" ? part : String(part));
+          const str = typeof element === "string" ? element : String(element);
+          buffer = new Buffer(conversions.USVString(str));
         }
         buffers.push(buffer);
       }
@@ -39,14 +57,15 @@ module.exports = class Blob {
 
     this[blobSymbols.buffer] = Buffer.concat(buffers);
 
-    this[blobSymbols.type] = properties && properties.type ? String(properties.type).toLowerCase() : "";
-    if (!this[blobSymbols.type].match(/^[\u0020-\u007E]*$/)) {
-      this[blobSymbols.type] = "";
+    if (options !== undefined && options !== null && typeof options !== "object") {
+      throw new TypeError("Blob options must be undefined, null, or an object");
     }
-    this[blobSymbols.closed] = false;
+    if (options) {
+      this[blobSymbols.type] = getType(options.type);
+    }
   }
   get size() {
-    return this[blobSymbols.buffer].length;
+    return this[blobSymbols.closed] ? 0 : this[blobSymbols.buffer].length;
   }
   get type() {
     return this[blobSymbols.type];
@@ -54,14 +73,44 @@ module.exports = class Blob {
   get isClosed() {
     return this[blobSymbols.closed];
   }
-  slice() {
+  slice(start = undefined, end = undefined, contentType = undefined) {
+    if (start !== undefined) {
+      start = conversions["long long"](start, { clamp: true });
+    }
+    if (end !== undefined) {
+      end = conversions["long long"](end, { clamp: true });
+    }
+
+    const size = this.size;
+
+    let relativeStart;
+    let relativeEnd;
+    if (start === undefined) {
+      relativeStart = 0;
+    } else if (start < 0) {
+      relativeStart = Math.max(size + start, 0);
+    } else {
+      relativeStart = Math.min(start, size);
+    }
+    if (end === undefined) {
+      relativeEnd = size;
+    } else if (end < 0) {
+      relativeEnd = Math.max(size + end, 0);
+    } else {
+      relativeEnd = Math.min(end, size);
+    }
+
+    const span = Math.max(relativeEnd - relativeStart, 0);
+
     const buffer = this[blobSymbols.buffer];
     const slicedBuffer = buffer.slice(
-      arguments[0] || 0,
-      arguments[1] || this.size
+      relativeStart,
+      relativeStart + span
     );
-    const blob = new Blob([], { type: arguments[2] || this.type });
+    const blob = new Blob();
     blob[blobSymbols.buffer] = slicedBuffer;
+    blob[blobSymbols.closed] = this[blobSymbols.closed];
+    blob[blobSymbols.type] = getType(contentType);
     return blob;
   }
   close() {


### PR DESCRIPTION
Don't let the diffstat fool you: there are a lot of things changed by this PR. In fact, there are so many changes, I feel a `<details>` is justified.

This PR isn't exactly completed. New Web Platform Tests still need to be written for many things, but especially

- `size` when the blob is closed
- `slice()` with negative arguments
- inheritance of type (not inherited) and readability state (inherited) in `slice()`

A lot of other changes are mainly just routine Web IDL compliance improvements.

<details><summary>Detailed changelog</summary>

#### General
For functions, I now declare all the optional function arguments inside the parentheses with default values of `undefined` if not specified. This is easier to read (for me anyway), while keeping the function arity intact.

#### Constructor
> https://w3c.github.io/FileAPI/#constructorBlob

- More closely followed step-by-step correspondence with the spec
  - That does indeed mean that some variable names are changed to the ones used in the spec
- Extraneous `this instanceof Blob` test dropped
  - The test is implicit for Harmony classes
- Any iterable can now be used as `blobParts`
  - https://heycam.github.io/webidl/#es-to-sequence
- Switch on element in `blobParts` is reordered
  - Previously the branch for `Buffer` was dead code as `ArrayBuffer.isView(buffer)` is always true
  - Now the test for `Buffer` is in first, followed by the order dictated by the spec (except for `USVString`, which is a catch-all case)
  - https://w3c.github.io/FileAPI/#constructorBlob
- The conversion from ES `String` to IDL `USVString` is enforced using webidl-conversions
  - https://w3c.github.io/FileAPI/#typedefdef-blobpart
- Special checks for `RegExp` and `Date` for `options` are removed
  - As they've been removed from the spec
  - https://heycam.github.io/webidl/#es-to-dictionary
- The check for non-ASCII-printable characters is refactored into a separate function so that it can be used in `slice`
  - The regex is also simplified

#### `size` property
> https://w3c.github.io/FileAPI/#dfn-size

- Return 0 when the blob is closed.

#### slice()
> https://w3c.github.io/FileAPI/#dfn-slice

- Negative `start` and `end` are now supported
  - https://w3c.github.io/FileAPI/#dfn-start
  - https://w3c.github.io/FileAPI/#dfn-end
- `start` and `end` are now explicitly converted to number and clamped to `long long`
  - Some nonsensical code now works as expected (e.g. `slice('abc') === slice(0)`)
  - https://w3c.github.io/FileAPI/#ref-for-dfn-slice-1
- Do not inherit type from parent blob
  - https://w3c.github.io/FileAPI/#dfn-contentTypeBlob
- `type` is now directly filled in `slice` instead of going through the constructor
  - https://w3c.github.io/FileAPI/#dfn-contentTypeBlob
- Inherit readability state from parent
  - https://w3c.github.io/FileAPI/#ref-for-readabilityState-8

</details>