### PR TITLE
canvas-prebuilt package is currently broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,16 @@ matrix:
           - www2.web-platform.test
           - xn--n8j6ds53lwwkrqhv28a.web-platform.test
           - xn--lve-6lad.web-platform.test
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+            - libcairo2-dev
+            - libjpeg8-dev
+            - libpango1.0-dev
+            - libgif-dev
+            - build-essential
     - node_js: "7.2.1"
       env: TEST_SUITE=node-canvas
       script: "export CXX=g++-4.8 && npm i canvas && npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,17 @@ matrix:
             - libgif-dev
             - build-essential
     - node_js: "7.2.1"
+      env: TEST_SUITE=node-canvas-prebuilt
+      script: "export CXX=g++-4.8 && npm i canvas-prebuilt && npm test"
+      addons:
+        hosts:
+          - web-platform.test
+          - www.web-platform.test
+          - www1.web-platform.test
+          - www2.web-platform.test
+          - xn--n8j6ds53lwwkrqhv28a.web-platform.test
+          - xn--lve-6lad.web-platform.test
+    - node_js: "7.2.1"
       env: TEST_SUITE=node-canvas
       script: "export CXX=g++-4.8 && npm i canvas && npm test"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 4
   - "7.2.1" # https://github.com/nodejs/node/issues/10806 and related regressions. Also change below.
 sudo: false
+dist: trusty
 
 git:
   submodules: false
