### PR TITLE
Use correct interfaces for many elements

### DIFF
--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -39,7 +39,6 @@ const DocumentFragment = require("../generated/DocumentFragment");
 const DOMImplementation = require("../generated/DOMImplementation");
 const ParentNodeImpl = require("./ParentNode-impl").implementation;
 const Element = require("../generated/Element");
-const HTMLElement = require("../generated/HTMLElement");
 const HTMLUnknownElement = require("../generated/HTMLUnknownElement");
 const TreeWalker = require("../generated/TreeWalker");
 const NodeIterator = require("../generated/NodeIterator");
@@ -174,12 +173,6 @@ function toLastModifiedString(date) {
     ":" + pad(date.getSeconds());
 }
 
-const nonInheritedTags = new Set([
-  "article", "section", "nav", "aside", "hgroup", "header", "footer", "address", "dt",
-  "dd", "figure", "figcaption", "main", "em", "strong", "small", "s", "cite", "dfn", "abbr",
-  "ruby", "rt", "rp", "code", "var", "samp", "kbd", "i", "b", "u", "mark", "bdi", "bdo", "wbr"
-]);
-
 const eventInterfaceTable = {
   customevent: CustomEvent,
   errorevent: ErrorEvent,
@@ -296,29 +289,6 @@ class DocumentImpl extends NodeImpl {
     this._latestEntry = null;
   }
 
-  _defaultElementBuilder(document, tagName, ns) {
-    if (ns !== "http://www.w3.org/1999/xhtml") {
-      return Element.create([], {
-        core: this._core,
-        ownerDocument: this,
-        localName: tagName
-      });
-    }
-
-    if (nonInheritedTags.has(tagName.toLowerCase())) {
-      return HTMLElement.create([], {
-        core: this._core,
-        ownerDocument: this,
-        localName: tagName
-      });
-    }
-    return HTMLUnknownElement.create([], {
-      core: this._core,
-      ownerDocument: this,
-      localName: tagName
-    });
-  }
-
   get contentType() {
     return this._contentType || (this._parsingMode === "xml" ? "application/xml" : "text/html");
   }
@@ -398,11 +368,24 @@ class DocumentImpl extends NodeImpl {
 
   _createElementWithCorrectElementInterface(name, namespace) {
     // https://dom.spec.whatwg.org/#concept-element-interface
-    let builder = this._defaultElementBuilder.bind(this);
+    let elem;
+
     if (this._elementBuilders[namespace] && this._elementBuilders[namespace][name.toLowerCase()]) {
-      builder = this._elementBuilders[namespace][name.toLowerCase()];
+      elem = this._elementBuilders[namespace][name.toLowerCase()](this, name, namespace);
+    } else if (namespace === "http://www.w3.org/1999/xhtml") {
+      elem = HTMLUnknownElement.create([], {
+        core: this._core,
+        ownerDocument: this,
+        localName: name
+      });
+    } else {
+      elem = Element.create([], {
+        core: this._core,
+        ownerDocument: this,
+        localName: name
+      });
     }
-    const elem = builder(this, name, namespace);
+
     return idlUtils.implForWrapper(elem);
   }
 

--- a/lib/jsdom/living/register-elements.js
+++ b/lib/jsdom/living/register-elements.js
@@ -4,6 +4,8 @@
 const DocumentImpl = require("./nodes/Document-impl.js");
 
 const mappings = {
+  // https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom%3Aelement-interface
+  // https://html.spec.whatwg.org/multipage/indices.html#elements-3
   "http://www.w3.org/1999/xhtml": {
     HTMLElement: {
       file: require("./generated/HTMLElement.js"),

--- a/lib/jsdom/living/register-elements.js
+++ b/lib/jsdom/living/register-elements.js
@@ -7,7 +7,58 @@ const mappings = {
   "http://www.w3.org/1999/xhtml": {
     HTMLElement: {
       file: require("./generated/HTMLElement.js"),
-      tags: []
+      tags: [
+        "abbr",
+        "acronym",
+        "address",
+        "article",
+        "aside",
+        "b",
+        "basefont",
+        "bdi",
+        "bdo",
+        "big",
+        "center",
+        "cite",
+        "code",
+        "dd",
+        "dfn",
+        "dt",
+        "em",
+        "figcaption",
+        "figure",
+        "footer",
+        "header",
+        "hgroup",
+        "i",
+        "kbd",
+        "main",
+        "mark",
+        "nav",
+        "nobr",
+        "noembed",
+        "noframes",
+        "noscript",
+        "plaintext",
+        "rb",
+        "rp",
+        "rt",
+        "rtc",
+        "ruby",
+        "s",
+        "samp",
+        "section",
+        "small",
+        "strike",
+        "strong",
+        "sub",
+        "summary",
+        "sup",
+        "tt",
+        "u",
+        "var",
+        "wbr"
+      ]
     },
     HTMLAnchorElement: {
       file: require("./generated/HTMLAnchorElement.js"),
@@ -191,7 +242,7 @@ const mappings = {
     },
     HTMLPreElement: {
       file: require("./generated/HTMLPreElement.js"),
-      tags: ["pre"]
+      tags: ["listing", "pre", "xmp"]
     },
     HTMLProgressElement: {
       file: require("./generated/HTMLProgressElement.js"),

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -273,6 +273,7 @@ describe("Web Platform Tests", () => {
     "html/semantics/text-level-semantics/the-a-element/a.rel-setter-01.html",
     "html/semantics/text-level-semantics/the-a-element/a.text-getter-01.html",
     "html/semantics/text-level-semantics/the-a-element/a.text-setter-01.html",
+    // "html/semantics/interfaces.html", // needs <details>, <marquee>, <picture>, <slot>, <td>/<th>-fixes and custom elements
     "html/syntax/serializing-html-fragments/outerHTML.html",
     // "html/syntax/parsing/html5lib_template.html", // no idea what's going on here
     "html/syntax/parsing/template/additions-to-foster-parenting/template-is-a-foster-parent-element.html",


### PR DESCRIPTION
This pull requests assigns the HTMLElement interface to the following elements:

`acronym`
`basefont`
`big`
`center`
`nobr`
`noembed`
`noframes`
`noscript`
`plaintext`
`rb`
`rtc`
`strike`
`sub`
`summary`
`sup`
`tt`

...as well as the HTMLPreElement interface to `listing` and `xmp` as [mentioned](https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom%3Aelement-interface) in the specification.

I have included a test which looks at the interfaces being used, but further work will be needed before it fully passes as noted in the associated comment. I've also simplified the code used to initialise the elements, moving the list of HTMLElements to register-elements.js.