### PR TITLE
Implement window.performance

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -2,6 +2,7 @@
 
 const webIDLConversions = require("webidl-conversions");
 const { CSSStyleDeclaration } = require("cssstyle");
+const { Performance: RawPerformance } = require("w3c-hr-time");
 const notImplemented = require("./not-implemented");
 const VirtualConsole = require("../virtual-console");
 const { define, mixin } = require("../utils");
@@ -20,6 +21,7 @@ const BarProp = require("../living/generated/BarProp");
 const Document = require("../living/generated/Document");
 const External = require("../living/generated/External");
 const Navigator = require("../living/generated/Navigator");
+const Performance = require("../living/generated/Performance");
 const Screen = require("../living/generated/Screen");
 const createAbortController = require("../living/generated/AbortController").createInterface;
 const createAbortSignal = require("../living/generated/AbortSignal").createInterface;
@@ -53,6 +55,7 @@ dom.Window = Window;
 function Window(options) {
   EventTarget.setup(this);
 
+  const rawPerformance = new RawPerformance();
   const windowInitialized = hrtime();
 
   this._initGlobalEvents();
@@ -150,6 +153,7 @@ function Window(options) {
   const toolbar = BarProp.create();
   const external = External.create();
   const navigator = Navigator.create([], { userAgent: options.userAgent });
+  const performance = Performance.create([], { rawPerformance });
   const screen = Screen.create();
 
   define(this, {
@@ -206,6 +210,9 @@ function Window(options) {
     },
     get toolbar() {
       return toolbar;
+    },
+    get performance() {
+      return performance;
     },
     get screen() {
       return screen;

--- a/lib/jsdom/living/hr-time/DOMHighResTimeStamp.webidl
+++ b/lib/jsdom/living/hr-time/DOMHighResTimeStamp.webidl
@@ -1,0 +1,1 @@
+typedef double DOMHighResTimeStamp;

--- a/lib/jsdom/living/hr-time/Performance-impl.js
+++ b/lib/jsdom/living/hr-time/Performance-impl.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const EventTargetImpl = require("../events/EventTarget-impl").implementation;
+
+class PerformanceImpl extends EventTargetImpl {
+  constructor(args, privateData) {
+    super(args, privateData);
+
+    this._rawPerformance = privateData.rawPerformance;
+  }
+
+  now() {
+    return this._rawPerformance.now();
+  }
+
+  get timeOrigin() {
+    return this._rawPerformance.timeOrigin;
+  }
+
+  toJSON() {
+    return this._rawPerformance.toJSON();
+  }
+}
+
+exports.implementation = PerformanceImpl;

--- a/lib/jsdom/living/hr-time/Performance.webidl
+++ b/lib/jsdom/living/hr-time/Performance.webidl
@@ -1,0 +1,6 @@
+[Exposed=(Window,Worker)]
+interface Performance : EventTarget {
+    DOMHighResTimeStamp now();
+    readonly attribute DOMHighResTimeStamp timeOrigin;
+    [Default] object              toJSON();
+};

--- a/lib/jsdom/living/index.js
+++ b/lib/jsdom/living/index.js
@@ -46,6 +46,7 @@ exports.BarProp = require("./generated/BarProp").interface;
 exports.Location = require("./generated/Location").interface;
 exports.History = require("./generated/History").interface;
 exports.Screen = require("./generated/Screen").interface;
+exports.Performance = require("./generated/Performance").interface;
 
 exports.Blob = require("./generated/Blob").interface;
 exports.File = require("./generated/File").interface;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sax": "^1.2.4",
     "symbol-tree": "^3.2.2",
     "tough-cookie": "^2.3.3",
+    "w3c-hr-time": "^1.0.0",
     "webidl-conversions": "^4.0.2",
     "whatwg-encoding": "^1.0.3",
     "whatwg-url": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sax": "^1.2.4",
     "symbol-tree": "^3.2.2",
     "tough-cookie": "^2.3.3",
-    "w3c-hr-time": "^1.0.0",
+    "w3c-hr-time": "^1.0.1",
     "webidl-conversions": "^4.0.2",
     "whatwg-encoding": "^1.0.3",
     "whatwg-url": "^6.4.0",

--- a/scripts/webidl/convert.js
+++ b/scripts/webidl/convert.js
@@ -30,6 +30,7 @@ addDir("../../lib/jsdom/living/domparsing");
 addDir("../../lib/jsdom/living/svg");
 addDir("../../lib/jsdom/living/aborting");
 addDir("../../lib/jsdom/living/websockets");
+addDir("../../lib/jsdom/living/hr-time");
 
 
 const outputDir = path.resolve(__dirname, "../../lib/jsdom/living/generated/");

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -198,6 +198,15 @@ xml-serialization.xhtml: [fail, Unknown]
 
 ---
 
+DIR: hr-time
+
+idlharness.html: [fail, ReferenceError - WebIDL2 is not defined]
+test_cross_frame_start.html: [fail, Not implemented]
+timeOrigin.html: [fail, Needs Worker implementation]
+window-worker-timeOrigin.window.html: [fail, Needs Worker implementation]
+
+---
+
 DIR: html/browsers/browsing-the-web/history-traversal
 
 001.html: [fail, Unknown]

--- a/test/web-platform-tests/to-upstream/hr-time/timeOrigin-dont-upstream.html
+++ b/test/web-platform-tests/to-upstream/hr-time/timeOrigin-dont-upstream.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const windowOrigin = performance.timeOrigin;
+
+test(() => {
+  // Use a 30ms cushion when comparing with Date() to account for inaccuracy.
+  const startTime = Date.now();
+  assert_greater_than_equal(startTime + 30, windowOrigin, 'Date.now() should be at least as large as the window timeOrigin.');
+  const startNow = performance.now();
+  assert_less_than_equal(startTime, windowOrigin + startNow + 30, 'Date.now() should be close to window timeOrigin.');
+}, 'Window timeOrigin is close to Date.now() when there is no system clock adjustment.');
+
+// const workerScript = 'postMessage({timeOrigin: performance.timeOrigin})';
+// const blob = new Blob([workerScript]);
+
+// async_test(function(t) {
+//   const beforeWorkerCreation = performance.now();
+//   const worker = new Worker(URL.createObjectURL(blob));
+//   worker.addEventListener('message', t.step_func_done(function(event) {
+//     const workerOrigin = event.data.timeOrigin;
+//     assert_greater_than_equal(workerOrigin, windowOrigin + beforeWorkerCreation, 'Worker timeOrigin should be greater than the window timeOrigin.');
+//     const afterWorkerCreation = performance.now();
+//     assert_less_than_equal(workerOrigin - windowOrigin, afterWorkerCreation, 'Window and worker timeOrigins should be close.');
+//   }));
+// }, 'Window and worker timeOrigins are close when created one after another.');
+
+// async_test(function(t) {
+//   this.step_timeout(function() {
+//     const workerCreation = performance.now();
+//     const worker = new Worker(URL.createObjectURL(blob));
+//     worker.addEventListener('message', t.step_func_done(function(event) {
+//       const workerOrigin = event.data.timeOrigin;
+//       assert_greater_than_equal(workerOrigin - windowOrigin, 200, 'We waited 200ms to spawn the second worker, so its timeOrigin should be greater than that of the window.');
+//     }));
+//   }, 200);
+// }, 'Window and worker timeOrigins differ when worker is created after a delay.');
+</script>
+</body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,7 +3813,7 @@ void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
-w3c-hr-time@^1.0.0:
+w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,6 +3813,12 @@ void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
+w3c-hr-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.0.tgz#ec0d98938bbf3fdf8f3f84b1b0337adfa0801e96"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
 walkdir@^0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.11.tgz#a16d025eb931bd03b52f308caed0f40fcebe9532"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,8 +3814,8 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
 
 w3c-hr-time@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.0.tgz#ec0d98938bbf3fdf8f3f84b1b0337adfa0801e96"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
   dependencies:
     browser-process-hrtime "^0.1.2"
 


### PR DESCRIPTION
This pull request implements the `Performance` interface and `window.performance` as defined by the [High Resolution Time](https://w3c.github.io/hr-time/#the-performance-interface) specification, with the exception of the default toJSON operation as it is not supported by webidl2js yet.

I use `Date.now()` to obtain the "time origin timestamp" as I am not aware of another way to obtain a reference to an absolute time without native code.

This resolves https://github.com/tmpvar/jsdom/issues/1510.