### PR TITLE
Upgrade parse5 to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "html-encoding-sniffer": "^1.0.2",
     "left-pad": "^1.2.0",
     "nwmatcher": "^1.4.3",
-    "parse5": "^3.0.3",
+    "parse5": "^4.0.0",
     "pn": "^1.0.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/node@*":
-  version "8.0.53"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
-
 JSONStream@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -2758,11 +2754,9 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
+parse5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
 parsejson@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
This version does not have TypeScript typings for Node.js as a dependency.