### PR TITLE
Delete webkit prefixes in default CSS

### DIFF
--- a/lib/jsdom/browser/default-stylesheet.js
+++ b/lib/jsdom/browser/default-stylesheet.js
@@ -124,13 +124,10 @@ q {
     display: inline
 }
 
-q:before {
-    content: open-quote;
-}
-
-q:after {
-    content: close-quote;
-}
+/* nwmatcher does not support ::before and ::after, so we can't render q
+correctly: https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3
+TODO: add q::before and q::after selectors
+*/
 
 center {
     display: block;
@@ -425,7 +422,8 @@ input, textarea, keygen, select, button {
     text-align: start;
 }
 
-input[type="hidden" i] {
+/* TODO: Add " i" to attribute matchers to support case-insensitive matching */
+input[type="hidden"] {
     display: none
 }
 
@@ -439,7 +437,7 @@ input {
     cursor: auto;
 }
 
-input[type="search" i] {
+input[type="search"] {
     -webkit-appearance: searchfield;
     box-sizing: border-box;
 }
@@ -462,37 +460,37 @@ textarea {
     word-wrap: break-word;
 }
 
-input[type="password" i] {
+input[type="password"] {
     -webkit-text-security: disc !important;
 }
 
-input[type="hidden" i], input[type="image" i], input[type="file" i] {
+input[type="hidden"], input[type="image"], input[type="file"] {
     -webkit-appearance: initial;
     padding: initial;
     background-color: initial;
     border: initial;
 }
 
-input[type="file" i] {
+input[type="file"] {
     align-items: baseline;
     color: inherit;
     text-align: start !important;
 }
 
-input[type="radio" i], input[type="checkbox" i] {
+input[type="radio"], input[type="checkbox"] {
     margin: 3px 0.5ex;
     padding: initial;
     background-color: initial;
     border: initial;
 }
 
-input[type="button" i], input[type="submit" i], input[type="reset" i] {
+input[type="button"], input[type="submit"], input[type="reset"] {
     -webkit-appearance: push-button;
     -webkit-user-select: none;
     white-space: pre
 }
 
-input[type="button" i], input[type="submit" i], input[type="reset" i], button {
+input[type="button"], input[type="submit"], input[type="reset"], button {
     align-items: flex-start;
     text-align: center;
     cursor: default;
@@ -503,7 +501,7 @@ input[type="button" i], input[type="submit" i], input[type="reset" i], button {
     box-sizing: border-box
 }
 
-input[type="range" i] {
+input[type="range"] {
     -webkit-appearance: slider-horizontal;
     padding: initial;
     border: initial;
@@ -511,17 +509,17 @@ input[type="range" i] {
     color: #909090;
 }
 
-input[type="button" i]:disabled, input[type="submit" i]:disabled, input[type="reset" i]:disabled,
+input[type="button"]:disabled, input[type="submit"]:disabled, input[type="reset"]:disabled,
 button:disabled, select:disabled, keygen:disabled, optgroup:disabled, option:disabled,
 select[disabled]>option {
     color: GrayText
 }
 
-input[type="button" i]:active, input[type="submit" i]:active, input[type="reset" i]:active, button:active {
+input[type="button"]:active, input[type="submit"]:active, input[type="reset"]:active, button:active {
     border-style: inset
 }
 
-input[type="button" i]:active:disabled, input[type="submit" i]:active:disabled, input[type="reset" i]:active:disabled, button:active:disabled {
+input[type="button"]:active:disabled, input[type="submit"]:active:disabled, input[type="reset"]:active:disabled, button:active:disabled {
     border-style: outset
 }
 
@@ -538,17 +536,17 @@ param {
     display: none
 }
 
-input[type="checkbox" i] {
+input[type="checkbox"] {
     -webkit-appearance: checkbox;
     box-sizing: border-box;
 }
 
-input[type="radio" i] {
+input[type="radio"] {
     -webkit-appearance: radio;
     box-sizing: border-box;
 }
 
-input[type="color" i] {
+input[type="color"] {
     -webkit-appearance: square-button;
     width: 44px;
     height: 23px;
@@ -558,7 +556,7 @@ input[type="color" i] {
     padding: 1px 2px;
 }
 
-input[type="color" i][list] {
+input[type="color"][list] {
     -webkit-appearance: menulist;
     width: 88px;
     height: 23px
@@ -690,15 +688,15 @@ input:focus, textarea:focus, keygen:focus, select:focus {
     outline-offset: -2px
 }
 
-input[type="button" i]:focus,
-input[type="checkbox" i]:focus,
-input[type="file" i]:focus,
-input[type="hidden" i]:focus,
-input[type="image" i]:focus,
-input[type="radio" i]:focus,
-input[type="reset" i]:focus,
-input[type="search" i]:focus,
-input[type="submit" i]:focus {
+input[type="button"]:focus,
+input[type="checkbox"]:focus,
+input[type="file"]:focus,
+input[type="hidden"]:focus,
+input[type="image"]:focus,
+input[type="radio"]:focus,
+input[type="reset"]:focus,
+input[type="search"]:focus,
+input[type="submit"]:focus {
     outline-offset: 0
 }
 
@@ -761,7 +759,7 @@ bdo {
     unicode-bidi: bidi-override;
 }
 
-textarea[dir=auto i] {
+textarea[dir=auto] {
     unicode-bidi: -webkit-plaintext;
 }
 

--- a/lib/jsdom/browser/default-stylesheet.js
+++ b/lib/jsdom/browser/default-stylesheet.js
@@ -403,11 +403,11 @@ button {
 }
 
 /* Form controls don't go vertical. */
-input, textarea, keygen, select, button, meter, progress {
+input, textarea, select, button, meter, progress {
     -webkit-writing-mode: horizontal-tb !important;
 }
 
-input, textarea, keygen, select, button {
+input, textarea, select, button {
     margin: 0__qem;
     font: -webkit-small-control;
     text-rendering: auto; /* FIXME: Remove when tabs work with optimizeLegibility. */
@@ -442,7 +442,7 @@ input[type="search"] {
     box-sizing: border-box;
 }
 
-keygen, select {
+select {
     border-radius: 5px;
 }
 
@@ -510,7 +510,7 @@ input[type="range"] {
 }
 
 input[type="button"]:disabled, input[type="submit"]:disabled, input[type="reset"]:disabled,
-button:disabled, select:disabled, keygen:disabled, optgroup:disabled, option:disabled,
+button:disabled, select:disabled, optgroup:disabled, option:disabled,
 select[disabled]>option {
     color: GrayText
 }
@@ -684,7 +684,7 @@ applet:focus, embed:focus, iframe:focus, object:focus {
     outline: none
 }
 
-input:focus, textarea:focus, keygen:focus, select:focus {
+input:focus, textarea:focus, select:focus {
     outline-offset: -2px
 }
 

--- a/lib/jsdom/browser/default-stylesheet.js
+++ b/lib/jsdom/browser/default-stylesheet.js
@@ -72,10 +72,6 @@ body {
     margin: 8px
 }
 
-body:-webkit-full-page-media {
-    background-color: rgb(0, 0, 0)
-}
-
 p {
     display: block;
     -webkit-margin-before: 1__qem;
@@ -173,35 +169,41 @@ h1 {
     font-weight: bold
 }
 
-:-webkit-any(article,aside,nav,section) h1 {
+article h1,
+aside h1,
+nav h1,
+section h1 {
     font-size: 1.5em;
     -webkit-margin-before: 0.83__qem;
     -webkit-margin-after: 0.83em;
 }
 
-:-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) h1 {
+article article h1,
+article aside h1,
+article nav h1,
+article section h1,
+aside article h1,
+aside aside h1,
+aside nav h1,
+aside section h1,
+nav article h1,
+nav aside h1,
+nav nav h1,
+nav section h1,
+section article h1,
+section aside h1,
+section nav h1,
+section section h1 {
     font-size: 1.17em;
     -webkit-margin-before: 1__qem;
     -webkit-margin-after: 1em;
 }
 
-:-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) h1 {
-    font-size: 1.00em;
-    -webkit-margin-before: 1.33__qem;
-    -webkit-margin-after: 1.33em;
-}
-
-:-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) h1 {
-    font-size: .83em;
-    -webkit-margin-before: 1.67__qem;
-    -webkit-margin-after: 1.67em;
-}
-
-:-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) :-webkit-any(article,aside,nav,section) h1 {
-    font-size: .67em;
-    -webkit-margin-before: 2.33__qem;
-    -webkit-margin-after: 2.33em;
-}
+/* Remaining selectors are deleted because nwmatcher does not support
+:matches() and expanding the selectors manually would be far too verbose.
+Also see https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings
+TODO: rewrite to use :matches() when nwmatcher supports it.
+*/
 
 h2 {
     display: block;
@@ -442,88 +444,8 @@ input[type="search" i] {
     box-sizing: border-box;
 }
 
-input::-webkit-textfield-decoration-container {
-    display: flex;
-    align-items: center;
-    -webkit-user-modify: read-only !important;
-    content: none !important;
-}
-
-input[type="search" i]::-webkit-textfield-decoration-container {
-    direction: ltr;
-}
-
-input::-webkit-clear-button {
-    -webkit-appearance: searchfield-cancel-button;
-    display: inline-block;
-    flex: none;
-    -webkit-user-modify: read-only !important;
-    -webkit-margin-start: 2px;
-    opacity: 0;
-    pointer-events: none;
-}
-
-input:enabled:read-write:-webkit-any(:focus,:hover)::-webkit-clear-button {
-    opacity: 1;
-    pointer-events: auto;
-}
-
-input[type="search" i]::-webkit-search-cancel-button {
-    -webkit-appearance: searchfield-cancel-button;
-    display: block;
-    flex: none;
-    -webkit-user-modify: read-only !important;
-    -webkit-margin-start: 1px;
-    opacity: 0;
-    pointer-events: none;
-}
-
-input[type="search" i]:enabled:read-write:-webkit-any(:focus,:hover)::-webkit-search-cancel-button {
-    opacity: 1;
-    pointer-events: auto;
-}
-
-input[type="search" i]::-webkit-search-decoration {
-    -webkit-appearance: searchfield-decoration;
-    display: block;
-    flex: none;
-    -webkit-user-modify: read-only !important;
-    -webkit-align-self: flex-start;
-    margin: auto 0;
-}
-
-input[type="search" i]::-webkit-search-results-decoration {
-    -webkit-appearance: searchfield-results-decoration;
-    display: block;
-    flex: none;
-    -webkit-user-modify: read-only !important;
-    -webkit-align-self: flex-start;
-    margin: auto 0;
-}
-
-input::-webkit-inner-spin-button {
-    -webkit-appearance: inner-spin-button;
-    display: inline-block;
-    cursor: default;
-    flex: none;
-    align-self: stretch;
-    -webkit-user-select: none;
-    -webkit-user-modify: read-only !important;
-    opacity: 0;
-    pointer-events: none;
-}
-
-input:enabled:read-write:-webkit-any(:focus,:hover)::-webkit-inner-spin-button {
-    opacity: 1;
-    pointer-events: auto;
-}
-
 keygen, select {
     border-radius: 5px;
-}
-
-keygen::-webkit-keygen-select {
-    margin: 0px;
 }
 
 textarea {
@@ -538,20 +460,6 @@ textarea {
     padding: 2px;
     white-space: pre-wrap;
     word-wrap: break-word;
-}
-
-::-webkit-input-placeholder {
-    -webkit-text-security: none;
-    color: darkGray;
-    display: block !important;
-    pointer-events: none !important;
-}
-
-input::-webkit-input-placeholder {
-    white-space: pre;
-    word-wrap: normal;
-    overflow: hidden;
-    -webkit-user-modify: read-only !important;
 }
 
 input[type="password" i] {
@@ -571,12 +479,6 @@ input[type="file" i] {
     text-align: start !important;
 }
 
-input:-webkit-autofill, textarea:-webkit-autofill, select:-webkit-autofill {
-    background-color: #FAFFBD !important;
-    background-image:none !important;
-    color: #000000 !important;
-}
-
 input[type="radio" i], input[type="checkbox" i] {
     margin: 3px 0.5ex;
     padding: initial;
@@ -590,15 +492,7 @@ input[type="button" i], input[type="submit" i], input[type="reset" i] {
     white-space: pre
 }
 
-input[type="file" i]::-webkit-file-upload-button {
-    -webkit-appearance: push-button;
-    -webkit-user-modify: read-only !important;
-    white-space: nowrap;
-    margin: 0;
-    font-size: inherit;
-}
-
-input[type="button" i], input[type="submit" i], input[type="reset" i], input[type="file" i]::-webkit-file-upload-button, button {
+input[type="button" i], input[type="submit" i], input[type="reset" i], button {
     align-items: flex-start;
     text-align: center;
     cursor: default;
@@ -617,49 +511,18 @@ input[type="range" i] {
     color: #909090;
 }
 
-input[type="range" i]::-webkit-slider-container, input[type="range" i]::-webkit-media-slider-container {
-    flex: 1;
-    min-width: 0;
-    box-sizing: border-box;
-    -webkit-user-modify: read-only !important;
-    display: flex;
-}
-
-input[type="range" i]::-webkit-slider-runnable-track {
-    flex: 1;
-    min-width: 0;
-    -webkit-align-self: center;
-
-    box-sizing: border-box;
-    -webkit-user-modify: read-only !important;
-    display: block;
-}
-
-input[type="range" i]::-webkit-slider-thumb, input[type="range" i]::-webkit-media-slider-thumb {
-    -webkit-appearance: sliderthumb-horizontal;
-    box-sizing: border-box;
-    -webkit-user-modify: read-only !important;
-    display: block;
-}
-
 input[type="button" i]:disabled, input[type="submit" i]:disabled, input[type="reset" i]:disabled,
-input[type="file" i]:disabled::-webkit-file-upload-button, button:disabled,
-select:disabled, keygen:disabled, optgroup:disabled, option:disabled,
+button:disabled, select:disabled, keygen:disabled, optgroup:disabled, option:disabled,
 select[disabled]>option {
     color: GrayText
 }
 
-input[type="button" i]:active, input[type="submit" i]:active, input[type="reset" i]:active, input[type="file" i]:active::-webkit-file-upload-button, button:active {
+input[type="button" i]:active, input[type="submit" i]:active, input[type="reset" i]:active, button:active {
     border-style: inset
 }
 
-input[type="button" i]:active:disabled, input[type="submit" i]:active:disabled, input[type="reset" i]:active:disabled, input[type="file" i]:active:disabled::-webkit-file-upload-button, button:active:disabled {
+input[type="button" i]:active:disabled, input[type="submit" i]:active:disabled, input[type="reset" i]:active:disabled, button:active:disabled {
     border-style: outset
-}
-
-option:-internal-spatial-navigation-focus {
-    outline: black dashed 1px;
-    outline-offset: -1px;
 }
 
 datalist {
@@ -695,77 +558,10 @@ input[type="color" i] {
     padding: 1px 2px;
 }
 
-input[type="color" i]::-webkit-color-swatch-wrapper {
-    display:flex;
-    padding: 4px 2px;
-    box-sizing: border-box;
-    -webkit-user-modify: read-only !important;
-    width: 100%;
-    height: 100%
-}
-
-input[type="color" i]::-webkit-color-swatch {
-    background-color: #000000;
-    border: 1px solid #777777;
-    flex: 1;
-    min-width: 0;
-    -webkit-user-modify: read-only !important;
-}
-
 input[type="color" i][list] {
     -webkit-appearance: menulist;
     width: 88px;
     height: 23px
-}
-
-input[type="color" i][list]::-webkit-color-swatch-wrapper {
-    padding-left: 8px;
-    padding-right: 24px;
-}
-
-input[type="color" i][list]::-webkit-color-swatch {
-    border-color: #000000;
-}
-
-input::-webkit-calendar-picker-indicator {
-    display: inline-block;
-    width: 0.66em;
-    height: 0.66em;
-    padding: 0.17em 0.34em;
-    -webkit-user-modify: read-only !important;
-    opacity: 0;
-    pointer-events: none;
-}
-
-input::-webkit-calendar-picker-indicator:hover {
-    background-color: #eee;
-}
-
-input:enabled:read-write:-webkit-any(:focus,:hover)::-webkit-calendar-picker-indicator,
-input::-webkit-calendar-picker-indicator:focus {
-    opacity: 1;
-    pointer-events: auto;
-}
-
-input[type="date" i]:disabled::-webkit-clear-button,
-input[type="date" i]:disabled::-webkit-inner-spin-button,
-input[type="datetime-local" i]:disabled::-webkit-clear-button,
-input[type="datetime-local" i]:disabled::-webkit-inner-spin-button,
-input[type="month" i]:disabled::-webkit-clear-button,
-input[type="month" i]:disabled::-webkit-inner-spin-button,
-input[type="week" i]:disabled::-webkit-clear-button,
-input[type="week" i]:disabled::-webkit-inner-spin-button,
-input:disabled::-webkit-calendar-picker-indicator,
-input[type="date" i][readonly]::-webkit-clear-button,
-input[type="date" i][readonly]::-webkit-inner-spin-button,
-input[type="datetime-local" i][readonly]::-webkit-clear-button,
-input[type="datetime-local" i][readonly]::-webkit-inner-spin-button,
-input[type="month" i][readonly]::-webkit-clear-button,
-input[type="month" i][readonly]::-webkit-inner-spin-button,
-input[type="week" i][readonly]::-webkit-clear-button,
-input[type="week" i][readonly]::-webkit-inner-spin-button,
-input[readonly]::-webkit-calendar-picker-indicator {
-    visibility: hidden;
 }
 
 select {
@@ -780,22 +576,6 @@ select {
     cursor: default;
 }
 
-select:not(:-internal-list-box) {
-    overflow: visible !important;
-}
-
-select:-internal-list-box {
-    -webkit-appearance: listbox;
-    align-items: flex-start;
-    border: 1px inset gray;
-    border-radius: initial;
-    overflow-x: hidden;
-    overflow-y: scroll;
-    vertical-align: text-bottom;
-    -webkit-user-select: none;
-    white-space: nowrap;
-}
-
 optgroup {
     font-weight: bolder;
     display: block;
@@ -807,30 +587,6 @@ option {
     padding: 0 2px 1px 2px;
     white-space: pre;
     min-height: 1.2em;
-}
-
-select:-internal-list-box option,
-select:-internal-list-box optgroup {
-    line-height: initial !important;
-}
-
-select:-internal-list-box:focus option:checked {
-    background-color: -internal-active-list-box-selection !important;
-    color: -internal-active-list-box-selection-text !important;
-}
-
-select:-internal-list-box option:checked {
-    background-color: -internal-inactive-list-box-selection !important;
-    color: -internal-inactive-list-box-selection-text !important;
-}
-
-select:-internal-list-box:disabled option:checked,
-select:-internal-list-box option:checked:disabled {
-    color: gray !important;
-}
-
-select:-internal-list-box hr {
-    border-style: none;
 }
 
 output {
@@ -848,43 +604,6 @@ meter {
     vertical-align: -0.2em;
 }
 
-meter::-webkit-meter-inner-element {
-    -webkit-appearance: inherit;
-    box-sizing: inherit;
-    -webkit-user-modify: read-only !important;
-    height: 100%;
-    width: 100%;
-}
-
-meter::-webkit-meter-bar {
-    background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
-    height: 100%;
-    width: 100%;
-    -webkit-user-modify: read-only !important;
-    box-sizing: border-box;
-}
-
-meter::-webkit-meter-optimum-value {
-    background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
-    height: 100%;
-    -webkit-user-modify: read-only !important;
-    box-sizing: border-box;
-}
-
-meter::-webkit-meter-suboptimum-value {
-    background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
-    height: 100%;
-    -webkit-user-modify: read-only !important;
-    box-sizing: border-box;
-}
-
-meter::-webkit-meter-even-less-good-value {
-    background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
-    height: 100%;
-    -webkit-user-modify: read-only !important;
-    box-sizing: border-box;
-}
-
 /* progress */
 
 progress {
@@ -894,30 +613,6 @@ progress {
     height: 1em;
     width: 10em;
     vertical-align: -0.2em;
-}
-
-progress::-webkit-progress-inner-element {
-    -webkit-appearance: inherit;
-    box-sizing: inherit;
-    -webkit-user-modify: read-only;
-    height: 100%;
-    width: 100%;
-}
-
-progress::-webkit-progress-bar {
-    background-color: gray;
-    height: 100%;
-    width: 100%;
-    -webkit-user-modify: read-only !important;
-    box-sizing: border-box;
-}
-
-progress::-webkit-progress-value {
-    background-color: green;
-    height: 100%;
-    width: 50%; /* should be removed later */
-    -webkit-user-modify: read-only !important;
-    box-sizing: border-box;
 }
 
 /* inline elements */
@@ -1003,19 +698,8 @@ input[type="image" i]:focus,
 input[type="radio" i]:focus,
 input[type="reset" i]:focus,
 input[type="search" i]:focus,
-input[type="submit" i]:focus,
-input[type="file" i]:focus::-webkit-file-upload-button {
+input[type="submit" i]:focus {
     outline-offset: 0
-}
-
-a:-webkit-any-link {
-    color: -webkit-link;
-    text-decoration: underline;
-    cursor: auto;
-}
-
-a:-webkit-any-link:active {
-    color: -webkit-activelink
 }
 
 /* HTML5 ruby elements */
@@ -1065,13 +749,6 @@ summary {
     display: block
 }
 
-summary::-webkit-details-marker {
-    display: inline-block;
-    width: 0.66em;
-    height: 0.66em;
-    -webkit-margin-end: 0.4em;
-}
-
 template {
     display: none
 }
@@ -1103,25 +780,6 @@ dialog {
     padding: 1em;
     background: white;
     color: black
-}
-
-dialog::backdrop {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: rgba(0,0,0,0.1)
-}
-
-/* page */
-
-@page {
-    /* FIXME: Define the right default values for page properties. */
-    size: auto;
-    margin: auto;
-    padding: 0px;
-    border-width: 0px;
 }
 
 /* noscript is handled internally, as it depends on settings. */


### PR DESCRIPTION
See tmpvar/jsdom#1560.

In particular, this helps because it takes out all the selectors that would cause exceptions to be thrown: webkit prefixes in selectors and case-insensitive attribute selectors.

I've tested this patch by running the test that runs slowly with breakpoints set on "all exceptions". There were no exceptions arising from <https://github.com/dperini/nwmatcher/blob/29a1cdc284e330ec6aa38e31c2f02e755a536381/src/nwmatcher-noqsa.js#L765>.

Even though this deletes code, this adds functionality. For example, the rule `-input[type="hidden" i]` would have been ignored before, because nwmatcher doesn't know how to handle ` i`. It would now apply (although type would have to be "hidden", and not "HiDdEn" or "HIDDEN").

This single change improves performance in one of my tests from 28s to 8s.

I'm not really sure how to run the benchmarks. `node ./benchmark/runner` appears to do nothing.