### PR TITLE
Make navigation work more like spec

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -114,12 +114,12 @@ class JSDOM {
       const document = idlUtils.implForWrapper(this[window]._document);
 
       const url = whatwgURL.parseURL(settings.url);
-      if (url === "failure") {
+      if (url === null) {
         throw new TypeError(`Could not parse "${settings.url}" as a URL`);
       }
 
       document._URL = url;
-      document._origin = whatwgURL.serializeURLToUnicodeOrigin(document._URL);
+      document._origin = whatwgURL.serializeURLOrigin(document._URL);
     }
   }
 

--- a/lib/jsdom/living/helpers/document-base-url.js
+++ b/lib/jsdom/living/helpers/document-base-url.js
@@ -48,5 +48,5 @@ function frozenBaseURL(baseElement, fallbackBaseURL) {
 
   const baseHrefAttribute = baseElement.getAttribute("href");
   const result = whatwgURL.parseURL(baseHrefAttribute, { baseURL: fallbackBaseURL });
-  return result === "failure" ? fallbackBaseURL : result;
+  return result === null ? fallbackBaseURL : result;
 }

--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -62,7 +62,7 @@ function scanForImportRules(elementImpl, cssRules, baseURL) {
       //     If loading of the style sheet fails its cssRules list is simply
       //     empty. I.e. an @import rule always has an associated style sheet.
       const parsed = whatwgURL.parseURL(cssRules[i].href, { baseURL });
-      if (parsed === "failure") {
+      if (parsed === null) {
         const window = elementImpl._ownerDocument._defaultView;
         if (window) {
           const error = new Error(`Could not parse CSS @import URL ${cssRules[i].href} relative to base URL ` +

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -237,12 +237,12 @@ class DocumentImpl extends NodeImpl {
 
     const urlOption = privateData.options.url === undefined ? "about:blank" : privateData.options.url;
     const parsed = whatwgURL.parseURL(urlOption);
-    if (parsed === "failure") {
+    if (parsed === null) {
       throw new TypeError(`Could not parse "${urlOption}" as a URL`);
     }
 
     this._URL = parsed;
-    this._origin = whatwgURL.serializeURLToUnicodeOrigin(parsed);
+    this._origin = whatwgURL.serializeURLOrigin(parsed);
 
     this._location = Location.createImpl([], { relevantDocument: this });
     this._history = History.createImpl([], {

--- a/lib/jsdom/living/nodes/HTMLBaseElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLBaseElement-impl.js
@@ -10,7 +10,7 @@ class HTMLBaseElement extends HTMLElementImpl {
     const url = this.hasAttribute("href") ? this.getAttribute("href") : "";
     const parsed = whatwgURL.parseURL(url, { baseURL: fallbackBaseURL(document) });
 
-    if (parsed === "failure") {
+    if (parsed === null) {
       return url;
     }
 

--- a/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLFrameElement-impl.js
@@ -1,13 +1,13 @@
 "use strict";
 
 const parseContentType = require("content-type-parser");
-const URL = require("whatwg-url").URL;
-
+const { parseURL, serializeURL } = require("whatwg-url");
+const { evaluateJavaScriptURL } = require("../window/navigation");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const applyDocumentFeatures = require("../../browser/documentfeatures").applyDocumentFeatures;
 const resourceLoader = require("../../browser/resource-loader");
 const defineGetter = require("../../utils").defineGetter;
-const documentBaseURLSerialized = require("../helpers/document-base-url").documentBaseURLSerialized;
+const { documentBaseURL } = require("../helpers/document-base-url");
 const getAttributeValue = require("../attributes").getAttributeValue;
 const idlUtils = require("../generated/utils");
 const reflectURLAttribute = require("../../utils").reflectURLAttribute;
@@ -28,19 +28,16 @@ function loadFrame(frame) {
   let url;
   const srcAttribute = getAttributeValue(frame, "src");
   if (srcAttribute === null || srcAttribute === "") {
-    url = new URL("about:blank");
+    url = parseURL("about:blank");
   } else {
-    try {
-      url = new URL(srcAttribute, documentBaseURLSerialized(parentDoc));
-    } catch (e) {
-      url = new URL("about:blank");
-    }
+    url = parseURL(srcAttribute, { baseURL: documentBaseURL(parentDoc) || undefined }) || parseURL("about:blank");
   }
+  const serializedURL = serializeURL(url);
 
   // This is not great, but prevents a require cycle during webidl2js generation
   const wnd = new parentDoc._defaultView.constructor({
     parsingMode: "html",
-    url: url.protocol === "javascript:" || url.href === "about:blank" ? parentDoc.URL : url.href,
+    url: url.scheme === "javascript" || serializedURL === "about:blank" ? parentDoc.URL : serializedURL,
     resourceLoader: parentDoc._customResourceLoader,
     userAgent: parentDoc._defaultView.navigator.userAgent,
     referrer: parentDoc.URL,
@@ -63,21 +60,24 @@ function loadFrame(frame) {
   contentWindow._virtualConsole = parent._virtualConsole;
 
   // Handle about:blank with a simulated load of an empty document.
-  if (url.href === "about:blank") {
+  if (serializedURL === "about:blank") {
     // Cannot be done inside the enqueued callback; the documentElement etc. need to be immediately available.
     contentDoc.write("<html><head></head><body></body></html>");
     contentDoc.close();
     resourceLoader.enqueue(frame)(); // to fire the load event
-  } else if (url.protocol === "javascript:") {
+  } else if (url.scheme === "javascript") {
     // Cannot be done inside the enqueued callback; the documentElement etc. need to be immediately available.
     contentDoc.write("<html><head></head><body></body></html>");
     contentDoc.close();
-    contentWindow.eval(url.pathname);
+    const result = evaluateJavaScriptURL(contentWindow, url);
+    if (typeof result === "string") {
+      contentDoc.body.textContent = result;
+    }
     resourceLoader.enqueue(frame)(); // to fire the load event
   } else {
     resourceLoader.load(
       frame,
-      url.href,
+      serializedURL,
       { defaultEncoding: parentDoc._encoding, detectMetaCharset: true },
       (html, responseURL, response) => {
         if (response) {

--- a/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js
+++ b/lib/jsdom/living/nodes/HTMLHyperlinkElementUtils-impl.js
@@ -34,7 +34,7 @@ exports.implementation = class HTMLHyperlinkElementUtilsImpl {
       return "";
     }
 
-    return whatwgURL.serializeURLToUnicodeOrigin(this.url);
+    return whatwgURL.serializeURLOrigin(this.url);
   }
 
   get protocol() {
@@ -288,7 +288,7 @@ function setTheURL(hheu) {
 
   const parsed = parseURLToResultingURLRecord(href, hheu._ownerDocument);
 
-  hheu.url = parsed === "failure" ? null : parsed;
+  hheu.url = parsed === null ? null : parsed;
 }
 
 function updateHref(hheu) {

--- a/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLinkElement-impl.js
@@ -54,7 +54,7 @@ function obtainTheResource(el) {
   }
 
   const url = parseURLToResultingURLRecord(href, el._ownerDocument);
-  if (url === "failure") {
+  if (url === null) {
     return;
   }
 

--- a/lib/jsdom/living/window/History-impl.js
+++ b/lib/jsdom/living/window/History-impl.js
@@ -83,7 +83,7 @@ exports.implementation = class HistoryImpl {
       // difference matters in the case of cross-frame calls.
       newURL = parseURLToResultingURLRecord(url, this._document);
 
-      if (newURL === "failure") {
+      if (newURL === null) {
         throw new DOMException(DOMException.SECURITY_ERR, `Could not parse url argument "${url}" to ${methodName} ` +
           `against base URL "${documentBaseURLSerialized(this._document)}".`);
       }

--- a/lib/jsdom/living/window/Location-impl.js
+++ b/lib/jsdom/living/window/Location-impl.js
@@ -3,7 +3,6 @@ const whatwgURL = require("whatwg-url");
 const documentBaseURL = require("../helpers/document-base-url.js").documentBaseURL;
 const parseURLToResultingURLRecord = require("../helpers/document-base-url.js").parseURLToResultingURLRecord;
 const DOMException = require("../../web-idl/DOMException.js");
-const notImplemented = require("../../browser/not-implemented.js");
 const navigate = require("./navigation.js").navigate;
 
 // Not implemented: use of entry settings object's API base URL in href setter, assign, and replace. Instead we just
@@ -20,17 +19,15 @@ exports.implementation = class LocationImpl {
   }
 
   _locationObjectSetterNavigate(url) {
-    // Not implemented: extra steps here to determine replacement flag, since they are not applicable to our
-    // rudimentary "navigation" implementation.
+    // Not implemented: extra steps here to determine replacement flag.
 
     return this._locationObjectNavigate(url);
   }
 
-  _locationObjectNavigate(url/* , { replacement = false } = {} */) {
+  _locationObjectNavigate(url, { replacement = false } = {}) {
     // Not implemented: the setup for calling navigate, which doesn't apply to our stub navigate anyway.
-    // Not implemented: using the replacement flag.
 
-    navigate(this._relevantDocument._defaultView, url);
+    navigate(this._relevantDocument._defaultView, url, { replacement, exceptionsEnabled: true });
   }
 
   toString() {
@@ -42,7 +39,7 @@ exports.implementation = class LocationImpl {
   }
   set href(v) {
     const newURL = whatwgURL.parseURL(v, { baseURL: documentBaseURL(this._relevantDocument) });
-    if (newURL === "failure") {
+    if (newURL === null) {
       throw new TypeError(`Could not parse "${v}" as a URL`);
     }
 
@@ -50,7 +47,7 @@ exports.implementation = class LocationImpl {
   }
 
   get origin() {
-    return whatwgURL.serializeURLToUnicodeOrigin(this._url);
+    return whatwgURL.serializeURLOrigin(this._url);
   }
 
   get protocol() {
@@ -60,7 +57,7 @@ exports.implementation = class LocationImpl {
     const copyURL = Object.assign({}, this._url);
 
     const possibleFailure = whatwgURL.basicURLParse(v + ":", { url: copyURL, stateOverride: "scheme start" });
-    if (possibleFailure === "failure") {
+    if (possibleFailure === null) {
       throw new TypeError(`Could not parse the URL after setting the procol to "${v}"`);
     }
 
@@ -209,7 +206,7 @@ exports.implementation = class LocationImpl {
     // Should be entry settings object; oh well
     const parsedURL = parseURLToResultingURLRecord(url, this._relevantDocument);
 
-    if (parsedURL === "failure") {
+    if (parsedURL === null) {
       throw new DOMException(DOMException.SYNTAX_ERR, `Could not resolve the given string "${url}" relative to the ` +
         `base URL "${this._relevantDocument.URL}"`);
     }
@@ -221,7 +218,7 @@ exports.implementation = class LocationImpl {
     // Should be entry settings object; oh well
     const parsedURL = parseURLToResultingURLRecord(url, this._relevantDocument);
 
-    if (parsedURL === "failure") {
+    if (parsedURL === null) {
       throw new DOMException(DOMException.SYNTAX_ERR, `Could not resolve the given string "${url}" relative to the ` +
         `base URL "${this._relevantDocument.URL}"`);
     }
@@ -230,6 +227,7 @@ exports.implementation = class LocationImpl {
   }
 
   reload() {
-    notImplemented("location.reload()", this._relevantDocument._defaultView);
+    const flags = { replace: true, reloadTriggered: true, exceptionsEnabled: true };
+    navigate(this._relevantDocument._defaultView, this._url, flags);
   }
 };

--- a/lib/jsdom/living/window/navigation.js
+++ b/lib/jsdom/living/window/navigation.js
@@ -64,6 +64,15 @@ exports.traverseHistory = (window, specifiedEntry, flags = {}) => {
   window._currentSessionHistoryEntryIndex = window._sessionHistory.indexOf(specifiedEntry);
 };
 
+exports.evaluateJavaScriptURL = (window, urlRecord) => {
+  const urlString = whatwgURL.serializeURL(urlRecord);
+  const scriptSource = whatwgURL.percentDecode(Buffer.from(urlString)).toString();
+  if (window._runScripts === "dangerously") {
+    return window.eval(scriptSource);
+  }
+  return undefined;
+};
+
 // https://html.spec.whatwg.org/#navigating-across-documents
 exports.navigate = (window, newURL, flags) => {
   // This is NOT a spec-compliant implementation of navigation in any way. It implements a few selective steps that
@@ -88,14 +97,9 @@ exports.navigate = (window, newURL, flags) => {
   // NOT IMPLEMENTED: if resource is a response...
   if (newURL.scheme === "javascript") {
     window.setTimeout(() => {
-      const urlString = whatwgURL.serializeURL(newURL).replace(/^javascript:/, "");
-      // https://url.spec.whatwg.org/#percent-decode
-      const scriptSource = whatwgURL.percentDecode(Buffer.from(urlString)).toString();
-      if (window._runScripts === "dangerously") {
-        const result = window.eval(scriptSource);
-        if (typeof result === "string") {
-          notImplemented("string results from 'javascript:' URLs", window);
-        }
+      const result = exports.evaluateJavaScriptURL(window, newURL);
+      if (typeof result === "string") {
+        notImplemented("string results from 'javascript:' URLs", window);
       }
     }, 0);
     return;

--- a/lib/jsdom/living/window/navigation.js
+++ b/lib/jsdom/living/window/navigation.js
@@ -6,12 +6,9 @@ const HashChangeEvent = require("../generated/HashChangeEvent.js");
 const PopStateEvent = require("../generated/PopStateEvent.js");
 const idlUtils = require("../generated/utils");
 
-exports.traverseHistory = (window, specifiedEntry, flags) => {
+exports.traverseHistory = (window, specifiedEntry, flags = {}) => {
   // Not spec compliant, just minimal. Lots of missing steps.
 
-  if (flags === undefined) {
-    flags = {};
-  }
   const nonBlockingEvents = Boolean(flags.nonBlockingEvents);
 
   const document = idlUtils.implForWrapper(window._document);
@@ -67,37 +64,90 @@ exports.traverseHistory = (window, specifiedEntry, flags) => {
   window._currentSessionHistoryEntryIndex = window._sessionHistory.indexOf(specifiedEntry);
 };
 
-exports.navigate = (window, newURL) => {
+// https://html.spec.whatwg.org/#navigating-across-documents
+exports.navigate = (window, newURL, flags) => {
   // This is NOT a spec-compliant implementation of navigation in any way. It implements a few selective steps that
-  // are nice for jsdom users, regarding hash changes. We could maybe implement javascript: URLs in the future, but
-  // the rest is too hard.
+  // are nice for jsdom users, regarding hash changes and JavaScript URLs. Full navigation support is being worked on
+  // and will likely require some additional hooks to be implemented.
 
   const document = idlUtils.implForWrapper(window._document);
-
   const currentURL = document._URL;
 
-  if (newURL.scheme !== currentURL.scheme ||
-      newURL.username !== currentURL.username ||
-      newURL.password !== currentURL.password ||
-      newURL.host !== currentURL.host ||
-      newURL.port !== currentURL.port ||
-      !arrayEqual(newURL.path, currentURL.path) ||
-      newURL.query !== currentURL.query ||
-      // Omitted per spec: url.fragment !== this._url.fragment ||
-      newURL.cannotBeABaseURL !== currentURL.cannotBeABaseURL) {
-    notImplemented("navigation (except hash changes)", window);
+  if (!flags.reloadTriggered && urlEquals(currentURL, newURL, { excludeFragments: true })) {
+    if (newURL.fragment !== currentURL.fragment) {
+      navigateToFragment(window, newURL, flags);
+    }
     return;
   }
 
-  if (newURL.fragment !== currentURL.fragment) {
-    // https://html.spec.whatwg.org/#scroll-to-fragid
+  // NOT IMPLEMENTED: Prompt to unload the active document of browsingContext.
 
+  // NOT IMPLEMENTED: form submission algorithm
+  // const navigationType = 'other';
+
+  // NOT IMPLEMENTED: if resource is a response...
+  if (newURL.scheme === "javascript") {
+    window.setTimeout(() => {
+      const urlString = whatwgURL.serializeURL(newURL).replace(/^javascript:/, "");
+      // https://url.spec.whatwg.org/#percent-decode
+      const scriptSource = whatwgURL.percentDecode(Buffer.from(urlString)).toString();
+      if (window._runScripts === "dangerously") {
+        const result = window.eval(scriptSource);
+        if (typeof result === "string") {
+          notImplemented("string results from 'javascript:' URLs", window);
+        }
+      }
+    }, 0);
+    return;
+  }
+  navigateFetch(window);
+};
+
+// https://html.spec.whatwg.org/#scroll-to-fragid
+function navigateToFragment(window, newURL, flags) {
+  const document = idlUtils.implForWrapper(window._document);
+
+  document._history._clearHistoryTraversalTasks();
+
+  if (!flags.replace) {
     window._sessionHistory.splice(window._currentSessionHistoryEntryIndex + 1, Infinity);
-
-    document._history._clearHistoryTraversalTasks();
-
     const newEntry = { document, url: newURL };
     window._sessionHistory.push(newEntry);
     exports.traverseHistory(window, newEntry, { nonBlockingEvents: true });
+  } else {
+    // handling replace=true here deviates from spec, but matches real browser behaviour
+    // see https://github.com/whatwg/html/issues/2796 for spec bug
+    const currentEntry = window._sessionHistory[window._currentSessionHistoryEntryIndex];
+    const oldURL = currentEntry.url;
+    currentEntry.url = newURL;
+    window.setTimeout(() => {
+      window.dispatchEvent(HashChangeEvent.create(["hashchange", {
+        bubbles: true,
+        cancelable: false,
+        oldURL: whatwgURL.serializeURL(oldURL),
+        newURL: whatwgURL.serializeURL(newURL)
+      }]));
+    }, 0);
   }
-};
+}
+
+// https://html.spec.whatwg.org/#process-a-navigate-fetch
+function navigateFetch(window) {
+  // TODO:
+  notImplemented("navigation (except hash changes)", window);
+}
+
+function urlEquals(a, b, flags) {
+  if (a.scheme !== b.scheme ||
+      a.username !== b.username ||
+      a.password !== b.password ||
+      a.host !== b.host ||
+      a.port !== b.port ||
+      !arrayEqual(a.path, b.path) ||
+      a.query !== b.query ||
+      // Omitted per spec: url.fragment !== this._url.fragment ||
+      a.cannotBeABaseURL !== b.cannotBeABaseURL) {
+    return false;
+  }
+  return flags.excludeFragments || a.fragment === b.fragment;
+}

--- a/lib/jsdom/living/window/navigation.js
+++ b/lib/jsdom/living/window/navigation.js
@@ -4,7 +4,8 @@ const arrayEqual = require("array-equal");
 const notImplemented = require("../../browser/not-implemented.js");
 const HashChangeEvent = require("../generated/HashChangeEvent.js");
 const PopStateEvent = require("../generated/PopStateEvent.js");
-const idlUtils = require("../generated/utils");
+const reportException = require("../helpers/runtime-script-errors.js");
+const idlUtils = require("../generated/utils.js");
 
 exports.traverseHistory = (window, specifiedEntry, flags = {}) => {
   // Not spec compliant, just minimal. Lots of missing steps.
@@ -68,7 +69,11 @@ exports.evaluateJavaScriptURL = (window, urlRecord) => {
   const urlString = whatwgURL.serializeURL(urlRecord);
   const scriptSource = whatwgURL.percentDecode(Buffer.from(urlString)).toString();
   if (window._runScripts === "dangerously") {
-    return window.eval(scriptSource);
+    try {
+      return window.eval(scriptSource);
+    } catch (e) {
+      reportException(window, e, urlString);
+    }
   }
   return undefined;
 };

--- a/lib/jsdom/utils.js
+++ b/lib/jsdom/utils.js
@@ -123,14 +123,14 @@ exports.reflectURLAttribute = (elementImpl, contentAttributeName) => {
   }
 
   const urlRecord = parseURLToResultingURLRecord(attributeValue, elementImpl._ownerDocument);
-  if (urlRecord === "failure") {
+  if (urlRecord === null) {
     return attributeValue;
   }
   return whatwgURL.serializeURL(urlRecord);
 };
 
 function isValidAbsoluteURL(str) {
-  return whatwgURL.parseURL(str) !== "failure";
+  return whatwgURL.parseURL(str) !== null;
 }
 
 exports.isValidTargetOrigin = function (str) {

--- a/lib/old-api.js
+++ b/lib/old-api.js
@@ -57,12 +57,12 @@ exports.changeURL = function (window, urlString) {
 
   const url = whatwgURL.parseURL(urlString);
 
-  if (url === "failure") {
+  if (url === null) {
     throw new TypeError(`Could not parse "${urlString}" as a URL`);
   }
 
   doc._URL = url;
-  doc._origin = whatwgURL.serializeURLToUnicodeOrigin(doc._URL);
+  doc._origin = whatwgURL.serializeURLOrigin(doc._URL);
 };
 
 // Proxy to features module

--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,6 +2819,11 @@
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
     "log-driver": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
@@ -5348,16 +5353,9 @@
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ="
     },
     "whatwg-url": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        }
-      }
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.1.0.tgz",
+      "integrity": "sha1-X8gnm5PXVIO5ztiyYjmFSEehhXg="
     },
     "which": {
       "version": "1.2.14",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tough-cookie": "^2.3.2",
     "webidl-conversions": "^4.0.0",
     "whatwg-encoding": "^1.0.1",
-    "whatwg-url": "^4.3.0",
+    "whatwg-url": "^6.1.0",
     "xml-name-validator": "^2.0.1"
   },
   "devDependencies": {

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -84,6 +84,7 @@ describe("Web Platform Tests", () => {
     "html/browsers/browsing-the-web/history-traversal/PopStateEvent.html",
     "html/browsers/browsing-the-web/history-traversal/hashchange_event.html",
     "html/browsers/browsing-the-web/history-traversal/popstate_event.html",
+    "html/browsers/browsing-the-web/navigating-across-documents/javascript-url-query-fragment-components.html",
     // "html/browsers/history/the-history-interface/001.html", // complicated navigation stuff and structured cloning
     // "html/browsers/history/the-history-interface/002.html", // complicated navigation stuff and structured cloning
     // "html/browsers/history/the-history-interface/004.html", // subtle timing issues that I can't quite figure out; see comment in History-impl.js

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -60,6 +60,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "encoding/meta/meta-http-equiv-simple-quotes.html",
     "encoding/meta/meta-http-equiv.html",
     "encoding/meta/no-meta.html",
+    "html/browsers/browsing-the-web/navigating-across-documents/javascript-url-side-effects.html",
     "html/browsers/windows/nested-browsing-contexts/iframe-referrer.html",
     "html/dom/elements/elements-in-the-dom/click-in-progress-flag.html",
     "html/dom/elements/global-attributes/dir-attribute.html",

--- a/test/web-platform-tests/to-upstream/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-side-effects.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-side-effects.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Clicking on javascript: URL links that return undefined causes side effects</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#javascript-protocol">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+async_test(t => {
+  assert_equals(window.clicked, undefined, "Before");
+
+  window.location.href = "javascript:window.clicked = true;";
+
+  assert_equals(window.clicked, undefined, "After");
+
+  t.step_timeout(() => {
+    assert_equals(window.clicked, true, "After plus a queued task");
+    t.done();
+  }, 0);
+}, "simple case");
+
+async_test(t => {
+  assert_equals(window.clicked2, undefined, "Before");
+
+  window.location.href = "javascript:window.clicked2%20%3D%20true%3B";
+
+  assert_equals(window.clicked2, undefined, "After");
+
+  t.step_timeout(() => {
+    assert_equals(window.clicked2, true, "After plus a queued task");
+    t.done();
+  }, 0);
+}, "percent-decoding");
+</script>

--- a/test/web-platform-tests/to-upstream/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-side-effects.html
+++ b/test/web-platform-tests/to-upstream/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-side-effects.html
@@ -9,6 +9,7 @@
 
 <script>
 "use strict";
+setup({ allow_uncaught_exception: true });
 
 async_test(t => {
   assert_equals(window.clicked, undefined, "Before");
@@ -35,4 +36,20 @@ async_test(t => {
     t.done();
   }, 0);
 }, "percent-decoding");
+
+async_test(t => {
+  let error;
+  window.addEventListener("error", ev => {
+    error = ev.error;
+  });
+
+  window.location.href = "javascript:%+#@?";
+
+  assert_equals(error, undefined, "No error yet");
+
+  t.step_timeout(() => {
+    assert_equals(error.constructor, SyntaxError, "After a queued task, SyntaxError");
+    t.done();
+  }, 0);
+});
 </script>


### PR DESCRIPTION
This makes the navigation work more like the spec.  What I’m hoping to do is get to the point where there is a clear place to hook in and handle navigation that involves creating a new dom instance, without requiring a full re-implementation of “Location” and “History”.