### PR TITLE
Add {request,cancel}AnimationFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ Note that we strongly advise against trying to "execute scripts" by mashing toge
 
 Finally, for advanced use cases you can use the `dom.runVMScript(script)` method, documented below.
 
+### Visual mode
+
+jsdom by default will do no rendering, layout, animation, rendering or css. However, you can opt-in to a subset of features which enables some of it. You do this by passing `pretendToBeVisual: true` to the jsdom constructor.
+
+```js
+const window = (new JSDOM(``, { pretendToBeVisual: true })).window;
+
+window.requestAnimationFrame(timestamp => {
+  timestamp > 0;
+});
+```
+
+This will make `document.hidden` return `true` and `document.visibilityState` return `"visible"`.
+
+Currently only `window.requestAnimationFrame` and `window.cancelAnimationFrame` have been implemented.
+
 ### Loading subresources
 
 By default, jsdom will not load any subresources such as scripts, stylesheets, images, or iframes. If you'd like jsdom to load such resources, you can pass the `resources: "usable"` option, which will load all usable resources. Those are:

--- a/README.md
+++ b/README.md
@@ -101,9 +101,13 @@ Note that we strongly advise against trying to "execute scripts" by mashing toge
 
 Finally, for advanced use cases you can use the `dom.runVMScript(script)` method, documented below.
 
-### Visual mode
+### Pretend to render
 
