### PR TITLE
Enable old custom resource loader in new API

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -315,6 +315,10 @@ function transformOptions(options, encoding) {
     transformed.windowOptions.pretendToBeVisual = Boolean(options.pretendToBeVisual);
   }
 
+  if (options.resourceLoader !== undefined) {
+    transformed.windowOptions.resourceLoader = options.resourceLoader;
+  }
+
   // concurrentNodeIterators??
 
   return transformed;


### PR DESCRIPTION
ref: #2050 

This PR just enables the old custom resource loader in the new API.

This PR doesn't intent to replace the need of a new design for the
resource loader, but can help to some people to update to the new API.