### PR TITLE
Support for ArrayBufferViews to XHR::send

### DIFF
--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -586,7 +586,7 @@ module.exports = function createXMLHttpRequest(window) {
           } else if (body instanceof ArrayBuffer) {
             flag.body = new Buffer(new Uint8Array(body));
           } else if (ArrayBuffer.isView(body)) {
-            flag.body = new Buffer(body.buffer);
+            flag.body = new Buffer(body.buffer, body.byteOffset, body.byteLength);
           } else if (body instanceof Document.interface) {
             if (body.childNodes.length === 0) {
               throw new DOMException(DOMException.INVALID_STATE_ERR);

--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -585,6 +585,8 @@ module.exports = function createXMLHttpRequest(window) {
             }
           } else if (body instanceof ArrayBuffer) {
             flag.body = new Buffer(new Uint8Array(body));
+          } else if (ArrayBuffer.isView(body)) {
+            flag.body = new Buffer(body.buffer);
           } else if (body instanceof Document.interface) {
             if (body.childNodes.length === 0) {
               throw new DOMException(DOMException.INVALID_STATE_ERR);

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -390,6 +390,7 @@ describe("Web Platform Tests", () => {
     "XMLHttpRequest/send-content-type-charset.htm",
     "XMLHttpRequest/send-content-type-string.htm",
     "XMLHttpRequest/send-data-arraybuffer.htm",
+    "XMLHttpRequest/send-data-arraybufferview.htm",
     "XMLHttpRequest/send-data-blob.htm",
     "XMLHttpRequest/send-data-es-object.htm",
     "XMLHttpRequest/send-data-formdata.htm",


### PR DESCRIPTION
This tiny two-liner adds support for ArrayBufferViews to be passed to `XMLHttpRequest.prototype.send`.

This makes the XHR more [spec-compliant](https://fetch.spec.whatwg.org/#body-mixin), as ArrayBufferViews are [BufferSources](https://heycam.github.io/webidl/#BufferSource).