### PR TITLE
bugfix: #1662 XHR throws before issuing CORS application/json POST re…

### DIFF
--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -905,7 +905,7 @@ module.exports = function createXMLHttpRequest(window) {
 
     let total = 0;
     let lengthComputable = false;
-    const length = parseInt(xhrUtils.getRequestHeader(client.headers, "content-length"));
+    const length = client.headers && parseInt(xhrUtils.getRequestHeader(client.headers, "content-length"));
     if (length) {
       total = length;
       lengthComputable = true;

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -78,7 +78,8 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "html/webappapis/timers/errors.html",
     "html/webappapis/timers/settimeout-setinterval-handles.html",
     "XMLHttpRequest/formdata-constructor.html",
-    "XMLHttpRequest/thrown-error-in-events.html"
+    "XMLHttpRequest/thrown-error-in-events.html",
+    "XMLHttpRequest/send-authentication-cors-post.htm"
   ]
   .forEach(runWebPlatformTest);
 });

--- a/test/web-platform-tests/to-upstream/XMLHttpRequest/send-authentication-cors-post.htm
+++ b/test/web-platform-tests/to-upstream/XMLHttpRequest/send-authentication-cors-post.htm
@@ -1,35 +1,35 @@
 <!doctype html>
-<html>
-  <head>
-    <title>XMLHttpRequest: send() - CORS POST basic authenticated request</title>
-    <link rel="author" title="Maxim Vorobjov" href="mailto:maxim.vorobjov@gmail.com">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="following::ol[1]/li[6]" />
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/.." />
-  </head>
-  <body>
-    <div id="log"></div>
-    <script>
-      var test = async_test()
-      test.step(function() {
-        var client = new XMLHttpRequest()
+<title>XMLHttpRequest: send() - CORS POST basic authenticated request</title>
+<link rel="author" title="Maxim Vorobjov" href="mailto:maxim.vorobjov@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="following::ol[1]/li[6]">
+<link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/..">
 
-        client.open("POST", "http://www1.w3c-test.org/XMLHttpRequest/resources/auth7/corsenabled.py", true)
-        client.setRequestHeader('Authorization', 'Basic MTMwZGY5NzEtMDE1NS00NTE4LWFjMjctOTU0ZmFhMzUwNWEzOnBhc3M=')
-        client.setRequestHeader("x-user", "130df971-0155-4518-ac27-954faa3505a3")
-        client.setRequestHeader("x-pass", "pass")
-        client.setRequestHeader('Accept', 'text/plain');
-        client.setRequestHeader('Content-type', 'application/json; charset=utf-8');
-        client.onreadystatechange = function () {
-          if (client.readyState < 4) {return}
-          test.step( function () {
-            assert_equals(client.status, 200)
-            test.done()
-          })
-        }
-        client.send("{'data':'test'}")
-      })
-    </script>
-  </body>
-</html>
+<div id="log"></div>
+
+<script>
+"use strict";
+
+async_test(t => {
+  var client = new XMLHttpRequest()
+
+  client.open("POST", "http://www1.w3c-test.org/XMLHttpRequest/resources/auth7/corsenabled.py", true)
+
+  client.setRequestHeader("Authorization", "Basic MTMwZGY5NzEtMDE1NS00NTE4LWFjMjctOTU0ZmFhMzUwNWEzOnBhc3M=")
+  client.setRequestHeader("x-user", "130df971-0155-4518-ac27-954faa3505a3")
+  client.setRequestHeader("x-pass", "pass")
+  client.setRequestHeader("Accept", "text/plain");
+  client.setRequestHeader("Content-type", "application/json; charset=utf-8");
+
+  client.onreadystatechange = t.step_func(() => {
+    if (client.readyState < 4) {
+      return;
+    }
+    assert_equals(client.status, 200);
+    t.done();
+  });
+
+  client.send("{'data':'test'}");
+});
+</script>

--- a/test/web-platform-tests/to-upstream/XMLHttpRequest/send-authentication-cors-post.htm
+++ b/test/web-platform-tests/to-upstream/XMLHttpRequest/send-authentication-cors-post.htm
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: send() - CORS POST basic authenticated request</title>
+    <link rel="author" title="Maxim Vorobjov" href="mailto:maxim.vorobjov@gmail.com">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="following::ol[1]/li[6]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/.." />
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var test = async_test()
+      test.step(function() {
+        var client = new XMLHttpRequest()
+
+        client.open("POST", "http://www1.w3c-test.org/XMLHttpRequest/resources/auth7/corsenabled.py", true)
+        client.setRequestHeader('Authorization', 'Basic MTMwZGY5NzEtMDE1NS00NTE4LWFjMjctOTU0ZmFhMzUwNWEzOnBhc3M=')
+        client.setRequestHeader("x-user", "130df971-0155-4518-ac27-954faa3505a3")
+        client.setRequestHeader("x-pass", "pass")
+        client.setRequestHeader('Accept', 'text/plain');
+        client.setRequestHeader('Content-type', 'application/json; charset=utf-8');
+        client.onreadystatechange = function () {
+          if (client.readyState < 4) {return}
+          test.step( function () {
+            assert_equals(client.status, 200)
+            test.done()
+          })
+        }
+        client.send("{'data':'test'}")
+      })
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Solution to #1662:

XMLHttpRequest when POSTing not empty body to other site (CORS) with authorization header (supposedly with any not simple header) throws exception even not sending request to the server. This kind of requests might be used to communicate with local middleware via REST with authorization, especially when system is built of micro services.

```
    TypeError: Cannot convert undefined or null to object

      at Object.getRequestHeader (node_modules/react-scripts/node_modules/jsdom/lib/jsdom/living/xhr-utils.js:19:23)
      at setDispatchProgressEvents (node_modules/react-scripts/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:908:38)
      at XMLHttpRequest.send (node_modules/react-scripts/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:700:11)
```

The issue is that on xmlhttprequest.js:908 'client' is EventEmitter, while code expected request client.

Solution still won't provide progress on data upload for CORS POST, but will fix exception and enable such kind of requests. I suppose proper fix would be to store final headers somewhere in the xhr object, while keeping properties.client only as EventEmitter..

to-upstream test is pointing to hosted w3c-test.org since local python test server is not running while upstream tests executing.