### PR TITLE
Enable to change content HTML by `reconfigure` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,14 +268,26 @@ const dom = new JSDOM();
 
 dom.window.top === dom.window;
 dom.window.location.href === "about:blank";
+dom.window.document.referrer = "";
+dom.window.document.contentType = "text/html";
+dom.window.document.body.innerHTML = "";
 
-dom.reconfigure({ windowTop: myFakeTopForTesting, url: "https://example.com/" });
+dom.reconfigure({
+  windowTop: myFakeTopForTesting,
+  url: "https://example.com/",
+  referrer: "https://www.example.org/",
+  contentType: "text/html"
+}, "<p>Hello</p>");
 
 dom.window.top === myFakeTopForTesting;
 dom.window.location.href === "https://example.com/";
+dom.window.document.referrer = "https://www.example.org/.";
+dom.window.document.contentType = "text/html";
+dom.window.document.body.innerHTML = "<p>Hello</p>";
 ```
 
-Note that changing the jsdom's URL will impact all APIs that return the current document URL, such as `window.location`, `document.URL`, and `document.documentURI`, as well as resolution of relative URLs within the document, and the same-origin checks and referrer used while fetching subresources. It will not, however, perform a navigation to the contents of that URL; the contents of the DOM will remain unchanged, and no new instances of `Window`, `Document`, etc. will be created.
+Note that changing the jsdom's URL will impact all APIs that return the current document URL, such as `window.location`, `document.URL`, and `document.documentURI`, as well as resolution of relative URLs within the document, and the same-origin checks and referrer used while fetching subresources.
+This method can change the contents of the DOM with the second parameter, but no new instance of `Window` and `Document` will be created.
 
 ## Convenience APIs
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -105,14 +105,14 @@ class JSDOM {
     return script.runInContext(this[window]);
   }
 
-  reconfigure(settings) {
+  reconfigure(settings, inputHtml) {
     if ("windowTop" in settings) {
       this[window]._top = settings.windowTop;
     }
 
-    if ("url" in settings) {
-      const document = idlUtils.implForWrapper(this[window]._document);
+    const document = idlUtils.implForWrapper(this[window]._document);
 
+    if ("url" in settings) {
       const url = whatwgURL.parseURL(settings.url);
       if (url === "failure") {
         throw new TypeError(`Could not parse "${settings.url}" as a URL`);
@@ -120,6 +120,30 @@ class JSDOM {
 
       document._URL = url;
       document._origin = whatwgURL.serializeURLToUnicodeOrigin(document._URL);
+    }
+
+    let options;
+
+    if (typeof inputHtml === "string") {
+      const { html, encoding } = normalizeHTML(inputHtml,
+        settings[transportLayerEncodingLabelHiddenOption]);
+
+      options = transformOptions(settings, encoding).windowOptions;
+
+      document._encoding = options.encoding;
+      document.open();
+      document._htmlToDom.appendHtmlToDocument(html, document);
+      document.close();
+    } else {
+      options = transformOptions(settings, "UTF-8").windowOptions;
+    }
+
+    if ("referrer" in settings) {
+      document._referrer = options.referrer;
+    }
+
+    if ("contentType" in settings) {
+      document._contentType = options.contentType;
     }
   }
 

--- a/test/api/methods.js
+++ b/test/api/methods.js
@@ -236,5 +236,138 @@ describe("API: JSDOM class's methods", () => {
         assert.strictEqual(window.document.documentURI, "http://example.com/");
       });
     });
+
+    describe("referrer", () => {
+      it("should change the referrer", () => {
+        const url1 = "http://current.com/";
+        const referrer1 = "http://referrer.com/";
+
+        const dom = new JSDOM("", { url: url1, referrer: referrer1 });
+        const window = dom.window;
+        const document = window.document;
+
+        assert.strictEqual(window.location.href, url1);
+        assert.strictEqual(document.URL, url1);
+        assert.strictEqual(document.referrer, referrer1);
+
+        const url2 = "http://next.org/";
+        const referrer2 = "http://referrer2.org/";
+
+        assert.doesNotThrow(
+          () => dom.reconfigure({ url: url2, referrer: referrer2 })
+        );
+
+        assert.strictEqual(window.location.href, url2);
+        assert.strictEqual(document.URL, url2);
+        assert.strictEqual(document.referrer, referrer2);
+      });
+
+      it("should not change the referrer when its option is given", () => {
+        const url1 = "http://current.com/";
+        const referrer1 = "http://referrer.com/";
+
+        const dom = new JSDOM("", { url: url1, referrer: referrer1 });
+        const window = dom.window;
+        const document = window.document;
+
+        assert.strictEqual(window.location.href, url1);
+        assert.strictEqual(document.URL, url1);
+        assert.strictEqual(document.referrer, referrer1);
+
+        const url2 = "http://next.org/";
+
+        assert.doesNotThrow(() => dom.reconfigure({ url: url2 }));
+
+        assert.strictEqual(window.location.href, url2);
+        assert.strictEqual(document.URL, url2);
+        assert.strictEqual(document.referrer, referrer1);
+      });
+    });
+
+    describe("contentType", () => {
+      it("should change the contentType", () => {
+        const url1 = "http://current.com/";
+        const contentType1 = "text/xml";
+
+        const dom = new JSDOM("", { url: url1, contentType: contentType1 });
+        const window = dom.window;
+        const document = window.document;
+
+        assert.strictEqual(window.location.href, url1);
+        assert.strictEqual(document.URL, url1);
+        assert.strictEqual(document.contentType, contentType1);
+
+        const url2 = "http://next.org/";
+        const contentType2 = "text/html";
+
+        assert.doesNotThrow(
+          () => dom.reconfigure({ url: url2, contentType: contentType2 })
+        );
+
+        assert.strictEqual(window.location.href, url2);
+        assert.strictEqual(document.URL, url2);
+        assert.strictEqual(document.contentType, contentType2);
+      });
+
+      it("should not change the contentType when its option is given", () => {
+        const url1 = "http://current.com/";
+        const contentType1 = "text/xml";
+
+        const dom = new JSDOM("", { url: url1, contentType: contentType1 });
+        const window = dom.window;
+        const document = window.document;
+
+        assert.strictEqual(window.location.href, url1);
+        assert.strictEqual(document.URL, url1);
+        assert.strictEqual(document.contentType, contentType1);
+
+        const url2 = "http://next.org/";
+
+        assert.doesNotThrow(() => dom.reconfigure({ url: url2 }));
+
+        assert.strictEqual(window.location.href, url2);
+        assert.strictEqual(document.URL, url2);
+        assert.strictEqual(document.contentType, contentType1);
+      });
+    });
+
+    describe("inputHtml", () => {
+      it("should change the content HTML", () => {
+        const html0 = "<p>Hello!</p>";
+        const dom = new JSDOM(html0);
+        const window = dom.window;
+        const document = window.document;
+        assert.strictEqual(document.body.innerHTML, html0);
+        assert.strictEqual(document.querySelector("p").textContent, "Hello!");
+        assert.strictEqual(document.querySelector("h1"), null);
+
+        const html1 = "<h1>Hi.</h1>";
+        dom.reconfigure({ }, html1);
+        assert.strictEqual(document.body.innerHTML, html1);
+        assert.strictEqual(dom.window, window);
+        assert.strictEqual(dom.window.document, document);
+        assert.strictEqual(dom.window.document.defaultView, window);
+        assert.strictEqual(document.querySelector("p"), null);
+        assert.strictEqual(document.querySelector("h1").textContent, "Hi.");
+      });
+
+      it("should not change the content HTML when no 2nd parameter is given",
+      () => {
+        const html0 = "<p>Hello!</p>";
+        const dom = new JSDOM(html0);
+        const window = dom.window;
+        const document = window.document;
+        assert.strictEqual(document.body.innerHTML, html0);
+        assert.strictEqual(document.querySelector("p").textContent, "Hello!");
+        assert.strictEqual(document.querySelector("h1"), null);
+
+        dom.reconfigure({ });
+        assert.strictEqual(document.body.innerHTML, html0);
+        assert.strictEqual(dom.window, window);
+        assert.strictEqual(dom.window.document, document);
+        assert.strictEqual(dom.window.document.defaultView, window);
+        assert.strictEqual(document.querySelector("p").textContent, "Hello!");
+      });
+    });
   });
 });


### PR DESCRIPTION
I've modified `JSDOM.reconfigure` method to enable to change the content HTML with its second parameter.

I try to simulate a window's behavior on node.js, and this modification will be useful for this purpose.