-jsdom by default will do no rendering, layout, animation, rendering or css. However, you can opt-in to a subset of features which enables some of it. You do this by passing `pretendToBeVisual: true` to the jsdom constructor.
+jsdom does not have the capability to render visual content, and will act like a headless browser by default. It provides hints to web pages through APIs such as `document.hidden` that their content is not visible.
+
+When the `pretendToBeVisual` option is set to `true`, jsdom will pretend that it is rendering and displaying content. It does this by changing the values of `document.hidden` and `document.visibilityState`. It will also provide an imitation of the `window.requestAnimationFrame()` / `window.cancelAnimationFrame()` methods, normally only available for content being rendered.
+
+Note that using this option could lead to unpredictable behaviour in code that changes action depending on content visibility.
 
 ```js
 const window = (new JSDOM(``, { pretendToBeVisual: true })).window;

--- a/README.md
+++ b/README.md
@@ -101,25 +101,25 @@ Note that we strongly advise against trying to "execute scripts" by mashing toge
 
 Finally, for advanced use cases you can use the `dom.runVMScript(script)` method, documented below.
 
-### Pretend to render
+### Pretending to be a visual browser
 
 jsdom does not have the capability to render visual content, and will act like a headless browser by default. It provides hints to web pages through APIs such as `document.hidden` that their content is not visible.
 
-When the `pretendToBeVisual` option is set to `true`, jsdom will pretend that it is rendering and displaying content. It does this by changing the values of `document.hidden` and `document.visibilityState`. It will also provide an imitation of the `window.requestAnimationFrame()` / `window.cancelAnimationFrame()` methods, normally only available for content being rendered.
+When the `pretendToBeVisual` option is set to `true`, jsdom will pretend that it is rendering and displaying content. It does this by:
 
-Note that using this option could lead to unpredictable behaviour in code that changes action depending on content visibility.
+* Changing `document.hidden` to return `true` instead of `false`
+* Changing `document.visibilityState` to return `"visible"` instead of `"prerender"`
+* Enabling `window.requestAnimationFrame()` and `window.cancelAnimationFrame()` methods, which otherwise do not exist
 
 ```js
 const window = (new JSDOM(``, { pretendToBeVisual: true })).window;
 
 window.requestAnimationFrame(timestamp => {
-  timestamp > 0;
+  console.log(timestamp > 0);
 });
 ```
 
-This will make `document.hidden` return `true` and `document.visibilityState` return `"visible"`.
-
-Currently only `window.requestAnimationFrame` and `window.cancelAnimationFrame` have been implemented.
+Note that jsdom still [does not do any layout or rendering](#unimplemented-parts-of-the-web-platform), so this is really just about _pretending_ to be visual, not about implementing the parts of the platform a real, visual web browser would implement.
 
 ### Loading subresources
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -238,6 +238,7 @@ function transformOptions(options, encoding) {
       parseOptions: { locationInfo: false },
       runScripts: undefined,
       encoding,
+      pretendToBeVisual: false,
 
       // Defaults filled in later
       virtualConsole: undefined,
@@ -308,6 +309,10 @@ function transformOptions(options, encoding) {
 
   if (options.beforeParse !== undefined) {
     transformed.beforeParse = options.beforeParse;
+  }
+
+  if (options.pretendToBeVisual !== undefined) {
+    transformed.windowOptions.pretendToBeVisual = Boolean(options.pretendToBeVisual);
   }
 
   // concurrentNodeIterators??

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -11,6 +11,7 @@ const cssom = require("cssom");
 const postMessage = require("../living/post-message");
 const DOMException = require("domexception");
 const { btoa, atob } = require("abab");
+const hrtime = require("browser-process-hrtime");
 const idlUtils = require("../living/generated/utils");
 const createXMLHttpRequest = require("../living/xmlhttprequest");
 const createFileReader = require("../living/generated/FileReader").createInterface;
@@ -43,7 +44,7 @@ dom.Window = Window;
 function Window(options) {
   EventTarget.setup(this);
 
-  const windowInitialized = process.hrtime();
+  const windowInitialized = hrtime();
 
   this._initGlobalEvents();
 
@@ -208,7 +209,7 @@ function Window(options) {
 
   if (this._pretendToBeVisual) {
     this.requestAnimationFrame = fn => {
-      const hr = process.hrtime(windowInitialized);
+      const hr = hrtime(windowInitialized);
       const hrInNano = hr[0] * 1e9 + hr[1];
       const fps = 1000 / 60;
       const hrInMicro = hrInNano / 1e6;

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -11,7 +11,6 @@ const cssom = require("cssom");
 const postMessage = require("../living/post-message");
 const DOMException = require("domexception");
 const { btoa, atob } = require("abab");
-const hrtime = require("browser-process-hrtime");
 const idlUtils = require("../living/generated/utils");
 const createXMLHttpRequest = require("../living/xmlhttprequest");
 const createFileReader = require("../living/generated/FileReader").createInterface;
@@ -44,7 +43,7 @@ dom.Window = Window;
 function Window(options) {
   EventTarget.setup(this);
 
-  const windowInitialized = hrtime();
+  const windowInitialized = process.hrtime();
 
   this._initGlobalEvents();
 
@@ -209,10 +208,9 @@ function Window(options) {
 
   if (this._pretendToBeVisual) {
     this.requestAnimationFrame = fn => {
-      const hr = hrtime(windowInitialized);
-      const hrInNano = hr[0] * 1e9 + hr[1];
+      const hr = process.hrtime(windowInitialized);
+      const hrInMicro = hr[0] * 1e3 + hr[1] / 1e6;
       const fps = 1000 / 60;
-      const hrInMicro = hrInNano / 1e6;
 
       return startTimer(
         window,

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -43,6 +43,8 @@ dom.Window = Window;
 function Window(options) {
   EventTarget.setup(this);
 
+  const windowInitialized = process.hrtime();
+
   this._initGlobalEvents();
 
   const window = this;
@@ -62,11 +64,12 @@ function Window(options) {
 
   ///// PRIVATE DATA PROPERTIES
 
-  // vm initialization is defered until script processing is activated
+  // vm initialization is deferred until script processing is activated
   this._globalProxy = this;
   Object.defineProperty(idlUtils.implForWrapper(this), idlUtils.wrapperSymbol, { get: () => this._globalProxy });
 
-  this.__timers = Object.create(null);
+  const timers = Object.create(null);
+  const animationFrameCallbacks = Object.create(null);
 
   // List options explicitly to be clear which are passed through
   this._document = Document.create([], {
@@ -182,24 +185,49 @@ function Window(options) {
   ///// METHODS
 
   let latestTimerId = 0;
+  let latestAnimationFrameCallbackId = 0;
 
   this.setTimeout = function (fn, ms) {
     const args = [];
     for (let i = 2; i < arguments.length; ++i) {
       args[i - 2] = arguments[i];
     }
-    return startTimer(window, setTimeout, clearTimeout, ++latestTimerId, fn, ms, args);
+    return startTimer(window, setTimeout, clearTimeout, ++latestTimerId, fn, ms, timers, args);
   };
   this.setInterval = function (fn, ms) {
     const args = [];
     for (let i = 2; i < arguments.length; ++i) {
       args[i - 2] = arguments[i];
     }
-    return startTimer(window, setInterval, clearInterval, ++latestTimerId, fn, ms, args);
+    return startTimer(window, setInterval, clearInterval, ++latestTimerId, fn, ms, timers, args);
   };
-  this.clearInterval = stopTimer.bind(this, window);
-  this.clearTimeout = stopTimer.bind(this, window);
-  this.__stopAllTimers = stopAllTimers.bind(this, window);
+  this.requestAnimationFrame = fn => {
+    const hr = process.hrtime(windowInitialized);
+    const hrInNano = hr[0] * 1e9 + hr[1];
+    const fps = 1000 / 60;
+    const hrInMicro = hrInNano / 1e6;
+
+    return startTimer(
+      window,
+      setTimeout,
+      clearTimeout,
+      ++latestAnimationFrameCallbackId,
+      fn,
+      fps,
+      animationFrameCallbacks,
+      [hrInMicro]
+    );
+  };
+  this.clearInterval = stopTimer.bind(this, timers);
+  this.clearTimeout = stopTimer.bind(this, timers);
+  this.cancelAnimationFrame = stopTimer.bind(this, animationFrameCallbacks);
+  this.__stopAllTimers = function () {
+    stopAllTimers(timers);
+    stopAllTimers(animationFrameCallbacks);
+
+    latestTimerId = 0;
+    latestAnimationFrameCallbackId = 0;
+  };
 
   function Option(text, value, defaultSelected, selected) {
     if (text === undefined) {
@@ -377,7 +405,7 @@ function Window(options) {
       delete this._document;
     }
 
-    stopAllTimers(currentWindow);
+    this.__stopAllTimers();
   };
 
   this.getComputedStyle = function (node) {
@@ -527,7 +555,7 @@ Object.defineProperty(Window.prototype, Symbol.toStringTag, {
   configurable: true
 });
 
-function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
+function startTimer(window, startFn, stopFn, timerId, callback, ms, timerStorage, args) {
   if (!window || !window._document) {
     return undefined;
   }
@@ -546,24 +574,23 @@ function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
   };
 
   const res = startFn(callback, ms);
-  window.__timers[timerId] = [res, stopFn];
+  timerStorage[timerId] = [res, stopFn];
   return timerId;
 }
 
-function stopTimer(window, id) {
-  const timer = window.__timers[id];
+function stopTimer(timerStorage, id) {
+  const timer = timerStorage[id];
   if (timer) {
     // Need to .call() with undefined to ensure the thisArg is not timer itself
     timer[1].call(undefined, timer[0]);
-    delete window.__timers[id];
+    delete timerStorage[id];
   }
 }
 
-function stopAllTimers(window) {
-  Object.keys(window.__timers).forEach(key => {
-    const timer = window.__timers[key];
+function stopAllTimers(timers) {
+  Object.keys(timers).forEach(key => {
+    const timer = timers[key];
     // Need to .call() with undefined to ensure the thisArg is not timer itself
     timer[1].call(undefined, timer[0]);
   });
-  window.__timers = Object.create(null);
 }

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -226,11 +226,6 @@ function Window(options) {
       );
     };
     this.cancelAnimationFrame = stopTimer.bind(this, animationFrameCallbacks);
-  } else {
-    // TODO: Should we throw to tell users about `pretendToBeVisual`?
-    // Also, should we somehow allow this to be polyfilled byt code using feature detection?
-    this.requestAnimationFrame = () => {};
-    this.cancelAnimationFrame = () => {};
   }
 
   this.__stopAllTimers = function () {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -69,8 +69,8 @@ function Window(options) {
   this._globalProxy = this;
   Object.defineProperty(idlUtils.implForWrapper(this), idlUtils.wrapperSymbol, { get: () => this._globalProxy });
 
-  const timers = Object.create(null);
-  const animationFrameCallbacks = Object.create(null);
+  let timers = Object.create(null);
+  let animationFrameCallbacks = Object.create(null);
 
   // List options explicitly to be clear which are passed through
   this._document = Document.create([], {
@@ -239,6 +239,9 @@ function Window(options) {
 
     latestTimerId = 0;
     latestAnimationFrameCallbackId = 0;
+
+    timers = Object.create(null);
+    animationFrameCallbacks = Object.create(null);
   };
 
   function Option(text, value, defaultSelected, selected) {

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -11,7 +11,6 @@ const cssom = require("cssom");
 const postMessage = require("../living/post-message");
 const DOMException = require("domexception");
 const { btoa, atob } = require("abab");
-const hrtime = require("browser-process-hrtime");
 const idlUtils = require("../living/generated/utils");
 const createXMLHttpRequest = require("../living/xmlhttprequest");
 const createFileReader = require("../living/generated/FileReader").createInterface;
@@ -22,6 +21,10 @@ const reportException = require("../living/helpers/runtime-script-errors");
 const { matchesDontThrow } = require("../living/helpers/selectors");
 const SessionHistory = require("../living/window/SessionHistory");
 const { contextifyWindow } = require("./documentfeatures.js");
+
+// Browserify's process implementation doesn't have hrtime, and this package is small so not much of a burden for
+// Node.js users.
+const hrtime = require("browser-process-hrtime");
 
 const GlobalEventHandlersImpl = require("../living/nodes/GlobalEventHandlers-impl").implementation;
 const WindowEventHandlersImpl = require("../living/nodes/WindowEventHandlers-impl").implementation;
@@ -210,9 +213,8 @@ function Window(options) {
   if (this._pretendToBeVisual) {
     this.requestAnimationFrame = fn => {
       const hr = hrtime(windowInitialized);
-      const hrInNano = hr[0] * 1e9 + hr[1];
+      const hrInMicro = hr[0] * 1e3 + hr[1] / 1e6;
       const fps = 1000 / 60;
-      const hrInMicro = hrInNano / 1e6;
 
       return startTimer(
         window,

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -130,6 +130,8 @@ function Window(options) {
   // HTMLFrameElement implementation.
   this._length = 0;
 
+  this._pretendToBeVisual = options.pretendToBeVisual;
+
   ///// GETTERS
 
   const external = External.create();
@@ -201,26 +203,35 @@ function Window(options) {
     }
     return startTimer(window, setInterval, clearInterval, ++latestTimerId, fn, ms, timers, args);
   };
-  this.requestAnimationFrame = fn => {
-    const hr = process.hrtime(windowInitialized);
-    const hrInNano = hr[0] * 1e9 + hr[1];
-    const fps = 1000 / 60;
-    const hrInMicro = hrInNano / 1e6;
-
-    return startTimer(
-      window,
-      setTimeout,
-      clearTimeout,
-      ++latestAnimationFrameCallbackId,
-      fn,
-      fps,
-      animationFrameCallbacks,
-      [hrInMicro]
-    );
-  };
   this.clearInterval = stopTimer.bind(this, timers);
   this.clearTimeout = stopTimer.bind(this, timers);
-  this.cancelAnimationFrame = stopTimer.bind(this, animationFrameCallbacks);
+
+  if (this._pretendToBeVisual) {
+    this.requestAnimationFrame = fn => {
+      const hr = process.hrtime(windowInitialized);
+      const hrInNano = hr[0] * 1e9 + hr[1];
+      const fps = 1000 / 60;
+      const hrInMicro = hrInNano / 1e6;
+
+      return startTimer(
+        window,
+        setTimeout,
+        clearTimeout,
+        ++latestAnimationFrameCallbackId,
+        fn,
+        fps,
+        animationFrameCallbacks,
+        [hrInMicro]
+      );
+    };
+    this.cancelAnimationFrame = stopTimer.bind(this, animationFrameCallbacks);
+  } else {
+    // TODO: Should we throw to tell users about `pretendToBeVisual`?
+    // Also, should we somehow allow this to be polyfilled byt code using feature detection?
+    this.requestAnimationFrame = () => {};
+    this.cancelAnimationFrame = () => {};
+  }
+
   this.__stopAllTimers = function () {
     stopAllTimers(timers);
     stopAllTimers(animationFrameCallbacks);

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -11,6 +11,7 @@ const cssom = require("cssom");
 const postMessage = require("../living/post-message");
 const DOMException = require("domexception");
 const { btoa, atob } = require("abab");
+const hrtime = require("browser-process-hrtime");
 const idlUtils = require("../living/generated/utils");
 const createXMLHttpRequest = require("../living/xmlhttprequest");
 const createFileReader = require("../living/generated/FileReader").createInterface;
@@ -43,7 +44,7 @@ dom.Window = Window;
 function Window(options) {
   EventTarget.setup(this);
 
-  const windowInitialized = process.hrtime();
+  const windowInitialized = hrtime();
 
   this._initGlobalEvents();
 
@@ -208,9 +209,10 @@ function Window(options) {
 
   if (this._pretendToBeVisual) {
     this.requestAnimationFrame = fn => {
-      const hr = process.hrtime(windowInitialized);
-      const hrInMicro = hr[0] * 1e3 + hr[1] / 1e6;
+      const hr = hrtime(windowInitialized);
+      const hrInNano = hr[0] * 1e9 + hr[1];
       const fps = 1000 / 60;
+      const hrInMicro = hrInNano / 1e6;
 
       return startTimer(
         window,

--- a/lib/jsdom/living/nodes/Document-impl.js
+++ b/lib/jsdom/living/nodes/Document-impl.js
@@ -806,10 +806,18 @@ class DocumentImpl extends NodeImpl {
   }
 
   get hidden() {
+    if (this._defaultView && this._defaultView._pretendToBeVisual) {
+      return false;
+    }
+
     return true;
   }
 
   get visibilityState() {
+    if (this._defaultView && this._defaultView._pretendToBeVisual) {
+      return "visible";
+    }
+
     return "prerender";
   }
 }

--- a/lib/old-api.js
+++ b/lib/old-api.js
@@ -121,6 +121,12 @@ exports.jsdom = function (html, options) {
     options.runScripts = "dangerously";
   }
 
+  if (options.pretendToBeVisual !== undefined) {
+    options.pretendToBeVisual = Boolean(options.pretendToBeVisual);
+  } else {
+    options.pretendToBeVisual = false;
+  }
+
   // List options explicitly to be clear which are passed through
   const window = new Window({
     parsingMode: options.parsingMode,
@@ -143,7 +149,8 @@ exports.jsdom = function (html, options) {
     strictSSL: options.strictSSL,
     proxy: options.proxy,
     userAgent: options.userAgent,
-    runScripts: options.runScripts
+    runScripts: options.runScripts,
+    pretendToBeVisual: options.pretendToBeVisual
   });
 
   const documentImpl = idlUtils.implForWrapper(window.document);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "acorn": "^5.1.2",
     "acorn-globals": "^4.0.0",
     "array-equal": "^1.0.0",
-    "browser-process-hrtime": "^0.1.2",
     "content-type-parser": "^1.0.1",
     "cssom": ">= 0.3.2 < 0.4.0",
     "cssstyle": ">= 0.2.37 < 0.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "acorn": "^5.1.2",
     "acorn-globals": "^4.0.0",
     "array-equal": "^1.0.0",
+    "browser-process-hrtime": "^0.1.2",
     "content-type-parser": "^1.0.1",
     "cssom": ">= 0.3.2 < 0.4.0",
     "cssstyle": ">= 0.2.37 < 0.3.0",

--- a/test/api/options.js
+++ b/test/api/options.js
@@ -255,6 +255,7 @@ describe("API: constructor options", () => {
         const { window } = new JSDOM(``);
 
         assert.isUndefined(window.requestAnimationFrame);
+        assert.isUndefined(window.cancelAnimationFrame);
       });
     });
 
@@ -266,13 +267,15 @@ describe("API: constructor options", () => {
         assert.strictEqual(document.visibilityState, "visible");
       });
 
-      it("document should call rAF", context => {
+      it("document should call rAF", { async: true }, context => {
         const { window } = new JSDOM(``, { pretendToBeVisual: true });
 
         window.requestAnimationFrame(() => {
           context.done();
         });
-      }, { async: true });
+
+        // Further functionality tests are in web platform tests
+      });
     });
   });
 });

--- a/test/api/options.js
+++ b/test/api/options.js
@@ -241,4 +241,44 @@ describe("API: constructor options", () => {
       assert.strictEqual(windowPassed, dom.window);
     });
   });
+
+  describe("pretendToBeVisual", () => {
+    describe("not set", () => {
+      it("document should be hidden and in prerender", () => {
+        const { document } = (new JSDOM(``)).window;
+
+        assert.strictEqual(document.hidden, true);
+        assert.strictEqual(document.visibilityState, "prerender");
+      });
+
+      it("document should no-op rAF", context => {
+        const { window } = new JSDOM(``);
+
+        window.requestAnimationFrame(() => {
+          context.done(new Error("rAF should not be called"));
+        });
+
+        setTimeout(() => {
+          context.done();
+        }, 500);
+      }, { async: true });
+    });
+
+    describe("set to true", () => {
+      it("document should be not be hidden and be visible", () => {
+        const { document } = (new JSDOM(``, { pretendToBeVisual: true })).window;
+
+        assert.strictEqual(document.hidden, false);
+        assert.strictEqual(document.visibilityState, "visible");
+      });
+
+      it("document should call rAF", context => {
+        const { window } = new JSDOM(``, { pretendToBeVisual: true });
+
+        window.requestAnimationFrame(() => {
+          context.done();
+        });
+      }, { async: true });
+    });
+  });
 });

--- a/test/api/options.js
+++ b/test/api/options.js
@@ -251,17 +251,11 @@ describe("API: constructor options", () => {
         assert.strictEqual(document.visibilityState, "prerender");
       });
 
-      it("document should no-op rAF", context => {
+      it("document should not have rAF", () => {
         const { window } = new JSDOM(``);
 
-        window.requestAnimationFrame(() => {
-          context.done(new Error("rAF should not be called"));
-        });
-
-        setTimeout(() => {
-          context.done();
-        }, 500);
-      }, { async: true });
+        assert.isUndefined(window.requestAnimationFrame);
+      });
     });
 
     describe("set to true", () => {

--- a/test/web-platform-tests/run-single-wpt.js
+++ b/test/web-platform-tests/run-single-wpt.js
@@ -157,7 +157,8 @@ function createJSDOM(urlPrefix, testPath) {
         if (error) {
           doneErrors.push(error);
         }
-      }
+      },
+      pretendToBeVisual: true
     });
   });
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -630,6 +630,13 @@ serializing.html: [fail, Unknown]
 
 ---
 
+DIR: html/webappapis/animation-frames
+
+callback-invoked.html: [fail, jsdom is headless so document.hidden is true. TODO fix before merging this PR.]
+idlharness.html: [fail, "Unknown ('ReferenceError: WebIDL2 is not defined', but why?)"]
+
+---
+
 DIR: html/webappapis/atob
 
 ---

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -632,7 +632,6 @@ serializing.html: [fail, Unknown]
 
 DIR: html/webappapis/animation-frames
 
-callback-invoked.html: [fail, jsdom is headless so document.hidden is true. TODO fix before merging this PR.]
 idlharness.html: [fail, "Unknown ('ReferenceError: WebIDL2 is not defined', but why?)"]
 
 ---

--- a/test/web-platform-tests/to-upstream/html/webappapis/animation-frames/no-interference-timers.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/animation-frames/no-interference-timers.html
@@ -32,7 +32,7 @@ test(() => {
   assert_equals(firstRafId, 1);
   assert_equals(rafId1, 2);
   assert_equals(rafId2, 3);
-}, "Animation frame IDs must be unaffected by timer IDs, and vice-versa");
+}, "Animation frame IDs must be unaffected by timer IDs");
 
 async_test(t => {
   window.clearTimeout(window.requestAnimationFrame(t.step_func_done()));

--- a/test/web-platform-tests/to-upstream/html/webappapis/animation-frames/no-interference-timers.html
+++ b/test/web-platform-tests/to-upstream/html/webappapis/animation-frames/no-interference-timers.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>requestAnimationFrame/cancelAnimationFrame: must not interfere with timers, or vice-versa</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames
+  // requires incrementing animation frame callback identifiers by 1 each time, and starting at 1.
+  // We can thus test that pretty rigorously.
+  //
+  // However https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timers
+  // only requires "a user-agent-defined integer that is greater than zero" for timers, so we can't
+  // test much there.
+  //
+  // The main content of the test is that the RAF IDs don't get perturbed by interleaving with
+  // setTimeout/setInterval calls, anyway.
+
+  window.setTimeout(() => {}, 0);
+  const firstRafId = window.requestAnimationFrame(() => {});
+
+  window.setTimeout(() => {}, 0);
+  const rafId1 = window.requestAnimationFrame(() => {});
+  window.setTimeout(() => {}, 0);
+  window.setInterval(() => {}, 0);
+  const rafId2 = window.requestAnimationFrame(() => {});
+
+  assert_equals(firstRafId, 1);
+  assert_equals(rafId1, 2);
+  assert_equals(rafId2, 3);
+}, "Animation frame IDs must be unaffected by timer IDs, and vice-versa");
+
+async_test(t => {
+  window.clearTimeout(window.requestAnimationFrame(t.step_func_done()));
+}, "Animation frame callbacks must still be invoked even if passed to clearTimeout");
+
+async_test(t => {
+  window.clearInterval(window.requestAnimationFrame(t.step_func_done()));
+}, "Animation frame callbacks must still be invoked even if passed to clearInterval");
+
+async_test(t => {
+  window.cancelAnimationFrame(window.setTimeout(t.step_func_done()));
+}, "setTimeout callbacks must still be invoked even if passed to cancelAnimationFrame");
+
+async_test(t => {
+  window.cancelAnimationFrame(window.setInterval(t.step_func_done()));
+}, "setInterval callbacks must still be invoked even if passed to cancelAnimationFrame");
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,6 +434,10 @@ browser-pack@^6.0.1:
     through2 "^2.0.0"
     umd "^3.0.0"
 
+browser-process-hrtime@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+
 browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,10 +434,6 @@ browser-pack@^6.0.1:
     through2 "^2.0.0"
     umd "^3.0.0"
 
-browser-process-hrtime@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
-
 browser-resolve@^1.11.0, browser-resolve@^1.7.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"


### PR DESCRIPTION
~This seems deceptively straightforward...~ It was :P

I'm unsure how to test this. The readme in `test/api/README.md` says that the web-platform tests should cover this. Am I supposed to pull in some extra tests?

My current "test" is running this script:

```js
const { JSDOM } = require('./');
const { window } = new JSDOM();

window.requestAnimationFrame(console.log);
const id = window.requestAnimationFrame(console.log);
window.cancelAnimationFrame(id);
```

It outputs e.g. `1752.195617`.

We can add https://npmjs.com/raf if a battel-tested implementation is wanted.

Fixes #1963

EDIT: Ah, figured it out, I think. Activated some more tests. One of them fails, though (commented it out), anything I can do about that?