### PR TITLE
Do not trigger click on a disabled labeled control

### DIFF
--- a/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLLabelElement-impl.js
@@ -4,6 +4,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const MouseEvent = require("../generated/MouseEvent");
 const closest = require("../helpers/traversal").closest;
 const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
+const isDisabled = require("../helpers/form-controls").isDisabled;
 
 function isLabelable(node) {
   // labelable logic defined at: https://html.spec.whatwg.org/multipage/forms.html#category-label
@@ -49,13 +50,16 @@ class HTMLLabelElementImpl extends HTMLElementImpl {
   _activationBehavior() {
     if (this.hasAttribute("for")) {
       const node = this.ownerDocument.getElementById(this.getAttribute("for"));
-      if (node && isLabelable(node)) {
+      if (node && isLabelable(node) && !isDisabled(node)) {
         sendClickToAssociatedNode(node);
       }
     } else {
       for (const descendant of domSymbolTree.treeIterator(this)) {
         if (isLabelable(descendant)) {
-          sendClickToAssociatedNode(descendant);
+          if (!isDisabled(descendant)) {
+            sendClickToAssociatedNode(descendant);
+          }
+
           break;
         }
       }

--- a/test/web-platform-tests/to-upstream.js
+++ b/test/web-platform-tests/to-upstream.js
@@ -80,6 +80,7 @@ describe("Local tests in Web Platform Test format (to-upstream)", () => {
     "html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/window-external.html",
     "html/semantics/document-metadata/the-link-element/stylesheet-appropriate-time-to-obtain.html",
     "html/semantics/forms/the-input-element/disabled-checkbox.html",
+    "html/semantics/forms/the-label-element/disabled-labeled-control.html",
     "html/semantics/forms/the-option-element/option-ask-for-a-reset.html",
     "html/semantics/forms/the-textarea-element/select.html",
     "html/semantics/forms/the-textarea-element/set-value-reset-selection.html",

--- a/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/disabled-labeled-control.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/forms/the-label-element/disabled-labeled-control.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Label event handling with disabled labeled control</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<label id="label1">
+  <input id="input1" type="text" disabled>
+</label>
+
+<label id="label2" for="input2"></label>
+<input id="input2" type="text" disabled>
+
+<label id="label3">
+  <input id="input3" type="checkbox" disabled>
+</label>
+
+<label id="label4" for="input4"></label>
+<input id="input4" type="checkbox" disabled>
+
+<script>
+"use strict";
+
+test(() => {
+  const label = document.getElementById("label1");
+  const input = document.getElementById("input1");
+
+  let clickReceived = false;
+  input.addEventListener("click", () => {
+    clickReceived = true;
+  });
+
+  assert_true(input.disabled);
+  assert_false(clickReceived);
+  label.click();
+  assert_false(clickReceived);
+
+  input.disabled = false;
+  label.click();
+  assert_true(clickReceived);
+}, "clicking on a label should not cause a disabled child input to receive a click event");
+
+test(() => {
+  const label = document.getElementById("label2");
+  const input = document.getElementById("input2");
+
+  let clickReceived = false;
+  input.addEventListener("click", () => {
+    clickReceived = true;
+  });
+
+  assert_true(input.disabled);
+  assert_false(clickReceived);
+  label.click();
+  assert_false(clickReceived);
+
+  input.disabled = false;
+  label.click();
+  assert_true(clickReceived);
+}, "clicking on a label should not cause a disabled input referenced in the 'for' attribute to receive a click event");
+
+test(() => {
+  const label = document.getElementById("label3");
+  const checkbox = document.getElementById("input3");
+
+  assert_true(checkbox.disabled);
+  assert_false(checkbox.checked);
+  label.click();
+  assert_false(checkbox.checked);
+
+  checkbox.disabled = false;
+  label.click();
+  assert_true(checkbox.checked);
+}, "clicking on a label should not cause a disabled child checkbox to become checked");
+
+test(() => {
+  const label = document.getElementById("label4");
+  const checkbox = document.getElementById("input4");
+
+  assert_true(checkbox.disabled);
+  assert_false(checkbox.checked);
+  label.click();
+  assert_false(checkbox.checked);
+
+  checkbox.disabled = false;
+  label.click();
+  assert_true(checkbox.checked);
+}, "clicking on a label should not cause a disabled checkbox referenced in the 'for' attribute to become checked");
+</script>
+</body>


### PR DESCRIPTION
Fixes #1925 

I opted to test the specific incorrect behavior I discovered (where the labeled control is a checkbox). Alternatively, I could simply test that the "click" event is never dispatched. Let me know if that more generic test would be preferable.