### PR TITLE
Improve xhr.open not enough args error message

### DIFF
--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -447,7 +447,7 @@ module.exports = function createXMLHttpRequest(window) {
       const properties = this[xhrSymbols.properties];
       const argumentCount = arguments.length;
       if (argumentCount < 2) {
-        throw new TypeError("Not enought arguments");
+        throw new TypeError("Not enough arguments (expected at least 2)");
       }
       method = toByteString(method);
       if (!tokenRegexp.test(method)) {


### PR DESCRIPTION
I spotted this typo and thought we could further make
this error message more helpful.