### PR TITLE
Update all the Web IDL - Part Two

### DIFF
--- a/lib/jsdom/living/domparsing/DOMParser.webidl
+++ b/lib/jsdom/living/domparsing/DOMParser.webidl
@@ -1,7 +1,7 @@
-[Constructor]
+[Constructor,
+  Exposed=Window]
 interface DOMParser {
-    [NewObject]
-    Document parseFromString(DOMString str, SupportedType type);
+  [NewObject] Document parseFromString(DOMString str, SupportedType type);
 };
 
 enum SupportedType {

--- a/lib/jsdom/living/events/Event.webidl
+++ b/lib/jsdom/living/events/Event.webidl
@@ -1,5 +1,5 @@
 [Constructor(DOMString type, optional EventInit eventInitDict),
- Exposed=(Window,Worker)]
+ Exposed=(Window,Worker,AudioWorklet)]
 interface Event {
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
@@ -23,6 +23,8 @@ interface Event {
 //  readonly attribute boolean composed;
 
   [Unforgeable] readonly attribute boolean isTrusted;
+  // Modified - No support for DOMHighResTimeStamp usage in Event-impl
+  // readonly attribute DOMHighResTimeStamp timeStamp;
   readonly attribute DOMTimeStamp timeStamp;
 
   void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // historical

--- a/lib/jsdom/living/events/EventTarget.webidl
+++ b/lib/jsdom/living/events/EventTarget.webidl
@@ -1,4 +1,5 @@
-[Exposed=(Window,Worker)]
+[Constructor,
+ Exposed=(Window,Worker,AudioWorklet)]
 interface EventTarget {
   void addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options);
   void removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options);
@@ -9,11 +10,11 @@ callback interface EventListener {
   void handleEvent(Event event);
 };
 
-dictionary EventListenerOptions{
+dictionary EventListenerOptions {
   boolean capture = false;
 };
 
-dictionary AddEventListenerOptions: EventListenerOptions {
-// boolean passive = false;
+dictionary AddEventListenerOptions : EventListenerOptions {
+//  boolean passive = false;
   boolean once = false;
 };

--- a/lib/jsdom/living/events/FocusEvent.webidl
+++ b/lib/jsdom/living/events/FocusEvent.webidl
@@ -1,4 +1,4 @@
-[Constructor(DOMString type, optional FocusEventInit eventInitDict)]
+[Constructor(DOMString type, optional FocusEventInit eventInitDict), Exposed=Window]
 interface FocusEvent : UIEvent {
   readonly attribute EventTarget? relatedTarget;
 };

--- a/lib/jsdom/living/events/HashChangeEvent.webidl
+++ b/lib/jsdom/living/events/HashChangeEvent.webidl
@@ -1,4 +1,5 @@
-[Constructor(DOMString type, optional HashChangeEventInit eventInitDict)]
+[Exposed=Window,
+ Constructor(DOMString type, optional HashChangeEventInit eventInitDict)]
 interface HashChangeEvent : Event {
   readonly attribute USVString oldURL;
   readonly attribute USVString newURL;

--- a/lib/jsdom/living/events/KeyboardEvent.webidl
+++ b/lib/jsdom/living/events/KeyboardEvent.webidl
@@ -1,28 +1,32 @@
-[Constructor(DOMString typeArg, optional KeyboardEventInit keyboardEventInitDict)]
+[Constructor(DOMString type, optional KeyboardEventInit eventInitDict), Exposed=Window]
 interface KeyboardEvent : UIEvent {
-    // KeyLocationCode
-    const unsigned long DOM_KEY_LOCATION_STANDARD = 0x00;
-    const unsigned long DOM_KEY_LOCATION_LEFT = 0x01;
-    const unsigned long DOM_KEY_LOCATION_RIGHT = 0x02;
-    const unsigned long DOM_KEY_LOCATION_NUMPAD = 0x03;
-    readonly    attribute DOMString     key;
-    readonly    attribute DOMString     code;
-    readonly    attribute unsigned long location;
-    readonly    attribute boolean       ctrlKey;
-    readonly    attribute boolean       shiftKey;
-    readonly    attribute boolean       altKey;
-    readonly    attribute boolean       metaKey;
-    readonly    attribute boolean       repeat;
-    readonly    attribute boolean       isComposing;
-    boolean getModifierState (DOMString keyArg);
+  // KeyLocationCode
+  const unsigned long DOM_KEY_LOCATION_STANDARD = 0x00;
+  const unsigned long DOM_KEY_LOCATION_LEFT = 0x01;
+  const unsigned long DOM_KEY_LOCATION_RIGHT = 0x02;
+  const unsigned long DOM_KEY_LOCATION_NUMPAD = 0x03;
+
+  readonly attribute DOMString key;
+  readonly attribute DOMString code;
+  readonly attribute unsigned long location;
+
+  readonly attribute boolean ctrlKey;
+  readonly attribute boolean shiftKey;
+  readonly attribute boolean altKey;
+  readonly attribute boolean metaKey;
+
+  readonly attribute boolean repeat;
+  readonly attribute boolean isComposing;
+
+  boolean getModifierState(DOMString keyArg);
 };
 
 dictionary KeyboardEventInit : EventModifierInit {
-             DOMString     key = "";
-             DOMString     code = "";
-             unsigned long location = 0;
-             boolean       repeat = false;
-             boolean       isComposing = false;
+  DOMString key = "";
+  DOMString code = "";
+  unsigned long location = 0;
+  boolean repeat = false;
+  boolean isComposing = false;
 };
 
 partial interface KeyboardEvent {
@@ -40,14 +44,13 @@ partial interface KeyboardEvent {
 };
 
 partial interface KeyboardEvent {
-    // The following support legacy user agents
-    readonly    attribute unsigned long charCode;
-    readonly    attribute unsigned long keyCode;
-    readonly    attribute unsigned long which;
+  // The following support legacy user agents
+  readonly attribute unsigned long charCode;
+  readonly attribute unsigned long keyCode;
 };
 
 partial dictionary KeyboardEventInit {
-             unsigned long charCode = 0;
-             unsigned long keyCode = 0;
-             unsigned long which = 0;
+  // The following support legacy user agents
+  unsigned long charCode = 0;
+  unsigned long keyCode = 0;
 };

--- a/lib/jsdom/living/events/MessageEvent.webidl
+++ b/lib/jsdom/living/events/MessageEvent.webidl
@@ -1,4 +1,4 @@
-[Constructor(DOMString type, optional MessageEventInit eventInitDict), Exposed=(Window,Worker)]
+[Constructor(DOMString type, optional MessageEventInit eventInitDict), Exposed=(Window,Worker,AudioWorklet)]
 interface MessageEvent : Event {
   readonly attribute any data;
   readonly attribute USVString origin;

--- a/lib/jsdom/living/events/MouseEvent.webidl
+++ b/lib/jsdom/living/events/MouseEvent.webidl
@@ -1,28 +1,32 @@
-[Constructor(DOMString typeArg, optional MouseEventInit mouseEventInitDict)]
+[Constructor(DOMString type, optional MouseEventInit eventInitDict), Exposed=Window]
 interface MouseEvent : UIEvent {
-    readonly    attribute long           screenX;
-    readonly    attribute long           screenY;
-    readonly    attribute long           clientX;
-    readonly    attribute long           clientY;
-    readonly    attribute boolean        ctrlKey;
-    readonly    attribute boolean        shiftKey;
-    readonly    attribute boolean        altKey;
-    readonly    attribute boolean        metaKey;
-    readonly    attribute short          button;
-    readonly    attribute EventTarget?   relatedTarget;
-    // Introduced in this specification
-    readonly    attribute unsigned short buttons;
-    boolean getModifierState (DOMString keyArg);
+  readonly attribute long screenX;
+  readonly attribute long screenY;
+  readonly attribute long clientX;
+  readonly attribute long clientY;
+
+  readonly attribute boolean ctrlKey;
+  readonly attribute boolean shiftKey;
+  readonly attribute boolean altKey;
+  readonly attribute boolean metaKey;
+
+  readonly attribute short button;
+  readonly attribute unsigned short buttons;
+
+  readonly attribute EventTarget? relatedTarget;
+
+  boolean getModifierState(DOMString keyArg);
 };
 
 dictionary MouseEventInit : EventModifierInit {
-             long           screenX = 0;
-             long           screenY = 0;
-             long           clientX = 0;
-             long           clientY = 0;
-             short          button = 0;
-             unsigned short buttons = 0;
-             EventTarget?   relatedTarget = null;
+  long screenX = 0;
+  long screenY = 0;
+  long clientX = 0;
+  long clientY = 0;
+
+  short button = 0;
+  unsigned short buttons = 0;
+  EventTarget? relatedTarget = null;
 };
 
 // https://github.com/w3c/uievents/issues/136

--- a/lib/jsdom/living/events/PopStateEvent.webidl
+++ b/lib/jsdom/living/events/PopStateEvent.webidl
@@ -1,4 +1,5 @@
-[Constructor(DOMString type, optional PopStateEventInit eventInitDict)]
+[Exposed=Window,
+ Constructor(DOMString type, optional PopStateEventInit eventInitDict)]
 interface PopStateEvent : Event {
   readonly attribute any state;
 };

--- a/lib/jsdom/living/events/TouchEvent.webidl
+++ b/lib/jsdom/living/events/TouchEvent.webidl
@@ -1,9 +1,17 @@
+dictionary TouchEventInit : EventModifierInit {
+    sequence<Touch> touches = [];
+    sequence<Touch> targetTouches = [];
+    sequence<Touch> changedTouches = [];
+};
+
+[Constructor(DOMString type, optional TouchEventInit eventInitDict),
+ Exposed=Window]
 interface TouchEvent : UIEvent {
-      readonly    attribute TouchList touches;
-      readonly    attribute TouchList targetTouches;
-      readonly    attribute TouchList changedTouches;
-      readonly    attribute boolean   altKey;
-      readonly    attribute boolean   metaKey;
-      readonly    attribute boolean   ctrlKey;
-      readonly    attribute boolean   shiftKey;
-  };
+    readonly attribute TouchList touches;
+    readonly attribute TouchList targetTouches;
+    readonly attribute TouchList changedTouches;
+    readonly attribute boolean   altKey;
+    readonly attribute boolean   metaKey;
+    readonly attribute boolean   ctrlKey;
+    readonly attribute boolean   shiftKey;
+};

--- a/lib/jsdom/living/events/UIEvent.webidl
+++ b/lib/jsdom/living/events/UIEvent.webidl
@@ -1,30 +1,30 @@
-[Constructor(DOMString type, optional UIEventInit eventInitDict)]
+[Constructor(DOMString type, optional UIEventInit eventInitDict), Exposed=Window]
 interface UIEvent : Event {
-    readonly    attribute Window? view;
-    readonly    attribute long    detail;
+  readonly attribute Window? view;
+  readonly attribute long detail;
 };
 
 dictionary UIEventInit : EventInit {
-             Window? view = null;
-             long    detail = 0;
+  Window? view = null;
+  long detail = 0;
 };
 
 dictionary EventModifierInit : UIEventInit {
-             boolean ctrlKey = false;
-             boolean shiftKey = false;
-             boolean altKey = false;
-             boolean metaKey = false;
-             boolean modifierAltGraph = false;
-             boolean modifierCapsLock = false;
-             boolean modifierFn = false;
-             boolean modifierFnLock = false;
-             boolean modifierHyper = false;
-             boolean modifierNumLock = false;
-             boolean modifierOS = false;
-             boolean modifierScrollLock = false;
-             boolean modifierSuper = false;
-             boolean modifierSymbol = false;
-             boolean modifierSymbolLock = false;
+  boolean ctrlKey = false;
+  boolean shiftKey = false;
+  boolean altKey = false;
+  boolean metaKey = false;
+
+  boolean modifierAltGraph = false;
+  boolean modifierCapsLock = false;
+  boolean modifierFn = false;
+  boolean modifierFnLock = false;
+  boolean modifierHyper = false;
+  boolean modifierNumLock = false;
+  boolean modifierScrollLock = false;
+  boolean modifierSuper = false;
+  boolean modifierSymbol = false;
+  boolean modifierSymbolLock = false;
 };
 
 // https://github.com/w3c/uievents/issues/133
@@ -35,4 +35,15 @@ partial interface UIEvent {
                      optional boolean cancelableArg = false,
                      optional Window? viewArg = null,
                      optional long detailArg = 0);
+};
+
+// https://w3c.github.io/uievents/#legacy-interface-UIEvent
+partial interface UIEvent {
+  // The following support legacy user agents
+  readonly attribute unsigned long which;
+};
+
+// https://w3c.github.io/uievents/#legacy-dictionary-UIEventInit
+partial dictionary UIEventInit {
+  unsigned long which = 0;
 };

--- a/lib/jsdom/living/file-api/Blob.webidl
+++ b/lib/jsdom/living/file-api/Blob.webidl
@@ -1,5 +1,6 @@
-[Constructor(optional sequence<BlobPart> blobParts, optional BlobPropertyBag options),
-Exposed=(Window,Worker)]
+[Constructor(optional sequence<BlobPart> blobParts,
+             optional BlobPropertyBag options),
+ Exposed=(Window,Worker), Serializable]
 interface Blob {
 
   readonly attribute unsigned long long size;

--- a/lib/jsdom/living/file-api/File.webidl
+++ b/lib/jsdom/living/file-api/File.webidl
@@ -1,7 +1,7 @@
 [Constructor(sequence<BlobPart> fileBits,
-            USVString fileName,
-            optional FilePropertyBag options),
-Exposed=(Window,Worker)]
+             USVString fileName,
+             optional FilePropertyBag options),
+ Exposed=(Window,Worker), Serializable]
 interface File : Blob {
   readonly attribute DOMString name;
   readonly attribute long long lastModified;

--- a/lib/jsdom/living/file-api/FileList.webidl
+++ b/lib/jsdom/living/file-api/FileList.webidl
@@ -1,4 +1,4 @@
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), Serializable]
 interface FileList {
   [WebIDL2JSValueAsUnsupported=null] getter File? item(unsigned long index);
   readonly attribute unsigned long length;

--- a/lib/jsdom/living/file-api/FileReader.webidl
+++ b/lib/jsdom/living/file-api/FileReader.webidl
@@ -3,6 +3,7 @@ interface FileReader: EventTarget {
 
   // async read methods
   void readAsArrayBuffer(Blob blob);
+//  void readAsBinaryString(Blob blob);
   void readAsText(Blob blob, optional DOMString label);
   void readAsDataURL(Blob blob);
 
@@ -19,7 +20,7 @@ interface FileReader: EventTarget {
   // File or Blob data
   readonly attribute (DOMString or ArrayBuffer)? result;
 
-  readonly attribute DOMError? error;
+  readonly attribute DOMException? error;
 
   // event handler content attributes
   attribute EventHandler onloadstart;
@@ -28,4 +29,5 @@ interface FileReader: EventTarget {
   attribute EventHandler onabort;
   attribute EventHandler onerror;
   attribute EventHandler onloadend;
+
 };

--- a/lib/jsdom/living/navigator/Navigator.webidl
+++ b/lib/jsdom/living/navigator/Navigator.webidl
@@ -1,21 +1,22 @@
+[Exposed=Window]
 interface Navigator {
   // objects implementing this interface also implement the interfaces given below
 };
 Navigator implements NavigatorID;
 Navigator implements NavigatorLanguage;
 Navigator implements NavigatorOnLine;
-//Navigator implements NavigatorContentUtils;
+// Navigator implements NavigatorContentUtils;
 Navigator implements NavigatorCookies;
 Navigator implements NavigatorPlugins;
 Navigator implements NavigatorConcurrentHardware;
 
 [NoInterfaceObject, Exposed=(Window,Worker)]
 interface NavigatorID {
-  [Exposed=Window] readonly attribute DOMString appCodeName; // constant "Mozilla"
+  readonly attribute DOMString appCodeName; // constant "Mozilla"
   readonly attribute DOMString appName; // constant "Netscape"
   readonly attribute DOMString appVersion;
   readonly attribute DOMString platform;
-  [Exposed=Window] readonly attribute DOMString product; // constant "Gecko"
+  readonly attribute DOMString product; // constant "Gecko"
   [Exposed=Window] readonly attribute DOMString productSub;
   readonly attribute DOMString userAgent;
   [Exposed=Window] readonly attribute DOMString vendor;
@@ -35,12 +36,14 @@ interface NavigatorOnLine {
   readonly attribute boolean onLine;
 };
 
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface NavigatorCookies {
   readonly attribute boolean cookieEnabled;
 };
 
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface NavigatorPlugins {
 //  [SameObject] readonly attribute PluginArray plugins;
 //  [SameObject] readonly attribute MimeTypeArray mimeTypes;

--- a/lib/jsdom/living/window/External.webidl
+++ b/lib/jsdom/living/window/External.webidl
@@ -1,4 +1,5 @@
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface External {
   void AddSearchProvider();
   void IsSearchProviderInstalled();

--- a/lib/jsdom/living/window/History.webidl
+++ b/lib/jsdom/living/window/History.webidl
@@ -1,12 +1,14 @@
 enum ScrollRestoration { "auto", "manual" };
 
+[Exposed=Window]
 interface History {
+//  readonly attribute unsigned long index;
   readonly attribute unsigned long length;
 //  attribute ScrollRestoration scrollRestoration;
   readonly attribute any state;
   void go(optional long delta = 0);
   void back();
   void forward();
-  void pushState(any data, DOMString title, optional DOMString? url = null);
-  void replaceState(any data, DOMString title, optional DOMString? url = null);
+  void pushState(any data, DOMString title, optional USVString? url = null);
+  void replaceState(any data, DOMString title, optional USVString? url = null);
 };

--- a/lib/jsdom/living/window/Location.webidl
+++ b/lib/jsdom/living/window/Location.webidl
@@ -1,3 +1,4 @@
+[Exposed=Window]
 interface Location { // but see also additional creation steps and overridden internal methods
   [Unforgeable] stringifier attribute USVString href;
   [Unforgeable] readonly attribute USVString origin;
@@ -13,5 +14,5 @@ interface Location { // but see also additional creation steps and overridden in
   [Unforgeable] void replace(USVString url);
   [Unforgeable] void reload();
 
-  // [Unforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
+//  [Unforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
 };


### PR DESCRIPTION
Updates for the remaining Web IDL after https://github.com/tmpvar/jsdom/pull/2053 handles the nodes/ directory. An exception is `Attr.webidl`, which I've left unchanged as it depends on the work from https://github.com/tmpvar/jsdom/pull/1822.