### PR TITLE
Check for client.abort function before executing.

### DIFF
--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -362,7 +362,7 @@ module.exports = function createXMLHttpRequest(window) {
       properties.timeoutFn = null;
       properties.timeoutStart = 0;
       const client = properties.client;
-      if (client) {
+      if (client && typeof client.abort === "function") {
         client.abort();
       }
       if (!(this.readyState === XMLHttpRequest.UNSENT ||


### PR DESCRIPTION
line is now identical to the open() method, on #435 in the same file.