### PR TITLE
Remove duplicate NavigatorCookies

### DIFF
--- a/lib/jsdom/living/navigator/Navigator.webidl
+++ b/lib/jsdom/living/navigator/Navigator.webidl
@@ -41,11 +41,6 @@ interface NavigatorCookies {
 };
 
 [NoInterfaceObject]
-interface NavigatorCookies {
-  readonly attribute boolean cookieEnabled;
-};
-
-[NoInterfaceObject]
 interface NavigatorPlugins {
 //  [SameObject] readonly attribute PluginArray plugins;
 //  [SameObject] readonly attribute MimeTypeArray mimeTypes;


### PR DESCRIPTION
I was trying to install https://github.com/tmpvar/jsdom/pull/1994 from git and ran into this kind of puzzling error:
```
% npm install

> jsdom@11.3.0 prepare /Users/andrew/projects/jsdom
> yarn convert-idl

yarn convert-idl v0.23.4
$ node ./scripts/webidl/convert 
WebIDLParseError {
  message: 'The name "NavigatorCookies" of type "interface" is already seen',
  line: 44,
  input: ' {\n  readonly ',
  tokens: 
   [ { type: 'whitespace', value: ' ' },
     { type: 'other', value: '{' },
     { type: 'whitespace', value: '\n  ' },
     { type: 'identifier', value: 'readonly' },
     { type: 'whitespace', value: ' ' } ] }
error Command failed with exit code 1.
```
Some how there were two copies of that... I'm surprised I'm the only one to run into this though.