### PR TITLE
Correct DOMParser parsing of HTML entities in XML

### DIFF
--- a/lib/jsdom/browser/htmltodom.js
+++ b/lib/jsdom/browser/htmltodom.js
@@ -52,7 +52,7 @@ module.exports = class HTMLToDOM {
 
   _parseWithSax(html, fragment, element) {
     const SaxParser = this.parser.parser;
-    const parser = new SaxParser(/* strict = */true, { xmlns: true });
+    const parser = new SaxParser(/* strict = */true, { xmlns: true, strictEntities: true });
     parser.noscript = false;
     parser.looseCase = "toString";
     const openStack = [element];

--- a/test/web-platform-tests/to-upstream/domparsing/DOMParser-xml-character-entities.html
+++ b/test/web-platform-tests/to-upstream/domparsing/DOMParser-xml-character-entities.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<title>DOMParser should only parse XML character entities when parsing XML files</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+"use strict";
+
+function checkMetadata(doc, contentType) {
+  assert_true(doc instanceof Document, "Should be Document");
+  //  assert_equals(doc.URL, document.URL, "URL");
+  //  assert_equals(doc.documentURI, document.URL, "documentURI");
+  assert_equals(doc.characterSet, "UTF-8", "characterSet");
+  assert_equals(doc.charset, "UTF-8", "charset");
+  assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
+  assert_equals(doc.contentType, contentType, "contentType");
+  assert_equals(doc.location, null, "location");
+}
+
+const allowedTypes = ["text/xml", "application/xml", "application/xhtml+xml", "image/svg+xml"];
+
+allowedTypes.forEach(type => {
+  test(() => {
+    const p = new DOMParser();
+    const doc = p.parseFromString("<foo>&amp;<bar>&#215;</bar></foo>", type);
+    assert_true(doc instanceof Document, "Should be Document");
+    checkMetadata(doc, type);
+    assert_equals(doc.documentElement.namespaceURI, null);
+    assert_equals(doc.documentElement.localName, "foo");
+    assert_equals(doc.documentElement.tagName, "foo");
+  }, "Should parse XML character entities correctly in type " + type);
+
+  test(() => {
+    const p = new DOMParser();
+    const doc = p.parseFromString("<foo>&times;<bar>&#215;</bar></foo>", type);
+    checkMetadata(doc, type);
+    assert_equals(doc.documentElement.namespaceURI, "http://www.mozilla.org/newlayout/xml/parsererror.xml");
+    assert_equals(doc.documentElement.localName, "parsererror");
+    assert_equals(doc.documentElement.tagName, "parsererror");
+  }, "Should return an error document for undefined (HTML) character entities in type " + type);
+
+});
+</script>


### PR DESCRIPTION
To be consistent with browser implementations, `parseFromString` should not parse HTML character entities in XML documents.

node sax already provides a `strictEntities` option. This commit enables this option, ensuring only predefined XML character entities (`&amp;`, `&apos;`, `&gt;`, `&lt;`, and `&quot;`) are parsed.

See: https://github.com/isaacs/sax-js/tree/master#arguments
See: https://www.w3.org/TR/REC-xml/#sec-predefined-ent

---

Chrome 61:

![correct_domparser_parsing_of_html_entities_in_xml_by_myabc_ _pull_request__2029_ _tmpvar_jsdom](https://user-images.githubusercontent.com/755/32068215-922c4b3e-ba7d-11e7-94f5-c677c73182b1.png)
