### PR TITLE
HTMLTableElement tFoot/tHead missing setter

### DIFF
--- a/lib/jsdom/living/nodes/HTMLTableElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableElement-impl.js
@@ -2,10 +2,27 @@
 
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
+const domSymbolTree = require("../helpers/internal-constants").domSymbolTree;
 const firstChildWithHTMLLocalName = require("../helpers/traversal").firstChildWithHTMLLocalName;
 const childrenByHTMLLocalName = require("../helpers/traversal").childrenByHTMLLocalName;
 const HTMLCollection = require("../generated/HTMLCollection");
 const DOMException = require("../../web-idl/DOMException");
+const NODE_TYPE = require("../node-type");
+
+function tHeadInsertionPoint(table) {
+  const iterator = domSymbolTree.childrenIterator(table);
+  for (const child of iterator) {
+    if (child.nodeType !== NODE_TYPE.ELEMENT_NODE) {
+      continue;
+    }
+
+    if (child._namespaceURI !== "http://www.w3.org/1999/xhtml" || (child._localName !== "caption" && child._localName !== "colgroup")) {
+      return child;
+    }
+  }
+
+  return null;
+}
 
 class HTMLTableElementImpl extends HTMLElementImpl {
   get caption() {
@@ -16,8 +33,41 @@ class HTMLTableElementImpl extends HTMLElementImpl {
     return firstChildWithHTMLLocalName(this, "thead");
   }
 
+  set tHead(value) {
+    if (value !== null && value._localName !== "thead") {
+      throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR,
+        "Cannot set a non-thead element as a table header");
+    }
+
+    const currentHead = this.tHead;
+    if (currentHead !== null) {
+      this.removeChild(currentHead);
+    }
+
+    if (value !== null) {
+      const insertionPoint = tHeadInsertionPoint(this);
+      this.insertBefore(value, insertionPoint);
+    }
+  }
+
   get tFoot() {
     return firstChildWithHTMLLocalName(this, "tfoot");
+  }
+
+  set tFoot(value) {
+    if (value !== null && value._localName !== "tfoot") {
+      throw new DOMException(DOMException.HIERARCHY_REQUEST_ERR,
+        "Cannot set a non-tfoot element as a table footer");
+    }
+
+    const currentFoot = this.tFoot;
+    if (currentFoot !== null) {
+      this.removeChild(currentFoot);
+    }
+
+    if (value !== null) {
+      this.appendChild(value);
+    }
   }
 
   get rows() {
@@ -62,33 +112,25 @@ class HTMLTableElementImpl extends HTMLElementImpl {
   createTHead() {
     let el = this.tHead;
     if (!el) {
-      el = this._ownerDocument.createElement("THEAD");
-      this.appendChild(el);
+      el = this.tHead = this._ownerDocument.createElement("THEAD");
     }
     return el;
   }
 
   deleteTHead() {
-    const el = this.tHead;
-    if (el) {
-      el.parentNode.removeChild(el);
-    }
+    this.tHead = null;
   }
 
   createTFoot() {
     let el = this.tFoot;
     if (!el) {
-      el = this._ownerDocument.createElement("TFOOT");
-      this.appendChild(el);
+      el = this.tFoot = this._ownerDocument.createElement("TFOOT");
     }
     return el;
   }
 
   deleteTFoot() {
-    const el = this.tFoot;
-    if (el) {
-      el.parentNode.removeChild(el);
-    }
+    this.tFoot = null;
   }
 
   createCaption() {

--- a/lib/jsdom/living/nodes/HTMLTableElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLTableElement-impl.js
@@ -109,6 +109,20 @@ class HTMLTableElementImpl extends HTMLElementImpl {
     return this._tBodies;
   }
 
+  createTBody() {
+    const el = this._ownerDocument.createElement("TBODY");
+
+    const tbodies = childrenByHTMLLocalName(this, "tbody");
+    const insertionPoint = tbodies[tbodies.length - 1];
+
+    if (insertionPoint) {
+      this.insertBefore(el, insertionPoint.nextSibling);
+    } else {
+      this.appendChild(el);
+    }
+    return el;
+  }
+
   createTHead() {
     let el = this.tHead;
     if (!el) {

--- a/lib/jsdom/living/nodes/HTMLTableElement.idl
+++ b/lib/jsdom/living/nodes/HTMLTableElement.idl
@@ -9,7 +9,7 @@ interface HTMLTableElement : HTMLElement {
   HTMLTableSectionElement createTFoot();
   void deleteTFoot();
   [SameObject] readonly attribute HTMLCollection tBodies;
-//  HTMLTableSectionElement createTBody();
+  HTMLTableSectionElement createTBody();
   [SameObject] readonly attribute HTMLCollection rows;
   HTMLTableRowElement insertRow(optional long index = -1);
   void deleteRow(long index);

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -236,6 +236,8 @@ describe("Web Platform Tests", () => {
     "html/semantics/tabular-data/the-table-element/insertRow-method-01.html",
     "html/semantics/tabular-data/the-table-element/insertRow-method-02.html",
     "html/semantics/tabular-data/the-table-element/tBodies.html",
+    "html/semantics/tabular-data/the-table-element/tHead.html",
+    "html/semantics/tabular-data/the-table-element/tFoot.html",
     "html/semantics/tabular-data/the-table-element/table-insertRow.html",
     // "html/semantics/tabular-data/the-table-element/table-rows.html",
     "html/syntax/serializing-html-fragments/outerHTML.html",

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -231,7 +231,7 @@ describe("Web Platform Tests", () => {
     "html/semantics/scripting-1/the-template-element/template-element/template-descendant-frameset.html",
     "html/semantics/scripting-1/the-template-element/template-element/template-descendant-head.html",
     // "html/semantics/tabular-data/the-table-element/caption-methods.html",
-    // "html/semantics/tabular-data/the-table-element/createTBody.html",
+    "html/semantics/tabular-data/the-table-element/createTBody.html",
     "html/semantics/tabular-data/the-table-element/delete-caption.html",
     "html/semantics/tabular-data/the-table-element/insertRow-method-01.html",
     "html/semantics/tabular-data/the-table-element/insertRow-method-02.html",


### PR DESCRIPTION
HTMLTableElement's [tFoot](https://html.spec.whatwg.org/#dom-table-tfoot-2) and [tHead](https://html.spec.whatwg.org/#dom-table-thead-2) properties only have getters at the moment. This causes failures in [the-table-element/tFoot.html](https://github.com/w3c/web-platform-tests/blob/master/html/semantics/tabular-data/the-table-element/tFoot.html) and [the-table-element/tHead.html](https://github.com/w3c/web-platform-tests/blob/master/html/semantics/tabular-data/the-table-element/tHead.html).