### PR TITLE
Bug: stopImmediatePropagation not working

### DIFF
--- a/lib/jsdom/living/events/Event-impl.js
+++ b/lib/jsdom/living/events/Event-impl.js
@@ -50,7 +50,7 @@ class EventImpl {
 
   stopImmediatePropagation() {
     this._stopPropagationFlag = true;
-    this._stopImmediatePropagation = true;
+    this._stopImmediatePropagationFlag = true;
   }
 
   preventDefault() {

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -26,6 +26,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "dom/attributes-are-not-nodes.html",
     "dom/collections/HTMLCollection-iterator.html",
     "dom/events/AddEventListenerOptions-once.html",
+    "dom/events/Event-stopImmediatePropagation.html",
     "dom/events/EventTarget-add-remove-listener.html",
     "dom/events/EventTarget-prototype-constructor.html",
     "dom/events/EventTarget-this-of-listener.html",

--- a/test/web-platform-tests/to-upstream/dom/events/Event-stopImmediatePropagation.html
+++ b/test/web-platform-tests/to-upstream/dom/events/Event-stopImmediatePropagation.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event's stopImmediatePropagation</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation">
+<link rel="author" href="mailto:d@domenic.me" title="Domenic Denicola">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="target"></div>
+
+<script>
+"use strict";
+
+const target = document.querySelector("#target");
+
+let timesCalled = 0;
+target.addEventListener("test", e => {
+  ++timesCalled;
+  e.stopImmediatePropagation();
+  assert_equals(e.cancelBubble, true, "The stop propagation flag must have been set");
+});
+target.addEventListener("test", () => {
+  ++timesCalled;
+});
+
+const e = new Event("test");
+target.dispatchEvent(e);
+assert_equals(timesCalled, 1, "The second listener must not have been called");
+
+done();
+</script>


### PR DESCRIPTION
The `stopImmediatePropagation` event seems to be [implemented in jsdom](https://github.com/tmpvar/jsdom/blob/578e2cb3f16c760f26e737299a071ff78ec84589/lib/jsdom/living/events/Event-impl.js#L51). It should stop executing listeners for the same element, but it seems this isn't working as expected in jsdom (this assertion is ok in the browser):

```js
const jsdom = require('jsdom');
const assert = require('assert');

jsdom.env('<html><body></body></html>', (err, window) => {
  let i = 0;
  const body = window.document.body;
  body.addEventListener('test', evt => {
    i++;
    evt.stopImmediatePropagation();
  });
  body.addEventListener('test', evt => {
    i++;
  });
  const event = new window.Event('test');
  body.dispatchEvent(event);
  assert(i === 1);
});
```

On the other hand, `stopPropagation` works fine:

```js
const jsdom = require('jsdom');
const assert = require('assert');

jsdom.env('<html><body><div></div></body></html>', (err, window) => {
  let i = 0;
  const body = window.document.body;
  const div = body.querySelector('div');
  body.addEventListener('test', evt => {
    i++;
  });
  div.addEventListener('test', evt => {
    i++;
    evt.stopPropagation();
  });
  const event = new window.Event('test');
  div.dispatchEvent(event);
  assert(i === 1);
});
```