### PR TITLE
Speed up sync XHR result parsing

### DIFF
--- a/lib/jsdom/living/xhr-sync-worker.js
+++ b/lib/jsdom/living/xhr-sync-worker.js
@@ -16,15 +16,15 @@ process.stdin.on("data", chunk => {
 
 process.stdin.on("end", () => {
   const buffer = Buffer.concat(chunks);
-  const flag = JSON.parse(buffer.toString(), (k, v) => {
-    if (v && v.type === "Buffer" && v.data) {
-      return new Buffer(v.data);
-    }
-    if (k === "cookieJar" && v) {
-      return tough.CookieJar.fromJSON(v);
-    }
-    return v;
-  });
+
+  const flag = JSON.parse(buffer.toString());
+  if (flag.body && flag.body.type === "Buffer" && flag.body.data) {
+    flag.body = new Buffer(flag.body.data);
+  }
+  if (flag.cookieJar) {
+    flag.cookieJar = tough.CookieJar.fromJSON(flag.cookieJar);
+  }
+
   flag.synchronous = false;
   xhr[xhrSymbols.flag] = flag;
   const properties = xhr[xhrSymbols.properties];

--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -610,15 +610,18 @@ module.exports = function createXMLHttpRequest(window) {
           }
           throw res.error;
         }
-        const response = JSON.parse(res.stdout.toString(), (k, v) => {
-          if (k === "responseBuffer" && v && v.data) {
-            return new Buffer(v.data);
-          }
-          if (k === "cookieJar" && v) {
-            return tough.CookieJar.deserializeSync(v, this._ownerDocument._cookieJar.store);
-          }
-          return v;
-        });
+
+        const response = JSON.parse(res.stdout.toString());
+        if (response.properties.responseBuffer && response.properties.responseBuffer.data) {
+          response.properties.responseBuffer = new Buffer(response.properties.responseBuffer.data);
+        }
+        if (response.properties.cookieJar) {
+          response.properties.cookieJar = tough.CookieJar.deserializeSync(
+            response.properties.cookieJar,
+            this._ownerDocument._cookieJar.store
+          );
+        }
+
         response.properties.readyState = XMLHttpRequest.LOADING;
         this[xhrSymbols.properties] = response.properties;
 


### PR DESCRIPTION
I figured that rather than using JSON.parse()'s reviver function, it might be more efficient to let JSON.parse() do its thing and modify the resulting object afterwards.

This seems to cut the time spent parsing the result from the other process from an average of 650ms to 60ms. It should help with https://github.com/tmpvar/jsdom/issues/1833, and might allow us to enable some timeout-tests :-)