### PR TITLE
Only append inline handlers for an element once

### DIFF
--- a/lib/jsdom/living/helpers/create-event-accessor.js
+++ b/lib/jsdom/living/helpers/create-event-accessor.js
@@ -58,11 +58,13 @@ exports.setupForSimpleEventAccessors = (prototype, events) => {
   };
 
   prototype._setEventHandlerFor = function (event, handler) {
-    if (!this._eventHandlers) {
+    if (!this._registeredHandlers) {
+      this._registeredHandlers = new Set();
       this._eventHandlers = Object.create(null);
     }
 
-    if (!this._eventHandlers[event] && handler !== null) {
+    if (!this._registeredHandlers.has(event) && handler !== null) {
+      this._registeredHandlers.add(event);
       exports.appendHandler(this, event);
     }
     this._eventHandlers[event] = handler;

--- a/lib/jsdom/living/nodes/GlobalEventHandlers-impl.js
+++ b/lib/jsdom/living/nodes/GlobalEventHandlers-impl.js
@@ -37,6 +37,7 @@ const events = new Set([
 
 class GlobalEventHandlersImpl {
   _initGlobalEvents() {
+    this._registeredHandlers = new Set();
     this._eventHandlers = Object.create(null);
   }
 
@@ -59,7 +60,8 @@ class GlobalEventHandlersImpl {
       return;
     }
 
-    if (!target._eventHandlers[event] && handler !== null) {
+    if (!target._registeredHandlers.has(event) && handler !== null) {
+      target._registeredHandlers.add(event);
       appendHandler(target, event);
     }
     target._eventHandlers[event] = handler;

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -294,7 +294,7 @@ describe("Web Platform Tests", () => {
     "html/webappapis/scripting/events/event-handler-processing-algorithm.html",
     "html/webappapis/scripting/events/event-handler-spec-example.html",
     "html/webappapis/scripting/events/eventhandler-cancellation.html",
-    // "html/webappapis/scripting/events/inline-event-handler-ordering.html", // https://github.com/tmpvar/jsdom/issues/1948
+    "html/webappapis/scripting/events/inline-event-handler-ordering.html",
     "html/webappapis/scripting/events/invalid-uncompiled-raw-handler-compiled-late.html",
     "html/webappapis/scripting/events/invalid-uncompiled-raw-handler-compiled-once.html",
     "html/webappapis/scripting/events/onerroreventhandler.html",


### PR DESCRIPTION
We set the raw event body to null if compiling the source fails,
which previously led to us re-appending when we set another inline
attribute.

Fixes #1948.