### PR TITLE
Use `this.setTimeout` in window.postMessage

### DIFF
--- a/lib/jsdom/living/post-message.js
+++ b/lib/jsdom/living/post-message.js
@@ -30,7 +30,7 @@ module.exports = function (message, targetOrigin) {
 
   event.initEvent("message", false, false);
 
-  setTimeout(() => {
+  this.setTimeout(() => {
     this.dispatchEvent(event);
   }, 0);
 };


### PR DESCRIPTION
This follows in the same vein as #1312 (discussed on that PR and at https://github.com/facebook/jest/issues/625), making the same change of referring to `window.setTimeout` instead of the global `setTimeout` within the implementation of `window.postMessage`. 

As it was, the [same issue](https://github.com/facebook/jest/issues/625) applies in this case when trying to mock timers before posting messages.  Adjusting the reference to `setTimeout` solves the issue, allowing Jest's timer mocking to succeed.