### PR TITLE
Rethrow exception in timeout callback.

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -542,6 +542,7 @@ function startTimer(window, startFn, stopFn, timerId, callback, ms, args) {
       oldCallback.apply(window._globalProxy, args);
     } catch (e) {
       reportException(window, e, window.location.href);
+      throw e;
     }
   };
 


### PR DESCRIPTION
Application(e.g.Jest) watches uncaught Exception in callback function.(use **uncaughtException** event)
So rethrow exception in timeout callback.
