### PR TITLE
Add several obsolete no-op methods

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -16,6 +16,7 @@ const idlUtils = require("../living/generated/utils");
 const createXMLHttpRequest = require("../living/xmlhttprequest");
 const createFileReader = require("../living/generated/FileReader").createInterface;
 const Document = require("../living/generated/Document");
+const External = require("../living/generated/External");
 const Navigator = require("../living/generated/Navigator");
 const reportException = require("../living/helpers/runtime-script-errors");
 const { matchesDontThrow } = require("../living/helpers/selectors");
@@ -129,6 +130,7 @@ function Window(options) {
 
   ///// GETTERS
 
+  const external = External.create();
   const navigator = Navigator.create([], { userAgent: options.userAgent });
 
   define(this, {
@@ -155,6 +157,9 @@ function Window(options) {
     },
     get document() {
       return window._document;
+    },
+    get external() {
+      return external;
     },
     get location() {
       return idlUtils.wrapperForImpl(idlUtils.implForWrapper(window._document)._location);

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -423,6 +423,11 @@ function Window(options) {
     return cs;
   };
 
+  // The captureEvents() and releaseEvents() methods must do nothing
+  this.captureEvents = function () {};
+
+  this.releaseEvents = function () {};
+
   ///// PUBLIC DATA PROPERTIES (TODO: should be getters)
 
   this.console = {

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -780,6 +780,13 @@ class DocumentImpl extends NodeImpl {
     });
   }
 
+  // The clear(), captureEvents(), and releaseEvents() methods must do nothing
+  clear() {}
+
+  captureEvents() {}
+
+  releaseEvents() {}
+
   get styleSheets() {
     if (!this._styleSheets) {
       this._styleSheets = new this._core.StyleSheetList();

--- a/lib/jsdom/living/nodes/Document.idl
+++ b/lib/jsdom/living/nodes/Document.idl
@@ -101,9 +101,9 @@ partial interface Document {
   [SameObject] readonly attribute HTMLCollection anchors;
   [SameObject] readonly attribute HTMLCollection applets;
 
-//  void clear();
-//  void captureEvents();
-//  void releaseEvents();
+  void clear();
+  void captureEvents();
+  void releaseEvents();
 
 //  [SameObject] readonly attribute HTMLAllCollection all;
 };

--- a/lib/jsdom/living/nodes/Document.idl
+++ b/lib/jsdom/living/nodes/Document.idl
@@ -108,13 +108,9 @@ partial interface Document {
 //  [SameObject] readonly attribute HTMLAllCollection all;
 };
 
+// https://drafts.csswg.org/cssom/#extensions-to-the-document-interface
 partial interface Document {
   [SameObject] readonly attribute StyleSheetList styleSheets;
-//  attribute DOMString? selectedStyleSheetSet;
-//  readonly attribute DOMString? lastStyleSheetSet;
-//  readonly attribute DOMString? preferredStyleSheetSet;
-//  readonly attribute FrozenArray<DOMString> styleSheetSets;
-//  void enableStyleSheetsForSet(DOMString? name);
 };
 
 // http://w3c.github.io/page-visibility/

--- a/lib/jsdom/living/window/External-impl.js
+++ b/lib/jsdom/living/window/External-impl.js
@@ -1,0 +1,9 @@
+"use strict";
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#dom-external
+exports.implementation = class ExternalImpl {
+  // The AddSearchProvider() and IsSearchProviderInstalled() methods must do nothing
+  AddSearchProvider() {}
+
+  IsSearchProviderInstalled() {}
+};

--- a/lib/jsdom/living/window/External.idl
+++ b/lib/jsdom/living/window/External.idl
@@ -1,0 +1,5 @@
+[NoInterfaceObject]
+interface External {
+  void AddSearchProvider();
+  void IsSearchProviderInstalled();
+};

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -135,6 +135,7 @@ describe("Web Platform Tests", () => {
     "html/editing/focus/document-level-focus-apis/document-level-apis.html",
     "html/editing/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-default-value.html",
     // "html/infrastructure/urls/terminology-0/document-base-url.html", // we don't support srcdoc <base> correctly
+    "html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/nothing.html",
     "html/semantics/forms/attributes-common-to-form-controls/disabled-elements-01.html",
     "html/semantics/forms/resetting-a-form/reset-form-2.html",
     "html/semantics/forms/the-button-element/button-click-submits.html",

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -76,6 +76,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "html/named-access-on-window/only-name.html",
     "html/named-access-on-window/removing.html",
     "html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/applets.html",
+    "html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/window-external.html",
     "html/semantics/document-metadata/the-link-element/stylesheet-appropriate-time-to-obtain.html",
     "html/semantics/forms/the-input-element/disabled-checkbox.html",
     "html/semantics/forms/the-option-element/option-ask-for-a-reset.html",

--- a/test/web-platform-tests/to-upstream/.eslintrc.json
+++ b/test/web-platform-tests/to-upstream/.eslintrc.json
@@ -10,7 +10,8 @@
     "padded-blocks": "off", // we like to add spaces around the main test block
     "no-multiple-empty-lines": "off", // some bug with the eslint-plugin-html package makes this spuriously trigger
     "camelcase": "off", // setting options like allow_uncaught_exception requires this
-    "no-implicit-globals": "off" // it doesn't much matter if we use top-level function declarations here
+    "no-implicit-globals": "off", // it doesn't much matter if we use top-level function declarations here
+    "new-cap": ["error", { "capIsNewExceptions": ["AddSearchProvider", "IsSearchProviderInstalled"] }] // window.external
   },
   "globals": {
     "EventWatcher": false,

--- a/test/web-platform-tests/to-upstream/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/window-external.html
+++ b/test/web-platform-tests/to-upstream/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/window-external.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>window.external</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/obsolete.html#dom-external">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  assert_exists(window, "external");
+}, "window.external exists");
+
+test(() => {
+  assert_equals(window.external.AddSearchProvider(), undefined);
+  assert_equals(window.external.IsSearchProviderInstalled(), undefined);
+}, "window.external SearchProvider methods are no-ops");
+
+</script>


### PR DESCRIPTION
This pull request adds some required no-op methods which are part of the 'Obsolete features' section of the HTML specification.

Specifically, `clear()`, `captureEvents()` and `releaseEvents()` on document:
https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-clear

And the latter two again on window:
https://html.spec.whatwg.org/multipage/obsolete.html#dom-window-captureevents

It also implements the [`External`](https://html.spec.whatwg.org/multipage/obsolete.html#dom-external) interface used for `window.external`, no-ops for the two SearchProvider methods that go with it and a to-upstream test for this.

Finally, I took the opportunity to remove some unimplemented IDL for the alternative stylesheets API which has been [removed](https://drafts.csswg.org/cssom/#changes-from-5-december-2013) from the CSSOM specification.