### PR TITLE
Add Option element constructor

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -184,6 +184,38 @@ function Window(options) {
   this.clearTimeout = stopTimer.bind(this, window);
   this.__stopAllTimers = stopAllTimers.bind(this, window);
 
+  function Option(text, value, defaultSelected, selected) {
+    const option = window._document.createElement("option");
+    const impl = idlUtils.implForWrapper(option);
+
+    if (text) {
+      impl.text = text;
+    }
+    if (value) {
+      impl.setAttribute("value", value);
+    }
+    if (defaultSelected === true) {
+      impl.setAttribute("selected", "");
+    }
+    if (typeof selected === "boolean") {
+      impl.selected = selected;
+    }
+
+    return option;
+  }
+  Object.defineProperty(Option, "prototype", {
+    value: this.HTMLOptionElement.prototype,
+    configurable: false,
+    enumerable: false,
+    writable: false
+  });
+  Object.defineProperty(window, "Option", {
+    value: Option,
+    configurable: true,
+    enumerable: false,
+    writable: true
+  });
+
   function Image() {
     const img = window._document.createElement("img");
     const impl = idlUtils.implForWrapper(img);

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -61,6 +61,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "encoding/meta/no-meta.html",
     "html/browsers/windows/nested-browsing-contexts/iframe-referrer.html",
     "html/dom/elements/elements-in-the-dom/click-in-progress-flag.html",
+    "html/dom/elements/option/option-element-constructor.html",
     "html/editing/activation/click-bail-on-disabled.html",
     "html/editing/focus/focus-management/active-element.html",
     "html/editing/focus/focus-management/focus-on-all-elements.html",

--- a/test/web-platform-tests/to-upstream/html/dom/elements/option/option-element-constructor.html
+++ b/test/web-platform-tests/to-upstream/html/dom/elements/option/option-element-constructor.html
@@ -12,7 +12,7 @@
 
 <body>
 <script>
-  "use strict"
+  "use strict";
 
   test(() => {
     const option = new Option("text", "value");
@@ -29,7 +29,7 @@
     assert_equals(selected.getAttribute("selected"), "");
     assert_equals(notSelected.selected, false);
     assert_equals(selected.selected, true);
-  }, "Option constructor creates HTMLOptionElement with appropriate selectedness when specified with defaultSelected values");
+  }, "Option constructor handles selectedness correctly when specified with defaultSelected only");
 
   test(() => {
     const notSelected = new Option("text", "value", true, false);
@@ -37,5 +37,5 @@
 
     assert_equals(notSelected.selected, false);
     assert_equals(selected.selected, true);
-  }, "Option constructor creates HTMLOptionElement with specified selectedness, even when incongruous with defaultSelected values");
+  }, "Option constructor handles selectedness correctly, even when incongruous with defaultSelected");
 </script>

--- a/test/web-platform-tests/to-upstream/html/dom/elements/option/option-element-constructor.html
+++ b/test/web-platform-tests/to-upstream/html/dom/elements/option/option-element-constructor.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Option element constructor</title>
+<link rel="author" title="Alex Pearson" href="mailto:alex@alexpear.com">
+<link rel="help" href="https://html.spec.whatwg.org/#the-option-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="parent">
+  <div id="child" tabindex="0"></div>
+</div>
+
+<body>
+<script>
+  "use strict"
+
+  test(() => {
+    const option = new Option("text", "value");
+
+    assert_equals(option.textContent, "text");
+    assert_equals(option.value, "value");
+  }, "Option constructor creates HTMLOptionElement with specified text and value");
+
+  test(() => {
+    const notSelected = new Option("text", "value", false);
+    const selected = new Option("text", "value", true);
+
+    assert_equals(notSelected.getAttribute("selected"), null);
+    assert_equals(selected.getAttribute("selected"), "");
+    assert_equals(notSelected.selected, false);
+    assert_equals(selected.selected, true);
+  }, "Option constructor creates HTMLOptionElement with appropriate selectedness when specified with defaultSelected values");
+
+  test(() => {
+    const notSelected = new Option("text", "value", true, false);
+    const selected = new Option("text", "value", false, true);
+
+    assert_equals(notSelected.selected, false);
+    assert_equals(selected.selected, true);
+  }, "Option constructor creates HTMLOptionElement with specified selectedness, even when incongruous with defaultSelected values");
+</script>


### PR DESCRIPTION
This adds an Option constructor that adheres to the [current spec for Option constructors](https://html.spec.whatwg.org/#dom-option), available through `jsdom`'s `window`/`defaultView`. 

This has been tested against the specs included in this PR, as well as the real-life use case that led me to raise #1759. 

Please let me know if the location of the tests added to the to-upstream directory are organized correctly.