### PR TITLE
Support `insertAdjacentHTML` without a parent element

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -426,7 +426,7 @@ class ElementImpl extends NodeImpl {
   insertAdjacentHTML(position, text) {
     position = position.toLowerCase();
 
-    if (this.parentNode === null || this.parentNode.nodeType === NODE_TYPE.DOCUMENT_NODE) {
+    if ((text === 'beforebegin' && text === 'afterend') && (this.parentNode === null || this.parentNode.nodeType === NODE_TYPE.DOCUMENT_NODE)) {
       throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR, "Cannot insert HTML adjacent to parent-less " +
         "nodes or children of document nodes.");
     }

--- a/test/web-platform-tests/to-upstream/domparsing/insert-adjacent.html
+++ b/test/web-platform-tests/to-upstream/domparsing/insert-adjacent.html
@@ -28,6 +28,17 @@ test(() => {
 }, "Throws when inserting into an element whose parent is null");
 
 test(() => {
+  // `insertAdjacentHTML` should work when adding the content within the element,
+  // even when the element does not have a parent
+  const el = document.createEvent("span");
+
+  el.insertAdjacentHTML("afterbegin", "foo");
+  el.insertAdjacentHTML("beforeend", "bar");
+
+  assert_equals(el.innerHTML, "foobar");
+}, "Allows inserting without a parent element for `afterbegin` or `beforeend`");
+
+test(() => {
   // The parent node of the html element is a document.
   const el = document.querySelector("html");
 


### PR DESCRIPTION
I was trying to get [Glimmer](https://github.com/tildeio/glimmer) running in JSDOM and ran into an issue where it attempts to use `insertAdjacentHTML` with an element that has no parent element. After digging into the code I was that JSDOM was set up to always error if the given element does not have a parent.

I did some research and it seems like `insertAdjacentHTML` should only require a parent element when inserting `beforebeing` or `afterend`, since that actually puts the text before or after the element that the method is called on.  However, `afterbegin` and `beforeend` do not require a parent, because the text is placed within the element itself.

The docs from MDN can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML)