### PR TITLE
Parse colSpan/rowSpan attributes as integers in getters

### DIFF
--- a/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
@@ -34,8 +34,8 @@ class HTMLTableCellImpl extends HTMLElementImpl {
   }
 
   get rowSpan() {
-    const value = this.getAttribute("rowspan");
-    return value === null ? 1 : value;
+    const value = parseInt(this.getAttribute("rowspan"));
+    return value === null || value === 0 ? 1 : value;
   }
 
   set rowSpan(V) {

--- a/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableCellElement-impl.js
@@ -25,8 +25,8 @@ class HTMLTableCellImpl extends HTMLElementImpl {
   }
 
   get colSpan() {
-    const value = this.getAttribute("colspan");
-    return value === null ? 1 : value;
+    const value = parseInt(this.getAttribute("colspan"));
+    return value === null || value === 0 ? 1 : value;
   }
 
   set colSpan(V) {


### PR DESCRIPTION
Resolves https://github.com/tmpvar/jsdom/issues/1745

Also, fixes an issue where `colSpan` would return `'0'` when after the value was set to an invalid value (`td.colSpan = "foo"`);