### PR TITLE
Fix FocusEventImpl inheritance

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -65,6 +65,7 @@ function Window(options) {
 
   // vm initialization is defered until script processing is activated
   this._globalProxy = this;
+  Object.defineProperty(idlUtils.implForWrapper(this), idlUtils.wrapperSymbol, { get: () => this._globalProxy });
 
   this.__timers = Object.create(null);
 

--- a/lib/jsdom/living/events/CompositionEvent-impl.js
+++ b/lib/jsdom/living/events/CompositionEvent-impl.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const UIEventImpl = require("./UIEvent-impl").implementation;
+
+class CompositionEventImpl extends UIEventImpl {
+  initCompositionEvent(type, bubbles, cancelable, view, data) {
+    if (this._dispatchFlag) {
+      return;
+    }
+
+    this.initUIEvent(type, bubbles, cancelable, view, 0);
+    this.data = data;
+  }
+}
+
+module.exports = {
+  implementation: CompositionEventImpl
+};

--- a/lib/jsdom/living/events/CompositionEvent.webidl
+++ b/lib/jsdom/living/events/CompositionEvent.webidl
@@ -1,0 +1,19 @@
+// https://w3c.github.io/uievents/#interface-compositionevent
+[Constructor(DOMString type, optional CompositionEventInit eventInitDict), Exposed=Window]
+interface CompositionEvent : UIEvent {
+  readonly attribute DOMString data;
+};
+
+dictionary CompositionEventInit : UIEventInit {
+  DOMString data = "";
+};
+
+// https://github.com/w3c/uievents/issues/134
+partial interface CompositionEvent {
+  // Originally introduced (and deprecated) in this specification
+  void initCompositionEvent(DOMString typeArg,
+                            optional boolean bubblesArg = false,
+                            optional boolean cancelableArg = false,
+                            optional Window? viewArg = null,
+                            optional DOMString dataArg = "");
+};

--- a/lib/jsdom/living/events/FocusEvent-impl.js
+++ b/lib/jsdom/living/events/FocusEvent-impl.js
@@ -1,4 +1,4 @@
 "use strict";
-const EventImpl = require("./Event-impl").implementation;
+const UIEventImpl = require("./UIEvent-impl").implementation;
 
-exports.implementation = class FocusEventImpl extends EventImpl { };
+exports.implementation = class FocusEventImpl extends UIEventImpl {};

--- a/lib/jsdom/living/events/KeyboardEvent-impl.js
+++ b/lib/jsdom/living/events/KeyboardEvent-impl.js
@@ -3,16 +3,18 @@
 const UIEventImpl = require("./UIEvent-impl").implementation;
 
 class KeyboardEventImpl extends UIEventImpl {
-  initKeyboardEvent(type, bubbles, cancelable, view, key, location, modifiersList, repeat, locale) {
+  initKeyboardEvent(type, bubbles, cancelable, view, key, location, ctrlKey, altKey, shiftKey, metaKey) {
     if (this._dispatchFlag) {
       return;
     }
 
-    this.initUIEvent(type, bubbles, cancelable, view, key);
+    this.initUIEvent(type, bubbles, cancelable, view, 0);
+    this.key = key;
     this.location = location;
-    this.modifiersList = modifiersList;
-    this.repeat = repeat;
-    this.locale = locale;
+    this.ctrlKey = ctrlKey;
+    this.altKey = altKey;
+    this.shiftKey = shiftKey;
+    this.metaKey = metaKey;
   }
 }
 

--- a/lib/jsdom/living/events/KeyboardEvent.webidl
+++ b/lib/jsdom/living/events/KeyboardEvent.webidl
@@ -26,8 +26,17 @@ dictionary KeyboardEventInit : EventModifierInit {
 };
 
 partial interface KeyboardEvent {
-    // Originally introduced (and deprecated) in this specification
-    void initKeyboardEvent (DOMString typeArg, boolean bubblesArg, boolean cancelableArg, Window? viewArg, DOMString keyArg, unsigned long locationArg, DOMString modifiersListArg, boolean repeat, DOMString locale);
+  // Originally introduced (and deprecated) in this specification
+  void initKeyboardEvent(DOMString typeArg,
+                         optional boolean bubblesArg = false,
+                         optional boolean cancelableArg = false,
+                         optional Window? viewArg = null,
+                         optional DOMString keyArg = "",
+                         optional unsigned long locationArg = 0,
+                         optional boolean ctrlKey = false,
+                         optional boolean altKey = false,
+                         optional boolean shiftKey = false,
+                         optional boolean metaKey = false);
 };
 
 partial interface KeyboardEvent {

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -25,7 +25,22 @@ dictionary MouseEventInit : EventModifierInit {
              EventTarget?   relatedTarget = null;
 };
 
+// https://github.com/w3c/uievents/issues/136
 partial interface MouseEvent {
     // Deprecated in this specification
-    void initMouseEvent (DOMString typeArg, boolean bubblesArg, boolean cancelableArg, Window? viewArg, long detailArg, long screenXArg, long screenYArg, long clientXArg, long clientYArg, boolean ctrlKeyArg, boolean altKeyArg, boolean shiftKeyArg, boolean metaKeyArg, short buttonArg, EventTarget? relatedTargetArg);
+    void initMouseEvent(DOMString typeArg,
+                        optional boolean bubblesArg = false,
+                        optional boolean cancelableArg = false,
+                        optional Window? viewArg = null,
+                        optional long detailArg = 0,
+                        optional long screenXArg = 0,
+                        optional long screenYArg = 0,
+                        optional long clientXArg = 0,
+                        optional long clientYArg = 0,
+                        optional boolean ctrlKeyArg = 0,
+                        optional boolean altKeyArg = 0,
+                        optional boolean shiftKeyArg = 0,
+                        optional boolean metaKeyArg = 0,
+                        optional short buttonArg = 0,
+                        optional EventTarget? relatedTargetArg = null);
 };

--- a/lib/jsdom/living/events/UIEvent-impl.js
+++ b/lib/jsdom/living/events/UIEvent-impl.js
@@ -1,9 +1,48 @@
 "use strict";
 
+const idlUtils = require("../generated/utils");
+const UIEventInit = require("../generated/UIEventInit");
 const EventImpl = require("./Event-impl").implementation;
 
+// Until webidl2js gains support for checking for Window, this would have to do.
+function isWindow(val) {
+  if (typeof val !== "object") {
+    return false;
+  }
+  const wrapper = idlUtils.wrapperForImpl(val);
+  if (typeof wrapper === "object") {
+    return wrapper === wrapper._globalProxy;
+  }
+
+  // `val` may be either impl or wrapper currently, because webidl2js currently unwraps Window objects (and their global
+  // proxies) to their underlying EventTargetImpl during conversion, which is not what we want. But at the same time,
+  // some internal usage call this constructor with the actual global proxy.
+  return isWindow(idlUtils.implForWrapper(val));
+}
+
 class UIEventImpl extends EventImpl {
+  constructor(args, privateData) {
+    const eventInitDict = args[1] || UIEventInit.convert(undefined);
+
+    // undefined check included so that we can omit the property in internal usage.
+    if (eventInitDict.view !== null && eventInitDict.view !== undefined) {
+      if (!isWindow(eventInitDict.view)) {
+        throw new TypeError(`Failed to construct '${new.target.name.replace(/Impl$/, "")}': member view is not of ` +
+                            "type Window.");
+      }
+    }
+
+    super(args, privateData);
+  }
+
   initUIEvent(type, bubbles, cancelable, view, detail) {
+    if (view !== null) {
+      if (!isWindow(view)) {
+        throw new TypeError(`Failed to execute 'initUIEvent' on '${this.constructor.name.replace(/Impl$/, "")}': ` +
+                            "parameter 4 is not of type 'Window'.");
+      }
+    }
+
     if (this._dispatchFlag) {
       return;
     }

--- a/lib/jsdom/living/events/UIEvent.webidl
+++ b/lib/jsdom/living/events/UIEvent.webidl
@@ -27,7 +27,12 @@ dictionary EventModifierInit : UIEventInit {
              boolean modifierSymbolLock = false;
 };
 
+// https://github.com/w3c/uievents/issues/133
 partial interface UIEvent {
     // Deprecated in this specification
-    void initUIEvent (DOMString typeArg, boolean bubblesArg, boolean cancelableArg, Window? viewArg, long detailArg);
+    void initUIEvent(DOMString typeArg,
+                     optional boolean bubblesArg = false,
+                     optional boolean cancelableArg = false,
+                     optional Window? viewArg = null,
+                     optional long detailArg = 0);
 };

--- a/lib/jsdom/living/events/WheelEvent-impl.js
+++ b/lib/jsdom/living/events/WheelEvent-impl.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const MouseEventImpl = require("./MouseEvent-impl").implementation;
+
+class WheelEventImpl extends MouseEventImpl {}
+
+module.exports = {
+  implementation: WheelEventImpl
+};

--- a/lib/jsdom/living/events/WheelEvent.webidl
+++ b/lib/jsdom/living/events/WheelEvent.webidl
@@ -1,0 +1,21 @@
+[Constructor(DOMString type, optional WheelEventInit eventInitDict), Exposed=Window]
+interface WheelEvent : MouseEvent {
+  // DeltaModeCode
+  const unsigned long DOM_DELTA_PIXEL = 0x00;
+  const unsigned long DOM_DELTA_LINE  = 0x01;
+  const unsigned long DOM_DELTA_PAGE  = 0x02;
+
+  readonly attribute double deltaX;
+  readonly attribute double deltaY;
+  readonly attribute double deltaZ;
+  readonly attribute unsigned long deltaMode;
+};
+
+dictionary WheelEventInit : MouseEventInit {
+  double deltaX = 0.0;
+  double deltaY = 0.0;
+  double deltaZ = 0.0;
+  unsigned long deltaMode = 0;
+};
+
+// No browsers implement initWheelEvent().

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -32,6 +32,8 @@ exports.MouseEvent = require("./generated/MouseEvent").interface;
 exports.KeyboardEvent = require("./generated/KeyboardEvent").interface;
 exports.TouchEvent = require("./generated/TouchEvent").interface;
 exports.ProgressEvent = require("./generated/ProgressEvent").interface;
+exports.CompositionEvent = require("./generated/CompositionEvent").interface;
+exports.WheelEvent = require("./generated/WheelEvent").interface;
 exports.EventTarget = require("./generated/EventTarget").interface;
 
 exports.Location = require("./generated/Location").interface;

--- a/test/web-platform-tests/index.js
+++ b/test/web-platform-tests/index.js
@@ -341,6 +341,7 @@ describe("Web Platform Tests", () => {
     "dom/events/Event-init-while-dispatching.html",
     "dom/events/Event-initEvent.html",
     "dom/events/Event-propagation.html",
+    "dom/events/Event-subclasses-constructors.html",
     "dom/events/Event-type.html",
     "dom/events/Event-type-empty.html",
     "dom/events/EventListener-handleEvent.html",


### PR DESCRIPTION
This is rebased on https://github.com/tmpvar/jsdom/pull/1953 to avoid conflict.

Fixes #1959.