### PR TITLE
Fixing late window close error

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -287,6 +287,9 @@ function Window(options) {
     // Recursively close child frame windows, then ourselves.
     const currentWindow = this;
     (function windowCleaner(windowToClean) {
+      if(!windowToClean) {
+        return;
+      }
       for (let i = 0; i < windowToClean.length; i++) {
         windowCleaner(windowToClean[i]);
       }


### PR DESCRIPTION
I'm getting the following error on a production server of mine, and the only fix that seems to work is the simple implemented workaround.
`
TypeError: Cannot read property 'length' of undefined
  at windowCleaner (/app/node_modules/jsdom/lib/jsdom/browser/Window.js:290:40)
  at windowCleaner (/app/node_modules/jsdom/lib/jsdom/browser/Window.js:291:9)
  at Window.close (/app/current/node_modules/jsdom/lib/jsdom/browser/Window.js:298:6)
`

It seems to happen due to late living references to window trying to call close on it, close being closed twice or something like that. This a simple solution that won't cause any problem.

