### PR TITLE
Enable 'option-text-setter' test which passes

### DIFF
--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -561,7 +561,6 @@ DIR: html/semantics/forms/the-option-element
 
 option-label.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
 option-text-recurse.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
-option-text-setter.html: [fail, Unknown]
 option-value.html: [fail, Our impl is wrong; see comments in HTMLOptionElement-impl.js]
 
 ---


### PR DESCRIPTION
This test originally got enabled in https://github.com/tmpvar/jsdom/pull/2023, but was seemingly re-disabled during a rebase of that pull request.