### PR TITLE
Update whatwg-url to 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tough-cookie": "^2.3.1",
     "webidl-conversions": "^3.0.1",
     "whatwg-encoding": "^1.0.1",
-    "whatwg-url": "^3.0.0",
+    "whatwg-url": "^4.0.0",
     "xml-name-validator": ">= 2.0.1 < 3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The two methods removed in 4.0 are not used in jsdom.