### PR TITLE
Remove some non-standard parts of window

### DIFF
--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -550,10 +550,13 @@ function Window(options) {
     pageYOffset: 0,
     screenX: 0,
     screenY: 0,
-    screenLeft: 0,
-    screenTop: 0,
     scrollX: 0,
     scrollY: 0,
+
+    // Not in spec, but likely to be added eventually:
+    // https://github.com/w3c/csswg-drafts/issues/1091
+    screenLeft: 0,
+    screenTop: 0,
 
     alert: notImplementedMethod("window.alert"),
     blur: notImplementedMethod("window.blur"),

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -554,8 +554,6 @@ function Window(options) {
     screenTop: 0,
     scrollX: 0,
     scrollY: 0,
-    scrollTop: 0,
-    scrollLeft: 0,
 
     alert: notImplementedMethod("window.alert"),
     blur: notImplementedMethod("window.blur"),

--- a/lib/jsdom/browser/Window.js
+++ b/lib/jsdom/browser/Window.js
@@ -561,7 +561,6 @@ function Window(options) {
     alert: notImplementedMethod("window.alert"),
     blur: notImplementedMethod("window.blur"),
     confirm: notImplementedMethod("window.confirm"),
-    createPopup: notImplementedMethod("window.createPopup"),
     focus: notImplementedMethod("window.focus"),
     moveBy: notImplementedMethod("window.moveBy"),
     moveTo: notImplementedMethod("window.moveTo"),


### PR DESCRIPTION
This pull request removes some non-standard properties on `window` - `scrollLeft`, `scrollTop` and the `createPopup()` stub.

I also added a note for the `screenLeft` and `screenTop` properties which are not standardized at the moment, but implemented in all browsers except Firefox and therefore [likely to be added](https://github.com/w3c/csswg-drafts/issues/1091) to CSSOM View in the future.

In theory this could be considered a breaking change along the lines of https://github.com/tmpvar/jsdom/pull/2069, though it'd be surprising if someone depends on these non-standard dummy/stub properties being present.