### PR TITLE
Enable document.forms test

### DIFF
--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -129,7 +129,7 @@ describe("Web Platform Tests", () => {
     "html/dom/documents/dom-tree-accessors/Document.getElementsByClassName-null-undef.html",
     "html/dom/documents/dom-tree-accessors/Element.getElementsByClassName-null-undef.html",
     "html/dom/documents/dom-tree-accessors/document.embeds-document.plugins-01.html",
-    // "html/dom/documents/dom-tree-accessors/document.forms.html", // something wonky with HTMLCollection
+    "html/dom/documents/dom-tree-accessors/document.forms.html",
     "html/dom/documents/dom-tree-accessors/document.getElementsByClassName-same.html",
     "html/dom/documents/dom-tree-accessors/document.head-01.html",
     "html/dom/documents/dom-tree-accessors/document.head-02.html",


### PR DESCRIPTION
I gave the disabled tests another spin considering recent changes. Thanks to the hard work of @TimothyGu, it seems HTMLCollection is wonky no more :-)