### PR TITLE
Use correct line number for <script> if possible

### DIFF
--- a/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLScriptElement-impl.js
@@ -6,7 +6,7 @@ const HTMLElementImpl = require("./HTMLElement-impl").implementation;
 const { reflectURLAttribute } = require("../../utils");
 const resourceLoader = require("../../browser/resource-loader");
 const reportException = require("../helpers/runtime-script-errors");
-const { domSymbolTree } = require("../helpers/internal-constants");
+const { domSymbolTree, locationInfo } = require("../helpers/internal-constants");
 const nodeTypes = require("../node-type");
 
 const jsMIMETypes = new Set([
@@ -124,8 +124,20 @@ function processJavaScript(element, code, filename) {
   if (window) {
     document._currentScript = element;
 
+    let lineOffset = 0;
+    if (!element.src) {
+      for (const child of domSymbolTree.childrenIterator(element)) {
+        if (child.nodeType === nodeTypes.TEXT_NODE) {
+          if (child[locationInfo]) {
+            lineOffset = child[locationInfo].line - 1;
+          }
+          break;
+        }
+      }
+    }
+
     try {
-      vm.runInContext(code, window, { filename, displayErrors: false });
+      vm.runInContext(code, window, { filename, lineOffset, displayErrors: false });
     } catch (e) {
       reportException(window, e, filename);
     } finally {

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -40,7 +40,7 @@ describe("API: runScripts constructor option", () => {
     it("should execute <script>s with correct location when set to \"dangerously\" and includeNodeLocations", () => {
       const virtualConsole = new VirtualConsole();
       const promise = new Promise((resolve, reject) => {
-        virtualConsole.on("jsdomError", (err) => {
+        virtualConsole.on("jsdomError", err => {
           try {
             assert.strictEqual(err.type, "unhandled exception");
             assert(err.detail.stack.includes("at about:blank:2"));
@@ -50,9 +50,13 @@ describe("API: runScripts constructor option", () => {
           }
         });
       });
+
+      // eslint-disable no-new
       new JSDOM(`<body>
         <script>throw new Error();</script>
       </body>`, { runScripts: "dangerously", includeNodeLocations: true, virtualConsole });
+      // eslint-enable no-new
+
       return promise;
     });
 

--- a/test/api/options-run-scripts.js
+++ b/test/api/options-run-scripts.js
@@ -51,11 +51,10 @@ describe("API: runScripts constructor option", () => {
         });
       });
 
-      // eslint-disable no-new
+      // eslint-disable-next-line no-new
       new JSDOM(`<body>
         <script>throw new Error();</script>
       </body>`, { runScripts: "dangerously", includeNodeLocations: true, virtualConsole });
-      // eslint-enable no-new
 
       return promise;
     });


### PR DESCRIPTION
This makes debugging WPT drastically easier. With the new API, this requires `includeNodeLocations` option to work.

Column is not tracked since it works a bit differently:

```
> vm.runInContext('throw new Error()', ctx, { columnOffset: 4 })
evalmachine.<anonymous>:1
throw new Error()
    ^

Error
    at evalmachine.<anonymous>:1:11
```