@@ -65,16 +66,6 @@ matrix:
           - www2.web-platform.test
           - xn--n8j6ds53lwwkrqhv28a.web-platform.test
           - xn--lve-6lad.web-platform.test
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
-            - libcairo2-dev
-            - libjpeg8-dev
-            - libpango1.0-dev
-            - libgif-dev
-            - build-essential
     - node_js: "7.2.1"
       env: TEST_SUITE=node-canvas
       script: "export CXX=g++-4.8 && npm i canvas && npm test"

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -211,27 +211,28 @@ exports.parseDataUrl = function parseDataUrl(url) {
 /* eslint-disable global-require */
 
 
-const requireCanvasModule = (moduleName) => {
-  let module = null;
+function requireCanvasModule(moduleName) {
+  let m = null;
 
   try {
-    module = require(moduleName);
-    if (typeof module !== "function") {
+    m = require(moduleName);
+    if (typeof m !== "function") {
       // In browserify, the require will succeed but return an empty object
-      module = null;
+      m = null;
     }
   } catch (e) {
     // looks like the module is not installed
   }
 
-  return module;
-};
+  return m;
+}
 
-const loadCanvas = () => {
+function loadCanvas() {
   let Canvas = null;
+  let moduleName;
 
-  for (module of ['canvas', 'canvas-prebuilt']) {
-    Canvas = requireCanvasModule(module);
+  for (moduleName of ["canvas", "canvas-prebuilt"]) {
+    Canvas = requireCanvasModule(moduleName);
     if (Canvas) {
       break;
     }

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -210,16 +210,34 @@ exports.parseDataUrl = function parseDataUrl(url) {
 
 /* eslint-disable global-require */
 
-exports.Canvas = null;
-["canvas", "canvas-prebuilt"].find(moduleName => {
+
+const requireCanvasModule = (moduleName) => {
+  let module = null;
+
   try {
-    exports.Canvas = require(moduleName);
-    if (typeof exports.Canvas !== "function") {
+    module = require(moduleName);
+    if (typeof module !== "function") {
       // In browserify, the require will succeed but return an empty object
-      exports.Canvas = null;
+      module = null;
     }
   } catch (e) {
-    exports.Canvas = null;
+    // looks like the module is not installed
   }
-  return exports.Canvas !== null;
-});
+
+  return module;
+};
+
+const loadCanvas = () => {
+  let Canvas = null;
+
+  for (module of ['canvas', 'canvas-prebuilt']) {
+    Canvas = requireCanvasModule(module);
+    if (Canvas) {
+      break;
+    }
+  }
+
+  return Canvas;
+}
+
+exports.Canvas = loadCanvas();

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -210,35 +210,20 @@ exports.parseDataUrl = function parseDataUrl(url) {
 
 /* eslint-disable global-require */
 
-
-function requireCanvasModule(moduleName) {
-  let m = null;
-
+exports.Canvas = null;
+["canvas", "canvas-prebuilt"].some(moduleName => {
   try {
-    m = require(moduleName);
-    if (typeof m !== "function") {
+    exports.Canvas = require(moduleName);
+    if (typeof exports.Canvas !== "function") {
       // In browserify, the require will succeed but return an empty object
-      m = null;
+      exports.Canvas = null;
     }
   } catch (e) {
-    // looks like the module is not installed
-  }
-
-  return m;
-}
-
-function loadCanvas() {
-  let Canvas = null;
-  let moduleName;
-
-  for (moduleName of ["canvas", "canvas-prebuilt"]) {
-    Canvas = requireCanvasModule(moduleName);
-    if (Canvas) {
-      break;
+    if (e.code === 'MODULE_NOT_FOUND') {
+      exports.Canvas = null;
+    } else {
+      throw e;
     }
   }
-
-  return Canvas;
-}
-
-exports.Canvas = loadCanvas();
+  return exports.Canvas !== null;
+});

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -219,7 +219,7 @@ exports.Canvas = null;
       exports.Canvas = null;
     }
   } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
+    if (e.code === "MODULE_NOT_FOUND") {
       exports.Canvas = null;
     } else {
       throw e;

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -211,7 +211,7 @@ exports.parseDataUrl = function parseDataUrl(url) {
 /* eslint-disable global-require */
 
 exports.Canvas = null;
-["canvas", "canvas-prebuilt"].some(moduleName => {
+["canvas", "canvas-prebuilt"].find(moduleName => {
   try {
     exports.Canvas = require(moduleName);
     if (typeof exports.Canvas !== "function") {

--- a/test/jsdom/utils.js
+++ b/test/jsdom/utils.js
@@ -85,4 +85,14 @@ describe("jsdom/utils", () => {
   specify("parseDataUrl should handle empty base64 data urls", () => {
     assert.strictEqual(utils.parseDataUrl("data:text/css;base64,").buffer.toString(), "");
   });
+
+  specify("Canvas is defined when installed", () => {
+    const testSuite = process.env['TEST_SUITE'];
+
+    if (testSuite === 'node-canvas' || testSuite === 'node-canvas-prebuilt') {
+      assert.isNotNull(utils.Canvas);
+    } else {
+      assert.isNull(utils.Canvas);
+    }
+  });
 });

--- a/test/jsdom/utils.js
+++ b/test/jsdom/utils.js
@@ -86,13 +86,17 @@ describe("jsdom/utils", () => {
     assert.strictEqual(utils.parseDataUrl("data:text/css;base64,").buffer.toString(), "");
   });
 
-  specify("Canvas is defined when installed", () => {
+  describe("Canvas", () => {
     const testSuite = process.env.TEST_SUITE; // eslint-disable-line no-process-env
 
     if (testSuite === "node-canvas" || testSuite === "node-canvas-prebuilt") {
-      assert.isNotNull(utils.Canvas);
+      specify("Canvas should be defined", () => {
+        assert.isNotNull(utils.Canvas);
+      });
     } else {
-      assert.isNull(utils.Canvas);
+      specify("Canvas should be null", () => {
+        assert.isNull(utils.Canvas);
+      });
     }
   });
 });

--- a/test/jsdom/utils.js
+++ b/test/jsdom/utils.js
@@ -87,9 +87,9 @@ describe("jsdom/utils", () => {
   });
 
   specify("Canvas is defined when installed", () => {
-    const testSuite = process.env['TEST_SUITE'];
+    const testSuite = process.env.TEST_SUITE; // eslint-disable-line no-process-env
 
-    if (testSuite === 'node-canvas' || testSuite === 'node-canvas-prebuilt') {
+    if (testSuite === "node-canvas" || testSuite === "node-canvas-prebuilt") {
       assert.isNotNull(utils.Canvas);
     } else {
       assert.isNull(utils.Canvas);


### PR DESCRIPTION
After attempting to use `jsdom` and `canvas-prebuilt`, I ran into several failing test cases where a canvas element was not found in a project I am currently working on. After some digging, it turns out that:

1.) https://github.com/tmpvar/jsdom/pull/1754 added support for `canvas-prebuilt`, but it's exception handling was a "catch all", so it was catching *all* exceptions, not just import exceptions.
2.) `canvas-prebuilt` (as of version `1.4.0`) had a broken Linux build https://github.com/chearon/node-canvas-prebuilt/issues/8#issuecomment-294982947 (this is now fixed)
3.) `canvas-prebuilt` requires `GLIBC_2.17`, which is not available in `precise`. Thus, this would require upgrading the Travis CI build to use `trusty` which I experimented in this [commit](https://travis-ci.org/tmpvar/jsdom/builds/223976247) and caused some of the tests to fail. Additionally, I can imagine this being a change that the `jsdom` maintainers might not be to thrilled about, so I am hesitant to go further unless they thought it was a good idea.

So this PR makes some changes which ensures that `canvas` and `canvas-prebuilt` integration works as expected. Thus, the build will continue to be broken for this PR until the `canvas-prebuilt` package is fixed.

Example of problem with `canvas-prebuilt`:

https://travis-ci.org/tmpvar/jsdom/builds/223577476