### PR TITLE
Implement the details, picture and marquee elements

### DIFF
--- a/lib/jsdom/living/nodes/HTMLDetailsElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLDetailsElement-impl.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const Event = require("../generated/Event.js");
+
+const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+
+class HTMLDetailsElementImpl extends HTMLElementImpl {
+  _dispatchToggleEvent() {
+    const event = Event.createImpl(
+      ["toggle",
+      { bubbles: false, cancelable: false }],
+      { isTrusted: true }
+    );
+    this._dispatch(event);
+  }
+
+  _attrModified(name, value, oldValue) {
+    super._attrModified(name, value, oldValue);
+
+    if (name === "open") {
+      this._dispatchToggleEvent();
+    }
+  }
+}
+
+module.exports = {
+  implementation: HTMLDetailsElementImpl
+};

--- a/lib/jsdom/living/nodes/HTMLDetailsElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLDetailsElement-impl.js
@@ -5,20 +5,32 @@ const Event = require("../generated/Event.js");
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 
 class HTMLDetailsElementImpl extends HTMLElementImpl {
+  constructor(args, privateData) {
+    super(args, privateData);
+
+    this._taskQueue = null;
+  }
+
   _dispatchToggleEvent() {
-    const event = Event.createImpl(
-      ["toggle",
-      { bubbles: false, cancelable: false }],
-      { isTrusted: true }
+    this._taskQueue = null;
+
+    this._dispatch(
+      Event.createImpl(["toggle", {
+        bubbles: false, cancelable: false
+      }], { isTrusted: true })
     );
-    this._dispatch(event);
   }
 
   _attrModified(name, value, oldValue) {
     super._attrModified(name, value, oldValue);
 
-    if (name === "open") {
-      this._dispatchToggleEvent();
+    if (name === "open" && this._taskQueue === null) {
+      // Check that the attribute is added or removed, not merely changed
+      if (value !== oldValue &&
+          value !== null && oldValue === null ||
+          value === null && oldValue !== null) {
+        this._taskQueue = setTimeout(this._dispatchToggleEvent.bind(this), 0);
+      }
     }
   }
 }

--- a/lib/jsdom/living/nodes/HTMLDetailsElement.idl
+++ b/lib/jsdom/living/nodes/HTMLDetailsElement.idl
@@ -1,0 +1,5 @@
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLDetailsElement : HTMLElement {
+  [CEReactions, Reflect] attribute boolean open;
+};

--- a/lib/jsdom/living/nodes/HTMLMarqueeElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLMarqueeElement-impl.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+
+class HTMLMarqueeElementImpl extends HTMLElementImpl { }
+
+module.exports = {
+  implementation: HTMLMarqueeElementImpl
+};

--- a/lib/jsdom/living/nodes/HTMLMarqueeElement.idl
+++ b/lib/jsdom/living/nodes/HTMLMarqueeElement.idl
@@ -1,0 +1,22 @@
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLMarqueeElement : HTMLElement {
+  [CEReactions, Reflect] attribute DOMString behavior;
+  [CEReactions, Reflect=bgcolor] attribute DOMString bgColor;
+  [CEReactions, Reflect] attribute DOMString direction;
+  [CEReactions, Reflect] attribute DOMString height;
+  [CEReactions, Reflect] attribute unsigned long hspace;
+  [CEReactions] attribute long loop;
+  [CEReactions, Reflect=scrollamount] attribute unsigned long scrollAmount;
+  [CEReactions, Reflect=scrolldelay] attribute unsigned long scrollDelay;
+  [CEReactions, Reflect=truespeed] attribute boolean trueSpeed;
+  [CEReactions, Reflect] attribute unsigned long vspace;
+  [CEReactions, Reflect] attribute DOMString width;
+
+  attribute EventHandler onbounce;
+  attribute EventHandler onfinish;
+  attribute EventHandler onstart;
+
+  void start();
+  void stop();
+};

--- a/lib/jsdom/living/nodes/HTMLMarqueeElement.idl
+++ b/lib/jsdom/living/nodes/HTMLMarqueeElement.idl
@@ -6,17 +6,17 @@ interface HTMLMarqueeElement : HTMLElement {
   [CEReactions, Reflect] attribute DOMString direction;
   [CEReactions, Reflect] attribute DOMString height;
   [CEReactions, Reflect] attribute unsigned long hspace;
-  [CEReactions] attribute long loop;
+// [CEReactions] attribute long loop;
   [CEReactions, Reflect=scrollamount] attribute unsigned long scrollAmount;
   [CEReactions, Reflect=scrolldelay] attribute unsigned long scrollDelay;
   [CEReactions, Reflect=truespeed] attribute boolean trueSpeed;
   [CEReactions, Reflect] attribute unsigned long vspace;
   [CEReactions, Reflect] attribute DOMString width;
 
-  attribute EventHandler onbounce;
-  attribute EventHandler onfinish;
-  attribute EventHandler onstart;
+// attribute EventHandler onbounce;
+// attribute EventHandler onfinish;
+// attribute EventHandler onstart;
 
-  void start();
-  void stop();
+// void start();
+// void stop();
 };

--- a/lib/jsdom/living/nodes/HTMLPictureElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLPictureElement-impl.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const HTMLElementImpl = require("./HTMLElement-impl").implementation;
+
+class HTMLPictureElementImpl extends HTMLElementImpl { }
+
+module.exports = {
+  implementation: HTMLPictureElementImpl
+};

--- a/lib/jsdom/living/nodes/HTMLPictureElement.idl
+++ b/lib/jsdom/living/nodes/HTMLPictureElement.idl
@@ -1,0 +1,3 @@
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLPictureElement : HTMLElement {};

--- a/lib/jsdom/living/register-elements.js
+++ b/lib/jsdom/living/register-elements.js
@@ -106,6 +106,10 @@ const mappings = {
       file: require("./generated/HTMLDataListElement.js"),
       tags: ["datalist"]
     },
+    HTMLDetailsElement: {
+      file: require("./generated/HTMLDetailsElement.js"),
+      tags: ["details"]
+    },
     HTMLDialogElement: {
       file: require("./generated/HTMLDialogElement.js"),
       tags: ["dialog"]
@@ -194,6 +198,10 @@ const mappings = {
       file: require("./generated/HTMLMapElement.js"),
       tags: ["map"]
     },
+    HTMLMarqueeElement: {
+      file: require("./generated/HTMLMarqueeElement.js"),
+      tags: ["marquee"]
+    },
     HTMLMediaElement: {
       file: require("./generated/HTMLMediaElement.js"),
       tags: []
@@ -241,6 +249,10 @@ const mappings = {
     HTMLParamElement: {
       file: require("./generated/HTMLParamElement.js"),
       tags: ["param"]
+    },
+    HTMLPictureElement: {
+      file: require("./generated/HTMLPictureElement.js"),
+      tags: ["picture"]
     },
     HTMLPreElement: {
       file: require("./generated/HTMLPreElement.js"),

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -220,6 +220,8 @@ describe("Web Platform Tests", () => {
     "html/semantics/document-metadata/the-base-element/base_href_unspecified.html",
     // "html/semantics/document-metadata/the-base-element/base_multiple.html", // we don't support navigation via <a target>
     "html/semantics/document-metadata/the-base-element/base_srcdoc.html",
+    "html/semantics/interactive-elements/the-details-element/details.html",
+    // "html/semantics/interactive-elements/the-details-element/toggleEvent.html", // needs task queuing
     "html/semantics/scripting-1/the-script-element/script-language-type.html",
     "html/semantics/scripting-1/the-script-element/script-languages-01.html",
     // "html/semantics/scripting-1/the-script-element/script-languages-02.html", // our script execution timing is off; see discussion in https://github.com/tmpvar/jsdom/pull/1406

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -175,6 +175,10 @@ describe("Web Platform Tests", () => {
     "html/editing/focus/document-level-focus-apis/document-level-apis.html",
     "html/editing/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-default-value.html",
     // "html/infrastructure/urls/terminology-0/document-base-url.html", // we don't support srcdoc <base> correctly
+    // "html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-events.html", // events are not implemented
+    // "html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-loop.html", // only basic reflection is implemented
+    // "html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrollamount.html", // only basic reflection is implemented
+    // "html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrolldelay.html", // only basic reflection is implemented
     "html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/nothing.html",
     "html/semantics/forms/attributes-common-to-form-controls/disabled-elements-01.html",
     "html/semantics/forms/resetting-a-form/reset-form-2.html",

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -225,7 +225,7 @@ describe("Web Platform Tests", () => {
     // "html/semantics/document-metadata/the-base-element/base_multiple.html", // we don't support navigation via <a target>
     "html/semantics/document-metadata/the-base-element/base_srcdoc.html",
     "html/semantics/interactive-elements/the-details-element/details.html",
-    "html/semantics/interactive-elements/the-details-element/toggleEvent.html",
+    // "html/semantics/interactive-elements/the-details-element/toggleEvent.html", // the ninth test requires a streaming HTML parser to pass
     "html/semantics/scripting-1/the-script-element/script-language-type.html",
     "html/semantics/scripting-1/the-script-element/script-languages-01.html",
     // "html/semantics/scripting-1/the-script-element/script-languages-02.html", // our script execution timing is off; see discussion in https://github.com/tmpvar/jsdom/pull/1406

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -225,7 +225,7 @@ describe("Web Platform Tests", () => {
     // "html/semantics/document-metadata/the-base-element/base_multiple.html", // we don't support navigation via <a target>
     "html/semantics/document-metadata/the-base-element/base_srcdoc.html",
     "html/semantics/interactive-elements/the-details-element/details.html",
-    // "html/semantics/interactive-elements/the-details-element/toggleEvent.html", // needs task queuing
+    "html/semantics/interactive-elements/the-details-element/toggleEvent.html",
     "html/semantics/scripting-1/the-script-element/script-language-type.html",
     "html/semantics/scripting-1/the-script-element/script-languages-01.html",
     // "html/semantics/scripting-1/the-script-element/script-languages-02.html", // our script execution timing is off; see discussion in https://github.com/tmpvar/jsdom/pull/1406


### PR DESCRIPTION
This pull request adds implementations for the `<details>` and `<picture>` elements, as well as a stub for `<marquee>`.

The `<details>` "toggle" event is implemented, though it is missing one step involving a [task queue](https://html.spec.whatwg.org/#details-notification-task-steps) which I wasn't entirely sure how to approach. It uses the Event constructor, as it seems to be needed to set isTrusted.