### PR TITLE
Add `originalRequest` to the object returned by the resource loader

### DIFF
--- a/lib/jsdom/browser/resource-loader.js
+++ b/lib/jsdom/browser/resource-loader.js
@@ -209,6 +209,7 @@ exports.download = function (url, options, callback) {
     }
   });
   return {
+    originalRequest: req,
     abort() {
       req.abort();
       const error = new Error("request canceled by user");

--- a/test/old-api/env.js
+++ b/test/old-api/env.js
@@ -677,13 +677,15 @@ describe("jsdom/env", () => {
               assert.ok(typeof callback === "function");
               if (/\.js$/.test(resource.url.path)) {
                 resource.url.path = "/js/dir" + resource.url.path;
-                resource.defaultFetch((err, body) => {
+                const request = resource.defaultFetch((err, body) => {
                   if (err) {
                     callback(err);
                   } else {
                     callback(null, body + "\nwindow.modifiedContent = true;");
                   }
                 });
+                assert.ok(typeof request.abort === "function");
+                assert.ok(typeof request.originalRequest === "object");
               } else {
                 resource.defaultFetch(callback);
               }


### PR DESCRIPTION
I'm not sure if you are still interested in taking changes to what is a deprecated API, but hopefully this is simple enough to be uncontroversial.

The use case is to allow me to use the request object to track the progress of long-lived resource downloads (i.e. show a progress bar).