### PR TITLE
Submitting form elements should log errors if and only if not cancelled

### DIFF
--- a/lib/jsdom/living/nodes/HTMLFormElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFormElement-impl.js
@@ -56,7 +56,7 @@ class HTMLFormElementImpl extends HTMLElementImpl {
   _dispatchSubmitEvent() {
     const ev = this._ownerDocument.createEvent("HTMLEvents");
     ev.initEvent("submit", true, true);
-    if (!this.dispatchEvent(ev)) {
+    if (this.dispatchEvent(ev)) {
       this.submit();
     }
   }

--- a/test/jsdom/misc.js
+++ b/test/jsdom/misc.js
@@ -668,7 +668,9 @@ describe("jsdom/miscellaneous", () => {
 
     let error;
     const vc = jsdom.getVirtualConsole(doc.defaultView);
-    vc.on("jsdomError", e => {error = e});
+    vc.on("jsdomError", e => {
+      error = e;
+    });
 
     const form = doc.createElement("form");
     const bttn = doc.createElement("button");
@@ -684,7 +686,9 @@ describe("jsdom/miscellaneous", () => {
 
     let error;
     const vc = jsdom.getVirtualConsole(doc.defaultView);
-    vc.on("jsdomError", e => {error = e});
+    vc.on("jsdomError", e => {
+      error = e;
+    });
 
     const form = doc.createElement("form");
     form.addEventListener("submit", event => event.preventDefault());

--- a/test/jsdom/misc.js
+++ b/test/jsdom/misc.js
@@ -663,6 +663,38 @@ describe("jsdom/miscellaneous", () => {
     assert.equal(typeof elem.onsubmit, "function");
   });
 
+  specify("form_onsubmit_not_implemented", () => {
+    const doc = jsdom.jsdom();
+
+    let error;
+    const vc = jsdom.getVirtualConsole(doc.defaultView);
+    vc.on("jsdomError", e => error = e);
+
+    const form = doc.createElement("form");
+    const bttn = doc.createElement("button");
+    form.appendChild(bttn);
+    bttn.click();
+
+    assert(error, 'expected console to log not implemented error');
+    assert(error.message, 'Not implemented: HTMLFormElement.prototype.submit');
+  });
+
+  specify("form_onsubmit_not_implemented_ignored_if_prevented", () => {
+    const doc = jsdom.jsdom();
+
+    let error
+    const vc = jsdom.getVirtualConsole(doc.defaultView);
+    vc.on("jsdomError", e => error = e);
+
+    const form = doc.createElement("form");
+    form.addEventListener("submit", event => event.preventDefault());
+    const bttn = doc.createElement("button");
+    form.appendChild(bttn);
+    bttn.click();
+
+    assert(!error, 'expected console to not log any error');
+  });
+
   specify("get_element_by_id", () => {
     const doc = jsdom.jsdom();
     const el = doc.createElement("div");

--- a/test/jsdom/misc.js
+++ b/test/jsdom/misc.js
@@ -668,23 +668,23 @@ describe("jsdom/miscellaneous", () => {
 
     let error;
     const vc = jsdom.getVirtualConsole(doc.defaultView);
-    vc.on("jsdomError", e => error = e);
+    vc.on("jsdomError", e => {error = e});
 
     const form = doc.createElement("form");
     const bttn = doc.createElement("button");
     form.appendChild(bttn);
     bttn.click();
 
-    assert(error, 'expected console to log not implemented error');
-    assert(error.message, 'Not implemented: HTMLFormElement.prototype.submit');
+    assert(error, "expected console to log not implemented error");
+    assert(error.message, "Not implemented: HTMLFormElement.prototype.submit");
   });
 
   specify("form_onsubmit_not_implemented_ignored_if_prevented", () => {
     const doc = jsdom.jsdom();
 
-    let error
+    let error;
     const vc = jsdom.getVirtualConsole(doc.defaultView);
-    vc.on("jsdomError", e => error = e);
+    vc.on("jsdomError", e => {error = e});
 
     const form = doc.createElement("form");
     form.addEventListener("submit", event => event.preventDefault());
@@ -692,7 +692,7 @@ describe("jsdom/miscellaneous", () => {
     form.appendChild(bttn);
     bttn.click();
 
-    assert(!error, 'expected console to not log any error');
+    assert(!error, "expected console to not log any error");
   });
 
   specify("get_element_by_id", () => {


### PR DESCRIPTION
This logic was backwards, throwing errors when `event.preventDefault()` was called on a form submit event:

```
Error: Not implemented: HTMLFormElement.prototype.submit
```

When `event.preventDefault()` was **not** called, no error was logged.