### PR TITLE
fix(package.json): add engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "benchmark-browser": "node ./benchmark/runner --bundle",
     "convert-idl": "node ./scripts/webidl/convert"
   },
-  "main": "./lib/api.js"
+  "main": "./lib/api.js",
+  "engines": {
+    "node": ">=6.0.0"  
+  }
 }


### PR DESCRIPTION
it should be there, because there is code in `lib/api.js` that doesn't work on versions below 6.