### PR TITLE
Fix wrong script tests

### DIFF
--- a/test/old-api/env.js
+++ b/test/old-api/env.js
@@ -215,6 +215,7 @@ describe("jsdom/env", () => {
   specify("with configurable resource loader", { async: true }, t => {
     env({
       html: "<!DOCTYPE html><html><head><script src='foo.js'></script></head><body></body></html>",
+      url: "http://example.org/",
       resourceLoader(resource, callback) {
         callback(null, "window.resourceLoaderWasOverridden = true;");
       },

--- a/test/old-api/inside-worker-smoke-tests.js
+++ b/test/old-api/inside-worker-smoke-tests.js
@@ -55,9 +55,9 @@ describe("jsdom/inside-worker-smoke-tests", () => {
   });
 
   specify("execute scripts referring to global built-ins (GH-1175)", { async: true }, t => {
-    const document = jsdom.jsdom(`<!DOCTYPE html><script>
+    const document = jsdom.jsdom(`<!DOCTYPE html><body><script>
       document.body.textContent = Error.name + window.Object.name + NaN + ("undefined" in window);
-    </script>`);
+    </script></body>`);
 
     assert.strictEqual(document.body.textContent, "ErrorObjectNaNtrue");
     t.done();

--- a/test/to-port-to-wpts/current-script.js
+++ b/test/to-port-to-wpts/current-script.js
@@ -10,8 +10,9 @@ exports["document.currentScript is null when not executing <script>"] = t => {
 
 exports["document.currentScript is currently executing <script> element"] = t => {
   t.expect(2);
-  const html = "<html><head><script src='./files/current-script.js'></script></head>" +
-               "<body><span id='test'>hello from html</span></body></html>";
+  const html = "<html><body>" +
+               "<span id='test'>hello from html</span><script src='./files/current-script.js'></script>" +
+               "</body></html>";
 
   const document = jsdom.jsdom(html, {
     url: toFileUrl(__filename),

--- a/test/to-port-to-wpts/misc2.js
+++ b/test/to-port-to-wpts/misc2.js
@@ -937,8 +937,9 @@ describe("jsdom/miscellaneous", () => {
     });
 
     specify("ensure_scripts_can_be_executed_via_options_features", { async: true }, t => {
-      const html = `<html><head><script src="./files/hello.js"></script></head>
-                    <body><span id="test">hello from html</span></body></html>`;
+      const html = `<html><head></head>
+                    <body><span id="test">hello from html</span>
+                    <script src="./files/hello.js"></script></body></html>`;
 
       const doc = jsdom.jsdom(html, {
         url: toFileUrl(__filename),
@@ -955,9 +956,9 @@ describe("jsdom/miscellaneous", () => {
     });
 
     specify("ensure_resolution_is_not_thrown_off_by_hrefless_base_tag", { async: true }, t => {
-      const html = `<html><head><base target="whatever">
-                 <script src="./files/hello.js"></script></head><body>
-                 <span id="test">hello from html</span></body></html>`;
+      const html = `<html><head><base target="whatever"></head><body>
+                 <span id="test">hello from html</span>
+                 <script src="./files/hello.js"></script></body></html>`;
 
       const doc = jsdom.jsdom(html, {
         url: toFileUrl(__filename),
@@ -974,10 +975,10 @@ describe("jsdom/miscellaneous", () => {
     });
 
     specify("ensure_resources_can_be_skipped_via_options_features", { async: true }, t => {
-      const html = `<html><head><script src="./files/hello.js"></script>
-                 <script src="./files/nyan.js"></script></head>
+      const html = `<html><head></head>
                  <body><span id="test">hello from html</span><span id="cat">
-                 hello from cat</body></html>`;
+                 hello from cat<script src="./files/hello.js"></script>
+                 <script src="./files/nyan.js"></script></body></html>`;
 
       const doc2 = jsdom.jsdom(html, {
         url: toFileUrl(__filename),
@@ -998,10 +999,10 @@ describe("jsdom/miscellaneous", () => {
       const html = `
         <html>
           <head>
-            <script type="text/javascript" src="` + toFileUrl("files/hello.js") + `"></script>
           </head>
           <body>
             <span id="test">hello from html</span>
+            <script type="text/javascript" src="` + toFileUrl("files/hello.js") + `"></script>
           </body>
         </html>`;
 


### PR DESCRIPTION
Our tests relied on the fact that scripts ran when the whole document
was loaded into memory. This is not guaranteed in a streaming parser.

Let's not test jsdom implementation specific behaviour if it goes
against expected web platform behaviour.