### PR TITLE
Allow beforeParse() to modify the HTML that will be parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,30 @@ const dom = new JSDOM(`<p>Hello</p>`, {
 });
 ```
 
-This is especially useful if you are wanting to modify the environment in some way, for example adding shims for web platform APIs jsdom does not support.
+This is especially useful if you are wanting to modify the environment in some way, for example adding shims for web platform APIs jsdom does not support. 
+
+Futhermore, `beforeParse` allows you to **modify** the HTML that will be fed into the parser. This is particularly useful for dealing with large HTML documents when you are interested in small portions of their content only. Stripping the HTML down to a "region of interest" can speed up parsing significantly.
+
+```js
+const ROI_START_MARKER = '<!-- region of interest -->';
+const ROI_END_MARKER = '<!-- /region of interest -->';
+
+JSDOM.fromURL("https://example.com/", {
+    beforeParse(window, html) {
+      let startMarkerIndex = html.indexOf(ROI_START_MARKER),
+          endMarkerIndex = (startMarkerIndex >= 0) ? html.indexOf(ROI_END_MARKER) : -1,
+          diff = endMarkerIndex - startMarkerIndex;
+        
+        if (diff > 0) {
+          return html.substr(startMarkerIndex, diff + ROI_END_MARKER.length);
+        }
+    }
+}).then(dom => {
+  console.log(dom.serialize());
+});
+```
+If `beforeParse` returns a string, it will be fed to the parser. In all other cases, the original HTML is used.
+
 
 ## `JSDOM` object API
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -62,10 +62,11 @@ class JSDOM {
     const documentImpl = idlUtils.implForWrapper(this[window]._document);
     applyDocumentFeatures(documentImpl, features);
 
-    options.beforeParse(this[window]._globalProxy);
+    const customizedHtml = options.beforeParse(this[window]._globalProxy, html);
+    const htmlForDom = typeof customizedHtml === "string" ? customizedHtml : html;
 
     // TODO NEWAPI: this is still pretty hacky. It's also different than jsdom.jsdom. Does it work? Can it be better?
-    documentImpl._htmlToDom.appendToDocument(html, documentImpl);
+    documentImpl._htmlToDom.appendToDocument(htmlForDom, documentImpl);
     documentImpl.close();
   }
 


### PR DESCRIPTION
Parsing large HTML documents is resource-intensive, so sometimes it makes sense to limit parsing to only relevant parts of a document or parse nothing at all. For example if
(a) you're interested only in a fraction of the content ("region of interest")
(b) you can tell by a simple keyword-scan whether the document contains the wanted information at all.

With my modification, beforeParse() will be called with an additional, second parameter which is the html that would "normally" go straight to the parser. beforeParse() can now return a modified version of that html (or any other string, including empty ones) that will then be parsed instead. If it returns no string, parsing happens as usual, so the modification won't break any existing code.

I've included tests and a respective section in the README.

Depending on the document, I've seen performance increases of almost a second on a Pi3, so I really hope this becomes a feature of jsdom :-)