### PR TITLE
Start web platform tests server before tests run

### DIFF
--- a/test/web-platform-tests/run-tuwpts.js
+++ b/test/web-platform-tests/run-tuwpts.js
@@ -1,13 +1,13 @@
 "use strict";
 const path = require("path");
-const { describe } = require("mocha-sugar-free");
+const { describe, before } = require("mocha-sugar-free");
 const { spawnSync } = require("child_process");
 const { readManifest, getPossibleTestFilePaths } = require("./wpt-manifest-utils.js");
+const startWPTServer = require("./start-wpt-server.js");
 
 const wptPath = path.resolve(__dirname, "tests");
 const testsPath = path.resolve(__dirname, "to-upstream");
 const manifestFilename = path.resolve(__dirname, "tuwpt-manifest.json");
-const runSingleWPT = require("./run-single-wpt.js")({ toUpstream: true });
 
 // We can afford to re-generate the manifest each time; we have few enough files that it's cheap.
 const testsRootArg = path.relative(wptPath, testsPath);
@@ -17,6 +17,14 @@ spawnSync("python", args, { cwd: wptPath, stdio: "inherit" });
 
 const manifest = readManifest(manifestFilename);
 const possibleTestFilePaths = getPossibleTestFilePaths(manifest);
+
+let wptServerURL;
+const runSingleWPT = require("./run-single-wpt.js")(() => wptServerURL);
+before({ timeout: 30 * 1000 }, () => {
+  return startWPTServer({ toUpstream: true }).then(url => {
+    wptServerURL = url;
+  });
+});
 
 describe("Local tests in web-platform-test format (to-upstream)", () => {
   for (const test of possibleTestFilePaths) {

--- a/test/web-platform-tests/start-wpt-server.js
+++ b/test/web-platform-tests/start-wpt-server.js
@@ -1,0 +1,74 @@
+"use strict";
+/* eslint-disable no-console, global-require */
+const path = require("path");
+const dns = require("dns");
+const childProcess = require("child_process");
+const q = require("q");
+const { inBrowserContext } = require("../util.js");
+const requestHead = require("request-promise-native").head;
+const dnsLookup = q.denodeify(dns.lookup);
+
+const wptDir = path.resolve(__dirname, "tests");
+
+const configPaths = {
+  default: path.resolve(__dirname, "wpt-config.json"),
+  toUpstream: path.resolve(__dirname, "tuwpt-config.json")
+};
+
+const configs = {
+  default: require(configPaths.default),
+  toUpstream: require(configPaths.toUpstream)
+};
+
+module.exports = ({ toUpstream = false } = {}) => {
+  if (inBrowserContext()) {
+    return Promise.resolve();
+  }
+
+  const configType = toUpstream ? "toUpstream" : "default";
+  const configPath = configPaths[configType];
+  const config = configs[configType];
+
+  const urlPrefix = `http://${config.host}:${config.ports.http[0]}/`;
+
+  return dnsLookup("web-platform.test").then(
+    () => {
+      const configArg = path.relative(path.resolve(wptDir), configPath);
+      const args = ["./wpt.py", "serve", "--config", configArg];
+      const python = childProcess.spawn("python", args, {
+        cwd: wptDir,
+        stdio: "inherit"
+      });
+
+      return new Promise((resolve, reject) => {
+        python.on("error", e => {
+          reject(new Error("Error starting python server process:", e.message));
+        });
+
+        resolve(pollForServer(urlPrefix));
+
+        process.on("exit", () => {
+          // Python doesn't register a default handler for SIGTERM and it doesn't run __exit__() methods of context
+          // managers when it gets that signal. Using SIGINT avoids this problem.
+          python.kill("SIGINT");
+        });
+      });
+    },
+    () => {
+      throw new Error("Host entries not present for web platform tests. See " +
+                      "https://github.com/w3c/web-platform-tests#running-the-tests");
+    }
+  );
+};
+
+function pollForServer(url) {
+  return requestHead(url)
+    .then(() => {
+      console.log(`WPT server at ${url} is up!`);
+      return url;
+    })
+    .catch(err => {
+      console.log(`WPT server at ${url} is not up yet (${err.message}); trying again`);
+      return q.delay(500).then(() => pollForServer(url));
+    });
+}


### PR DESCRIPTION
This is an attempt to address recent flaky builds, which we think might be caused because the server is starting in the middle of a JSDOM API test, causing a timeout for the currently-running JSDOM API test.

The previous design started booting the server the first time it was needed, and made all tests wait for the server-creation promise before commencing their actual logic. Now, server-creation runs in a before() block.

In the process, it removes the fallback to w3c-test.org, as that configuration isn't tested and generally can cause issues.