### PR TITLE
Make tests pass on Node.js 9.x

### DIFF
--- a/lib/old-api.js
+++ b/lib/old-api.js
@@ -238,7 +238,7 @@ exports.env = exports.jsdom.env = function () {
         { defaultEncoding: config.defaultEncoding, detectMetaCharset: true },
         (err, text, res) => {
           if (err) {
-            if (err.code === "ENOENT" || err.code === "ENAMETOOLONG") {
+            if (err.code === "ENOENT" || err.code === "ENAMETOOLONG" || err.code === "ERR_INVALID_ARG_TYPE") {
               config.html = config.somethingToAutodetect;
               processHTML(config);
             } else {


### PR DESCRIPTION
This happens when the input string contains a NUL character.