### PR TITLE
Allow null in options

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -78,7 +78,7 @@ Object.defineProperty(exports, "defaultDocumentFeatures", {
 });
 
 exports.jsdom = function (html, options) {
-  if (options === undefined) {
+  if (options === undefined || options === null) {
     options = {};
   }
   if (options.parsingMode === undefined || options.parsingMode === "auto") {


### PR DESCRIPTION
Allow passing null to options and assign empty object if so.