### PR TITLE
[fix] window.origin doesn't exists (closes #1789)

### DIFF
--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -21,11 +21,11 @@ module.exports = function (message, targetOrigin) {
   }
 
   // TODO: event.source - requires reference to source window
-  // TODO: event.origin - requires reference to source window
   // TODO: event.ports
   // TODO: event.data - structured clone message - requires cloning DOM nodes
   const event = new this.MessageEvent("message", {
-    data: message
+    data: message,
+    origin: targetOrigin
   });
 
   event.initEvent("message", false, false);

--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -21,11 +21,11 @@ module.exports = function (message, targetOrigin) {
   }
 
   // TODO: event.source - requires reference to source window
+  // TODO: event.origin - requires reference to source window
   // TODO: event.ports
   // TODO: event.data - structured clone message - requires cloning DOM nodes
   const event = new this.MessageEvent("message", {
-    data: message,
-    origin: targetOrigin
+    data: message
   });
 
   event.initEvent("message", false, false);

--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -16,7 +16,7 @@ module.exports = function (message, targetOrigin) {
 
   // TODO: targetOrigin === '/' - requires reference to source window
   // See https://github.com/tmpvar/jsdom/pull/1140#issuecomment-111587499
-  if (targetOrigin !== "*" && targetOrigin !== this.origin) {
+  if (targetOrigin !== "*" && targetOrigin !== this.location.origin) {
     return;
   }
 


### PR DESCRIPTION
As stated in the issue, `window.origin` doesn’t exist. This change
allows us to post messages where the origin is something other than `*`.