### PR TITLE
Convert NamedNodeMap to IDL

### DIFF
--- a/lib/jsdom/living/attributes.js
+++ b/lib/jsdom/living/attributes.js
@@ -1,157 +1,20 @@
 "use strict";
 const DOMException = require("domexception");
-const { defineGetter } = require("../utils");
-const idlUtils = require("./generated/utils");
 const attrGenerated = require("./generated/Attr");
-const { changeAttributeImpl, getAttrImplQualifiedName } = require("./attributes/Attr-impl");
-
-// https://dom.spec.whatwg.org/#namednodemap
-
-const INTERNAL = Symbol("NamedNodeMap internal");
-
-// TODO: use NamedPropertyTracker when https://github.com/tmpvar/jsdom/pull/1116 lands?
-
-// Don't emulate named getters for these properties.
-// Compiled later after NamedNodeMap is all set up.
-const reservedNames = new Set();
-
-function NamedNodeMap() {
-  throw new TypeError("Illegal constructor");
-}
-
-defineGetter(NamedNodeMap.prototype, "length", function () {
-  return this[INTERNAL].attributeList.length;
-});
-
-NamedNodeMap.prototype.item = function (index) {
-  if (arguments.length < 1) {
-    throw new TypeError("Not enough arguments to NamedNodeMap.prototype.item");
-  }
-
-  // Don't bother with full unsigned long long conversion. When we have better WebIDL support generally, revisit.
-  index = Number(index);
-
-  return this[index] || null;
-};
-
-NamedNodeMap.prototype.getNamedItem = function (name) {
-  if (arguments.length < 1) {
-    throw new TypeError("Not enough arguments to NamedNodeMap.prototype.getNamedItem");
-  }
-  name = String(name);
-
-  return idlUtils.wrapperForImpl(exports.getAttributeByName(this[INTERNAL].element, name));
-};
-
-NamedNodeMap.prototype.getNamedItemNS = function (namespace, localName) {
-  if (arguments.length < 2) {
-    throw new TypeError("Not enough arguments to NamedNodeMap.prototype.getNamedItemNS");
-  }
-  if (namespace === undefined || namespace === null) {
-    namespace = null;
-  } else {
-    namespace = String(namespace);
-  }
-  localName = String(localName);
-
-  return idlUtils.wrapperForImpl(exports.getAttributeByNameNS(this[INTERNAL].element, namespace, localName));
-};
-
-NamedNodeMap.prototype.setNamedItem = function (attr) {
-  if (!attrGenerated.is(attr)) {
-    throw new TypeError("First argument to NamedNodeMap.prototype.setNamedItem must be an Attr");
-  }
-
-  return idlUtils.wrapperForImpl(exports.setAttribute(this[INTERNAL].element, idlUtils.implForWrapper(attr)));
-};
-
-NamedNodeMap.prototype.setNamedItemNS = function (attr) {
-  if (!attrGenerated.is(attr)) {
-    throw new TypeError("First argument to NamedNodeMap.prototype.setNamedItemNS must be an Attr");
-  }
-
-  return idlUtils.wrapperForImpl(exports.setAttribute(this[INTERNAL].element, idlUtils.implForWrapper(attr)));
-};
-
-NamedNodeMap.prototype.removeNamedItem = function (name) {
-  if (arguments.length < 1) {
-    throw new TypeError("Not enough arguments to NamedNodeMap.prototype.getNamedItem");
-  }
-  name = String(name);
-
-  const attr = exports.removeAttributeByName(this[INTERNAL].element, name);
-
-  if (attr === null) {
-    throw new DOMException("Tried to remove an attribute that was not present", "NotFoundError");
-  }
-
-  return idlUtils.wrapperForImpl(attr);
-};
-
-NamedNodeMap.prototype.removeNamedItemNS = function (namespace, localName) {
-  if (arguments.length < 2) {
-    throw new TypeError("Not enough arguments to NamedNodeMap.prototype.removeNamedItemNS");
-  }
-  if (namespace === undefined || namespace === null) {
-    namespace = null;
-  } else {
-    namespace = String(namespace);
-  }
-  localName = String(localName);
-
-  const attr = exports.removeAttributeByNameNS(this[INTERNAL].element, namespace, localName);
-
-  if (attr === null) {
-    throw new DOMException("Tried to remove an attribute that was not present", "NotFoundError");
-  }
-
-  return idlUtils.wrapperForImpl(attr);
-};
-
-exports.NamedNodeMap = NamedNodeMap;
-
-{
-  let { prototype } = NamedNodeMap;
-  while (prototype) {
-    for (const name of Object.getOwnPropertyNames(prototype)) {
-      reservedNames.add(name);
-    }
-    prototype = Object.getPrototypeOf(prototype);
-  }
-}
-
-exports.createNamedNodeMap = function (element) {
-  const nnm = Object.create(NamedNodeMap.prototype);
-  nnm[INTERNAL] = {
-    element,
-    attributeList: [],
-    attributesByNameMap: new Map()
-  };
-  return nnm;
-};
 
 // The following three are for https://dom.spec.whatwg.org/#concept-element-attribute-has. We don't just have a
 // predicate tester since removing that kind of flexibility gives us the potential for better future optimizations.
 
 exports.hasAttribute = function (element, A) {
-  const attributesNNM = element._attributes;
-  const { attributeList } = attributesNNM[INTERNAL];
-
-  return attributeList.includes(A);
+  return element._attributeList.includes(A);
 };
 
 exports.hasAttributeByName = function (element, name) {
-  const attributesNNM = element._attributes;
-  const { attributesByNameMap } = attributesNNM[INTERNAL];
-
-  return attributesByNameMap.has(name);
+  return element._attributesByNameMap.has(name);
 };
 
 exports.hasAttributeByNameNS = function (element, namespace, localName) {
-  const attributesNNM = element._attributes;
-  const { attributeList } = attributesNNM[INTERNAL];
-
-  return attributeList.some(attribute => {
+  return element._attributeList.some(attribute => {
     return attribute._localName === localName && attribute._namespace === namespace;
   });
 };
@@ -159,39 +22,26 @@ exports.hasAttributeByNameNS = function (element, namespace, localName) {
 exports.changeAttribute = function (element, attribute, value) {
   // https://dom.spec.whatwg.org/#concept-element-attributes-change
 
-  // The partitioning here works around a particularly bad circular require problem. See
-  // https://github.com/tmpvar/jsdom/pull/1247#issuecomment-149060470
-  changeAttributeImpl(element, attribute, value);
+  const oldValue = attribute._value;
+  attribute._value = value;
+
+  // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
+  element._attrModified(attribute._qualifiedName, value, oldValue);
 };
 
 exports.appendAttribute = function (element, attribute) {
   // https://dom.spec.whatwg.org/#concept-element-attributes-append
 
-  const attributesNNM = element._attributes;
-  const { attributeList } = attributesNNM[INTERNAL];
+  const attributeList = element._attributeList;
 
   // TODO mutation observer stuff
 
   attributeList.push(attribute);
   attribute._element = element;
 
-  // Sync target indexed properties
-  attributesNNM[attributeList.length - 1] = idlUtils.wrapperForImpl(attribute);
-
-  const name = getAttrImplQualifiedName(attribute);
-
-  // Sync target named properties
-  if (!reservedNames.has(name) && shouldNameBeInNNMProps(element, name)) {
-    Object.defineProperty(attributesNNM, name, {
-      configurable: true,
-      writable: true,
-      enumerable: false,
-      value: idlUtils.wrapperForImpl(attribute)
-    });
-  }
-
   // Sync name cache
-  const cache = attributesNNM[INTERNAL].attributesByNameMap;
+  const name = attribute._qualifiedName;
+  const cache = element._attributesByNameMap;
   let entry = cache.get(name);
   if (!entry) {
     entry = [];
@@ -206,8 +56,7 @@ exports.appendAttribute = function (element, attribute) {
 exports.removeAttribute = function (element, attribute) {
   // https://dom.spec.whatwg.org/#concept-element-attributes-remove
 
-  const attributesNNM = element._attributes;
-  const { attributeList } = attributesNNM[INTERNAL];
+  const attributeList = element._attributeList;
 
   // TODO mutation observer stuff
 
@@ -216,21 +65,9 @@ exports.removeAttribute = function (element, attribute) {
       attributeList.splice(i, 1);
       attribute._element = null;
 
-      // Sync target indexed properties
-      for (let j = i; j < attributeList.length; ++j) {
-        attributesNNM[j] = idlUtils.wrapperForImpl(attributeList[j]);
-      }
-      delete attributesNNM[attributeList.length];
-
-      const name = getAttrImplQualifiedName(attribute);
-
-      // Sync target named properties
-      if (!reservedNames.has(name) && shouldNameBeInNNMProps(element, name)) {
-        delete attributesNNM[name];
-      }
-
       // Sync name cache
-      const cache = attributesNNM[INTERNAL].attributesByNameMap;
+      const name = attribute._qualifiedName;
+      const cache = element._attributesByNameMap;
       const entry = cache.get(name);
       entry.splice(entry.indexOf(attribute), 1);
       if (entry.length === 0) {
@@ -248,8 +85,7 @@ exports.removeAttribute = function (element, attribute) {
 exports.replaceAttribute = function (element, oldAttr, newAttr) {
   // https://dom.spec.whatwg.org/#concept-element-attributes-replace
 
-  const attributesNNM = element._attributes;
-  const { attributeList } = attributesNNM[INTERNAL];
+  const attributeList = element._attributeList;
 
   // TODO mutation observer stuff
 
@@ -259,18 +95,9 @@ exports.replaceAttribute = function (element, oldAttr, newAttr) {
       oldAttr._element = null;
       newAttr._element = element;
 
-      // Sync target indexed properties
-      attributesNNM[i] = idlUtils.wrapperForImpl(newAttr);
-
-      const name = getAttrImplQualifiedName(newAttr);
-
-      // Sync target named properties
-      if (!reservedNames.has(name) && shouldNameBeInNNMProps(element, name)) {
-        attributesNNM[name] = newAttr;
-      }
-
       // Sync name cache
-      const cache = attributesNNM[INTERNAL].attributesByNameMap;
+      const name = newAttr._qualifiedName;
+      const cache = element._attributesByNameMap;
       let entry = cache.get(name);
       if (!entry) {
         entry = [];
@@ -294,7 +121,7 @@ exports.getAttributeByName = function (element, name) {
     name = name.toLowerCase();
   }
 
-  const cache = element._attributes[INTERNAL].attributesByNameMap;
+  const cache = element._attributesByNameMap;
   const entry = cache.get(name);
   if (!entry) {
     return null;
@@ -310,7 +137,7 @@ exports.getAttributeByNameNS = function (element, namespace, localName) {
     namespace = null;
   }
 
-  const { attributeList } = element._attributes[INTERNAL];
+  const attributeList = element._attributeList;
   for (let i = 0; i < attributeList.length; ++i) {
     const attr = attributeList[i];
     if (attr._namespace === namespace && attr._localName === localName) {
@@ -411,7 +238,7 @@ exports.removeAttributeByNameNS = function (element, namespace, localName) {
 exports.copyAttributeList = function (sourceElement, destElement) {
   // Needed by https://dom.spec.whatwg.org/#concept-node-clone
 
-  for (const sourceAttr of sourceElement._attributes[INTERNAL].attributeList) {
+  for (const sourceAttr of sourceElement._attributeList) {
     const destAttr = attrGenerated.createImpl([], {
       namespace: sourceAttr._namespace,
       namespacePrefix: sourceAttr._namespacePrefix,
@@ -426,8 +253,8 @@ exports.copyAttributeList = function (sourceElement, destElement) {
 exports.attributeListsEqual = function (elementA, elementB) {
   // Needed by https://dom.spec.whatwg.org/#concept-node-equals
 
-  const listA = elementA._attributes[INTERNAL].attributeList;
-  const listB = elementB._attributes[INTERNAL].attributeList;
+  const listA = elementA._attributeList;
+  const listB = elementB._attributeList;
 
   if (listA.length !== listB.length) {
     return false;
@@ -452,18 +279,11 @@ exports.attributeListsEqual = function (elementA, elementB) {
 exports.attributeNames = function (element) {
   // Needed by https://dom.spec.whatwg.org/#dom-element-getattributenames
 
-  return element._attributes[INTERNAL].attributeList.map(getAttrImplQualifiedName);
+  return element._attributeList.map(a => a._qualifiedName);
 };
 
 exports.hasAttributes = function (element) {
   // Needed by https://dom.spec.whatwg.org/#dom-element-hasattributes
 
-  return element._attributes[INTERNAL].attributeList.length > 0;
+  return element._attributeList.length > 0;
 };
-
-function shouldNameBeInNNMProps(element, name) {
-  if (element._ownerDocument._parsingMode === "html" && element._namespaceURI === "http://www.w3.org/1999/xhtml") {
-    return name.toLowerCase() === name;
-  }
-  return true;
-}

--- a/lib/jsdom/living/attributes/Attr-impl.js
+++ b/lib/jsdom/living/attributes/Attr-impl.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const attributes = require("../attributes.js");
+
 exports.implementation = class AttrImpl {
   constructor(_, privateData) {
     this._namespace = privateData.namespace !== undefined ? privateData.namespace : null;
@@ -24,12 +26,11 @@ exports.implementation = class AttrImpl {
   }
 
   get name() {
-    return exports.getAttrImplQualifiedName(this);
+    return this._qualifiedName;
   }
 
-  // Delegate to name
   get nodeName() {
-    return this.name;
+    return this._qualifiedName;
   }
 
   get value() {
@@ -39,7 +40,7 @@ exports.implementation = class AttrImpl {
     if (this._element === null) {
       this._value = v;
     } else {
-      exports.changeAttributeImpl(this._element, this, v);
+      attributes.changeAttribute(this._element, this, v);
     }
   }
 
@@ -62,26 +63,13 @@ exports.implementation = class AttrImpl {
   get ownerElement() {
     return this._element;
   }
-};
 
-exports.changeAttributeImpl = function (element, attributeImpl, value) {
-  // https://dom.spec.whatwg.org/#concept-element-attributes-change
+  get _qualifiedName() {
+    // https://dom.spec.whatwg.org/#concept-attribute-qualified-name
+    if (this._namespacePrefix === null) {
+      return this._localName;
+    }
 
-  // TODO mutation observer stuff
-
-  const oldValue = attributeImpl._value;
-  attributeImpl._value = value;
-
-  // Run jsdom hooks; roughly correspond to spec's "An attribute is set and an attribute is changed."
-  element._attrModified(exports.getAttrImplQualifiedName(attributeImpl), value, oldValue);
-};
-
-exports.getAttrImplQualifiedName = function (attributeImpl) {
-  // https://dom.spec.whatwg.org/#concept-attribute-qualified-name
-
-  if (attributeImpl._namespacePrefix === null) {
-    return attributeImpl._localName;
+    return this._namespacePrefix + ":" + this._localName;
   }
-
-  return attributeImpl._namespacePrefix + ":" + attributeImpl._localName;
 };

--- a/lib/jsdom/living/attributes/NamedNodeMap-impl.js
+++ b/lib/jsdom/living/attributes/NamedNodeMap-impl.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const DOMException = require("domexception");
+const idlUtils = require("../generated/utils.js");
+const attributes = require("../attributes.js");
+
+exports.implementation = class NamedNodeMapImpl {
+  constructor(args, privateData) {
+    this._element = privateData.element;
+  }
+  get _attributeList() {
+    return this._element._attributeList;
+  }
+
+  get [idlUtils.supportedPropertyIndices]() {
+    return this._attributeList.keys();
+  }
+  get length() {
+    return this._attributeList.length;
+  }
+  item(index) {
+    if (index >= this._attributeList.length) {
+      return null;
+    }
+    return this._attributeList[index];
+  }
+
+  get [idlUtils.supportedPropertyNames]() {
+    const names = new Set(this._attributeList.map(a => a._qualifiedName));
+    const el = this._element;
+    if (el._namespaceURI === "http://www.w3.org/1999/xhtml" && el._ownerDocument._parsingMode === "html") {
+      for (const name of names) {
+        const lowercaseName = name.toLowerCase();
+        if (lowercaseName !== name) {
+          names.delete(name);
+        }
+      }
+    }
+    return names;
+  }
+  getNamedItem(qualifiedName) {
+    return attributes.getAttributeByName(this._element, qualifiedName);
+  }
+  getNamedItemNS(namespace, localName) {
+    return attributes.getAttributeByNameNS(this._element, namespace, localName);
+  }
+  setNamedItem(attr) {
+    return attributes.setAttribute(this._element, attr);
+  }
+  setNamedItemNS(attr) {
+    return attributes.setAttribute(this._element, attr);
+  }
+  removeNamedItem(qualifiedName) {
+    const attr = attributes.removeAttributeByName(this._element, qualifiedName);
+    if (attr === null) {
+      throw new DOMException("Tried to remove an attribute that was not present", "NotFoundError");
+    }
+    return attr;
+  }
+  removeNamedItemNS(namespace, localName) {
+    const attr = attributes.removeAttributeByNameNS(this._element, namespace, localName);
+    if (attr === null) {
+      throw new DOMException("Tried to remove an attribute that was not present", "NotFoundError");
+    }
+    return attr;
+  }
+};

--- a/lib/jsdom/living/attributes/NamedNodeMap.webidl
+++ b/lib/jsdom/living/attributes/NamedNodeMap.webidl
@@ -1,0 +1,11 @@
+[Exposed=Window, LegacyUnenumerableNamedProperties]
+interface NamedNodeMap {
+  readonly attribute unsigned long length;
+  [WebIDL2JSValueAsUnsupported=null] getter Attr? item(unsigned long index);
+  [WebIDL2JSValueAsUnsupported=null] getter Attr? getNamedItem(DOMString qualifiedName);
+  Attr? getNamedItemNS(DOMString? namespace, DOMString localName);
+  [CEReactions] Attr? setNamedItem(Attr attr);
+  [CEReactions] Attr? setNamedItemNS(Attr attr);
+  [CEReactions] Attr removeNamedItem(DOMString qualifiedName);
+  [CEReactions] Attr removeNamedItemNS(DOMString? namespace, DOMString localName);
+};

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 exports.DOMException = require("domexception");
+exports.NamedNodeMap = require("./generated/NamedNodeMap").interface;
 exports.Attr = require("./generated/Attr").interface;
 exports.Node = require("./generated/Node").interface;
 exports.Element = require("./generated/Element").interface;
@@ -62,8 +63,7 @@ require("./register-elements")(exports);
 require("../level2/style")(exports);
 require("../level3/xpath")(exports);
 
-// These are OK but need migration to webidl2js eventually.
-exports.NamedNodeMap = require("./attributes").NamedNodeMap;
+// This one is OK but needs migration to webidl2js eventually.
 require("./node-filter")(exports);
 
 exports.URL = require("whatwg-url").URL;

--- a/lib/jsdom/living/nodes/Element-impl.js
+++ b/lib/jsdom/living/nodes/Element-impl.js
@@ -13,6 +13,7 @@ const { domSymbolTree } = require("../helpers/internal-constants");
 const DOMException = require("domexception");
 const DOMTokenList = require("../generated/DOMTokenList");
 const attrGenerated = require("../generated/Attr");
+const NamedNodeMap = require("../generated/NamedNodeMap");
 const validateNames = require("../helpers/validate-names");
 const { clone, listOfElementsWithQualifiedName, listOfElementsWithNamespaceAndLocalName,
   listOfElementsWithClassNames } = require("../node");
@@ -76,7 +77,13 @@ class ElementImpl extends NodeImpl {
     this._namespaceURI = null;
     this._prefix = null;
     this._localName = privateData.localName;
-    this._attributes = attributes.createNamedNodeMap(this);
+
+    this._attributeList = [];
+    // Used for caching.
+    this._attributesByNameMap = new Map();
+    this._attributes = NamedNodeMap.createImpl([], {
+      element: this
+    });
   }
 
   _attach() {


### PR DESCRIPTION
This also switches the ownership of "attribute list" and the associated cache to Element, which is a more literal reading of the spec and simplifies things here in jsdom.