### PR TITLE
Preserve window.location.hash across redirects

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -252,6 +252,8 @@ exports.env = exports.jsdom.env = function () {
       agentOptions: config.agentOptions
     };
 
+    const fragment = whatwgURL.parseURL(config.url).fragment;
+
     return resourceLoader.download(config.url, options, (err, responseText, res) => {
       if (err) {
         reportInitError(err, config);
@@ -262,6 +264,9 @@ exports.env = exports.jsdom.env = function () {
       // is updated when `request` follows redirects.
       config.html = responseText;
       config.url = res.request.uri.href;
+      if (fragment) {
+        config.url += `#${fragment}`;
+      }
 
       if (res.headers["last-modified"]) {
         config.lastModified = new Date(res.headers["last-modified"]);

--- a/test/jsdom/misc.js
+++ b/test/jsdom/misc.js
@@ -1180,14 +1180,14 @@ describe("jsdom/miscellaneous", () => {
 
       server.listen(8001, "127.0.0.1", () => {
         jsdom.env({
-          url: "http://127.0.0.1:8001",
+          url: "http://127.0.0.1:8001#hash",
           done(errors, window) {
             server.close();
             if (errors) {
               assert.ok(false, errors.message);
             } else {
               assert.equal(window.document.body.innerHTML, html, "root page should be redirected");
-              assert.equal(window.location.href, "http://127.0.0.1:8001/redir",
+              assert.equal(window.location.href, "http://127.0.0.1:8001/redir#hash",
                 "window.location.href should equal to redirected url");
             }
             t.done();


### PR DESCRIPTION
When `jsdom.env` is passed a url that does a 302 redirect, any hash on the
url is lost. You can check browser behavior here:
https://httpbin.org/redirect-to?url=https://example.com#hash

<strike>So far, this pull request consists only of a change in the
tests that demonstrates this issue. However, I think I'm making some
progress towards a fix, so hopefully I'll be able to update this once I
find one.</strike>

This change ensures that the url fragment is not lost when a redirect happens.

---

Relevant Specifications (found via [stack overflow](https://stackoverflow.com/questions/2286402/url-fragment-and-302-redirects)):

* https://www.w3.org/TR/cuap#uri

> Suppose that a user requests the resource at http://www.w3.org/TR/WD-ruby/#changes and the server redirects the user agent to http://www.w3.org/TR/ruby/. Before fetching that latter URI, the browser should append the fragment identifier #changes to it: http://www.w3.org/TR/ruby/#changes.

* https://tools.ietf.org/html/rfc7231#section-7.1.2

> If the Location value provided in a 3xx (Redirection) response does
not have a fragment component, a user agent MUST process the
redirection as if the value inherits the fragment component of the
URI reference used to generate the request target (i.e., the
redirection inherits the original reference's fragment, if any).
