### PR TITLE
Fix Window inline event handlers to require runScripts: "dangerously"

### DIFF
--- a/lib/jsdom/living/events/EventTarget-impl.js
+++ b/lib/jsdom/living/events/EventTarget-impl.js
@@ -158,7 +158,7 @@ function invokeInlineListeners(object, event) {
     const document = object._ownerDocument || (wrapper && (wrapper._document || wrapper._ownerDocument));
 
     const runScripts = document && document._defaultView && document._defaultView._runScripts === "dangerously";
-    if (!object.nodeName || runScripts) {
+    if (runScripts || (!object.nodeName && !wrapper._document)) {
       invokeEventListeners([{
         callback: inlineListener,
         options: normalizeEventHandlerOptions(false, ["capture", "once"])

--- a/test/api/regressions.js
+++ b/test/api/regressions.js
@@ -1,0 +1,26 @@
+"use strict";
+const { assert } = require("chai");
+const { describe, it } = require("mocha-sugar-free");
+const { delay } = require("../util.js");
+
+const { JSDOM, VirtualConsole } = require("../..");
+
+describe("API regression tests", () => {
+  it("should work fine even when the body element has an onload handler (GH-1848)", () => {
+    const virtualConsole = new VirtualConsole();
+    const jsdomErrors = [];
+    virtualConsole.on("jsdomError", e => {
+      jsdomErrors.push(e);
+    });
+
+    const dom = new JSDOM(`<html><body onload="foobar()"><p>It works</p></body></html>`, { virtualConsole });
+    const document = dom.window.document;
+
+    assert.strictEqual(document.body.innerHTML, "<p>It works</p>");
+
+    // The error shows up asynchronously!
+    return delay().then(() => {
+      assert.deepEqual(jsdomErrors, []);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1848, and ensures these are consistent with other inline event handlers. However, note that the story for inline event handlers and how they interact with runScripts is likely to change, per #1828. But at least they'll change consistently.