### PR TITLE
Fix clearTimeout in web workers

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -534,7 +534,8 @@ function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
 function stopTimer(window, id) {
   const timer = window.__timers[id];
   if (timer) {
-    timer[1].call(window, timer[0]);
+    // Need to .call() with undefined to ensure the thisArg is not timer itself
+    timer[1].call(undefined, timer[0]);
     delete window.__timers[id];
   }
 }
@@ -542,7 +543,8 @@ function stopTimer(window, id) {
 function stopAllTimers(window) {
   Object.keys(window.__timers).forEach(key => {
     const timer = window.__timers[key];
-    timer[1].call(window, timer[0]);
+    // Need to .call() with undefined to ensure the thisArg is not timer itself
+    timer[1].call(undefined, timer[0]);
   });
   window.__timers = Object.create(null);
 }

--- a/test/jsdom/inside-worker-smoke-tests.js
+++ b/test/jsdom/inside-worker-smoke-tests.js
@@ -84,4 +84,17 @@ describe("jsdom/inside-worker-smoke-tests", () => {
       }
     });
   });
+
+  specify("clearTimeout (GH-1732)", { async: true }, t => {
+    const document = jsdom.jsdom(`<script>const t = setTimeout(() => {
+      clearTimeout(t);
+      window.done();
+    }, 100);</script>`);
+
+    const window = document.defaultView;
+    window.addEventListener("error", e => {
+      assert.ifError(e.error);
+    });
+    window.done = () => t.done();
+  });
 });


### PR DESCRIPTION
Closes #1732. This worked fine in Node since there clearTimeout does not care what its thisArg is. But in browsers, it does, causing this error.

Thanks @jdthorpe for digging into this until he could produce an isolated test case!!

Will merge after CI signs off.