### PR TITLE
Blob toString no longer returns '[object Blob]'

### DIFF
--- a/test/web-platform-tests/to-upstream/XMLHttpRequest/formdata-set-blob.html
+++ b/test/web-platform-tests/to-upstream/XMLHttpRequest/formdata-set-blob.html
@@ -41,6 +41,14 @@ test(() => {
 }, "blob with custom name");
 
 test(() => {
+  formData.set("blob-4", new Blob());
+  const blob4 = formData.get("blob-4");
+  assert_equals(blob4.constructor.name, "File");
+  assert_equals(Object.prototype.toString.call(blob4), "[object Blob]");
+  assert_less_than(Math.abs(blob4.lastModified - Date.now()), 200, "lastModified should be now");
+}, "Blob toString() should return '[object Blob]'");
+
+test(() => {
   formData.set("file-1", new File([], "name"));
   const file1 = formData.get("file-1");
   assert_equals(file1.constructor.name, "File");


### PR DESCRIPTION
With the merging of tmpvar/jsdom#1681, it looks like [`toString` was dropped](https://github.com/tmpvar/jsdom/pull/1681/files#diff-2b1f271ea8bbc0be11ca9f49d84564b3L70), causing [certain code that checks for Blob types using `toString`](https://github.com/mzabriskie/axios/blob/master/lib/utils.js#L117-L125) to fail, as it's currently returning `[object Object]`.

I've submitted a failing test in this PR to demonstrate.