### PR TITLE
Use Set instead of Array for HTMLCollection keys

### DIFF
--- a/lib/jsdom/living/html-collection.js
+++ b/lib/jsdom/living/html-collection.js
@@ -13,7 +13,7 @@ class HTMLCollection {
       throw new TypeError("Invalid constructor");
     }
 
-    this[privates] = { element, query, keys: [], length: 0, version: -1, conflictElements: Object.create(null) };
+    this[privates] = { element, query, keys: new Set(), length: 0, version: -1, conflictElements: Object.create(null) };
     updateHTMLCollection(this);
   }
 
@@ -70,10 +70,10 @@ function resetHTMLCollectionTo(collection, impls) {
   collection[privates].length = wrappers.length;
 
   const keys = collection[privates].keys;
-  for (let i = 0; i < keys.length; ++i) {
+  for (let i = 0; i < keys.size; ++i) {
     delete collection[keys[i]];
   }
-  keys.length = 0;
+  keys.clear();
 
   for (let i = 0; i < impls.length; ++i) {
     addIfAttrPresent(impls[i], wrappers[i], "name");
@@ -96,7 +96,7 @@ function resetHTMLCollectionTo(collection, impls) {
     }
 
     // Don't override existing named ones
-    if (keys.includes(value)) {
+    if (keys.has(value)) {
       return;
     }
 
@@ -105,7 +105,7 @@ function resetHTMLCollectionTo(collection, impls) {
     } else {
       collection[value] = wrapper;
     }
-    keys.push(value);
+    keys.add(value);
   }
 }
 


### PR DESCRIPTION
I am seeing a significant performance improvement parsing large documents with this change. When testing on the markup of the full HTML Spec, I saw an average time of 17 seconds drop to 5 seconds.