### PR TITLE
Added missing super() in constructor

### DIFF
--- a/lib/jsdom/living/xmlhttprequest.js
+++ b/lib/jsdom/living/xmlhttprequest.js
@@ -98,6 +98,7 @@ module.exports = function createXMLHttpRequest(window) {
 
   class XMLHttpRequest extends XMLHttpRequestEventTarget.interface {
     constructor() { // eslint-disable-line constructor-super
+      super();
       const theThis = Object.create(new.target.prototype);
       XMLHttpRequestEventTarget.setup(theThis);
       theThis.upload = XMLHttpRequestUpload.create();


### PR DESCRIPTION
- **Node.js version:** 6.10
- **jsdom version:** 11.2.0

```
const { JSDOM } = require("jsdom");

const test = new JSDOM('<div>hello</div>');
```

When I run my test I get the following error:

.../node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js: missing super() call in constructor
         98 | 
         99 |   class XMLHttpRequest extends XMLHttpRequestEventTarget.interface {
      > 100 |     constructor() { // eslint-disable-line constructor-super
            |     ^
        101 |       const theThis = Object.create(new.target.prototype);
        102 |       XMLHttpRequestEventTarget.setup(theThis);

After adding `super();` everything works as expected.