### PR TITLE
Update nwmatcher dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cssstyle": ">= 0.2.37 < 0.3.0",
     "escodegen": "^1.6.1",
     "html-encoding-sniffer": "^1.0.1",
-    "nwmatcher": ">= 1.3.9 < 2.0.0",
+    "nwmatcher": ">= 1.4.0 < 2.0.0",
     "parse5": "^3.0.2",
     "pn": "^1.0.0",
     "request": "^2.79.0",


### PR DESCRIPTION
Resolves: https://github.com/tmpvar/jsdom/issues/1740
Due to a bug in the nwmatcher (https://github.com/dperini/nwmatcher/issues/103), query selectors with single characters would return an error. Update nwmatcher minimum version to include bug fix.