### PR TITLE
Align timers with specification

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -171,14 +171,14 @@ function Window(options) {
     for (let i = 2; i < arguments.length; ++i) {
       args[i - 2] = arguments[i];
     }
-    return startTimer(window, setTimeout, clearTimeout, latestTimerId++, fn, ms, args);
+    return startTimer(window, setTimeout, clearTimeout, ++latestTimerId, fn, ms, args);
   };
   this.setInterval = function (fn, ms) {
     const args = [];
     for (let i = 2; i < arguments.length; ++i) {
       args[i - 2] = arguments[i];
     }
-    return startTimer(window, setInterval, clearInterval, latestTimerId++, fn, ms, args);
+    return startTimer(window, setInterval, clearInterval, ++latestTimerId, fn, ms, args);
   };
   this.clearInterval = stopTimer.bind(this, window);
   this.clearTimeout = stopTimer.bind(this, window);

--- a/test/web-platform-tests/to-upstream/html/webappapis/timers/settimeout-setinterval-handles.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/timers/settimeout-setinterval-handles.html
@@ -9,6 +9,24 @@
 <script>
 "use strict";
 
+test(() => {
+  const a = setTimeout(noop);
+  const b = setInterval(noop);
+
+  clearTimeout(a);
+  clearInterval(b);
+
+  assert_true(typeof a === "number");
+  assert_true(typeof b === "number");
+
+  assert_true(a > 0);
+  assert_true(b > 0);
+
+  function noop() {
+    // no-op
+  }
+}, "setTimeout and setInterval should return numeric handles integer that is greater than zero");
+
 async_test(t => {
   const a = setTimeout(() => {
     // shouldn't execute since we clear immediately


### PR DESCRIPTION
The returned value for `setTimeout()` and `setInterval()` should be numeric non-zero value.

Fixes #1726