### PR TITLE
Enable support for canvas-prebuilt package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 
 matrix:
   include:
-  - node_js: 4
+    - node_js: 4
       env: TEST_SUITE=node-canvas-prebuilt
       script: "export CXX=g++-4.8 && npm i canvas-prebuilt && npm test"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,17 @@ addons:
 
 matrix:
   include:
+  - node_js: 4
+      env: TEST_SUITE=node-canvas-prebuilt
+      script: "export CXX=g++-4.8 && npm i canvas-prebuilt && npm test"
+      addons:
+        hosts:
+          - web-platform.test
+          - www.web-platform.test
+          - www1.web-platform.test
+          - www2.web-platform.test
+          - xn--n8j6ds53lwwkrqhv28a.web-platform.test
+          - xn--lve-6lad.web-platform.test
     - node_js: 4
       env: TEST_SUITE=node-canvas
       script: "export CXX=g++-4.8 && npm i canvas && npm test"

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ jsdom.env({
 
 ## Canvas
 
-jsdom includes support for using the [canvas](https://npmjs.org/package/canvas) package to extend any `<canvas>` elements with the canvas API. To make this work, you need to include canvas as a dependency in your project, as a peer of jsdom. If jsdom can find the canvas package, it will use it, but if it's not present, then `<canvas>` elements will behave like `<div>`s.
+jsdom includes support for using the [canvas](https://npmjs.org/package/canvas) or [canvas-prebuilt](https://npmjs.org/package/canvas-prebuilt) package to extend any `<canvas>` elements with the canvas API. To make this work, you need to include canvas as a dependency in your project, as a peer of jsdom. If jsdom can find the canvas package, it will use it, but if it's not present, then `<canvas>` elements will behave like `<div>`s.
 
 ## More Examples
 

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -211,12 +211,15 @@ exports.parseDataUrl = function parseDataUrl(url) {
 /* eslint-disable global-require */
 
 exports.Canvas = null;
-try {
-  exports.Canvas = require("canvas");
-  if (typeof exports.Canvas !== "function") {
-    // In browserify, the require will succeed but return an empty object
+["canvas", "canvas-prebuilt"].some(function(moduleName) {
+  try {
+    exports.Canvas = require(moduleName);
+    if (typeof exports.Canvas !== "function") {
+      // In browserify, the require will succeed but return an empty object
+      exports.Canvas = null;
+    }
+  } catch (e) {
     exports.Canvas = null;
   }
-} catch (e) {
-  exports.Canvas = null;
-}
+  return exports.Canvas !== null;
+});

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -211,7 +211,7 @@ exports.parseDataUrl = function parseDataUrl(url) {
 /* eslint-disable global-require */
 
 exports.Canvas = null;
-["canvas", "canvas-prebuilt"].some(function (moduleName) {
+["canvas", "canvas-prebuilt"].some(moduleName => {
   try {
     exports.Canvas = require(moduleName);
     if (typeof exports.Canvas !== "function") {

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -211,7 +211,7 @@ exports.parseDataUrl = function parseDataUrl(url) {
 /* eslint-disable global-require */
 
 exports.Canvas = null;
-["canvas", "canvas-prebuilt"].some(function(moduleName) {
+["canvas", "canvas-prebuilt"].some(function (moduleName) {
   try {
     exports.Canvas = require(moduleName);
     if (typeof exports.Canvas !== "function") {


### PR DESCRIPTION
canvas-prebuilt is a package from @chearon https://github.com/chearon/node-canvas-prebuilt, contributor of node-canvas.

Is easier to install for most of the situation and is same as canvas, but prebuilt.

Is a drop in replacement with a different name, i made this PR to enable the us of this package in jsdom.