### PR TITLE
Throw error when the API receives an unknown option

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -249,6 +249,28 @@ function transformOptions(options, encoding) {
     beforeParse() { }
   };
 
+  const knownOptions = new Set([
+    "beforeParse",
+    "contentType",
+    "cookieJar",
+    "encoding",
+    "includeNodeLocations",
+    "parseOptions",
+    "parsingMode",
+    "referrer",
+    "resources",
+    "runScripts",
+    "url",
+    "userAgent",
+    "virtualConsole"
+  ]);
+
+  for (const option in options) {
+    if (!knownOptions.has(option)) {
+      throw new TypeError(`Found unknown option "${option}"`);
+    }
+  }
+
   if (options.contentType !== undefined) {
     const contentTypeParsed = parseContentType(options.contentType);
     if (contentTypeParsed === null) {

--- a/test/api/options.js
+++ b/test/api/options.js
@@ -7,6 +7,10 @@ const { JSDOM } = require("../..");
 const { version: packageVersion } = require("../../package.json");
 
 describe("API: constructor options", () => {
+  it("should throw an error when passing an unknown option", () => {
+    assert.throws(() => new JSDOM(``, { unknown: "option" }), TypeError);
+  });
+
   describe("referrer", () => {
     it("should allow customizing document.referrer via the referrer option", () => {
       const document = (new JSDOM(``, { referrer: "http://example.com/" })).window.document;


### PR DESCRIPTION
This could spare users from some confusion and time spent debugging issues like #1874.

**EDIT**: It has occurred to me that the words valid/invalid may be more suitable than known/unknown in this context. I can make the switch if you'd prefer that.