### PR TITLE
Handle setting innerHTML to the empty string

### DIFF
--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -50,12 +50,10 @@ function setInnerHTML(document, node, html) {
     clearChildNodes(node);
   }
 
-  if (html !== "") {
-    if (node.nodeName === "#document") {
-      document._htmlToDom.appendHtmlToDocument(html, node);
-    } else {
-      document._htmlToDom.appendHtmlToElement(html, node);
-    }
+  if (node.nodeName === "#document") {
+    document._htmlToDom.appendHtmlToDocument(html, node);
+  } else {
+    document._htmlToDom.appendHtmlToElement(html, node);
   }
 }
 

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -47,6 +47,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "dom/nodes/ParentNode-querySelector-escapes.html",
     "dom/nodes/Text-wholeText.html",
     "domparsing/DOMParser-dont-upstream.html",
+    "domparsing/innerhtml-08.html",
     "domparsing/insert-adjacent.html",
     "domparsing/outerhtml-03.html",
     "FileAPI/blob/Blob-isClosed.html",

--- a/test/web-platform-tests/to-upstream/domparsing/innerhtml-08.html
+++ b/test/web-platform-tests/to-upstream/domparsing/innerhtml-08.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>innerHTML to empty string</title>
+<link rel="help" href="https://w3c.github.io/DOM-Parsing/#dom-element-innerhtml">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(t => {
+
+  const doc = document.createElement("html");
+  doc.innerHTML = "<head><title>foo</title></head><body></body>";
+
+  doc.innerHTML = "";
+
+  assert_true(doc.getElementsByTagName("body")[0] instanceof HTMLBodyElement);
+
+}, "Setting innerHTML to empty string");
+</script>

--- a/test/web-platform-tests/to-upstream/domparsing/innerhtml-08.html
+++ b/test/web-platform-tests/to-upstream/domparsing/innerhtml-08.html
@@ -6,16 +6,15 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
-"use strict";
+  "use strict";
 
-test(t => {
+  test(() => {
+    const doc = document.createElement("html");
+    doc.innerHTML = "<head><title>foo</title></head><body></body>";
 
-  const doc = document.createElement("html");
-  doc.innerHTML = "<head><title>foo</title></head><body></body>";
+    doc.innerHTML = "";
 
-  doc.innerHTML = "";
+    assert_true(doc.getElementsByTagName("body")[0] instanceof HTMLBodyElement);
 
-  assert_true(doc.getElementsByTagName("body")[0] instanceof HTMLBodyElement);
-
-}, "Setting innerHTML to empty string");
+  }, "Setting innerHTML to empty string");
 </script>


### PR DESCRIPTION
I have looked at issue #1779, and the problem seems to have been in the innerHTML implementation. The setInnerHTML function includes a specific if-condition rejecting the empty string as input, while browsers seem to handle it. With the if-condition removed the output has been consistent with the way browsers behave, during my limited testing.

I am naturally a bit wary about simply removing a condition since someone must've put it there for a reason in the first place, but perhaps it no longer applies as the codebase has changed. Regardless, I'd appreciate if someone knowing more about the intricacies of innerHTML would chime in.