### PR TITLE
Fix <style>'s sheet property

### DIFF
--- a/lib/jsdom/living/helpers/stylesheets.js
+++ b/lib/jsdom/living/helpers/stylesheets.js
@@ -4,24 +4,36 @@ const whatwgEncoding = require("whatwg-encoding");
 const whatwgURL = require("whatwg-url");
 const resourceLoader = require("../../browser/resource-loader");
 
+// TODO: this should really implement https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet
+// It (and the things it calls) is nowhere close right now.
 exports.fetchStylesheet = (elementImpl, urlString) => {
   const parsedURL = whatwgURL.parseURL(urlString);
   return fetchStylesheetInternal(elementImpl, urlString, parsedURL);
 };
 
-exports.evaluateStylesheet = (elementImpl, data, baseURL) => {
+// https://drafts.csswg.org/cssom/#remove-a-css-style-sheet
+exports.removeStylesheet = (sheet, elementImpl) => {
   const { styleSheets } = elementImpl._ownerDocument;
+  styleSheets.splice(styleSheets.indexOf(sheet, 1));
 
-  if (elementImpl.sheet) {
-    styleSheets.splice(styleSheets.indexOf(elementImpl.sheet, 1));
-  }
+  // Remove the association explicitly; in the spec it's implicit so this step doesn't exist.
+  elementImpl.sheet = null;
 
+  // TODO: "Set the CSS style sheet’s parent CSS style sheet, owner node and owner CSS rule to null."
+  // Probably when we have a real CSSOM implementation.
+};
+
+// https://drafts.csswg.org/cssom/#create-a-css-style-sheet kinda:
+// - Parsing failures are not handled gracefully like they should be
+// - The import rules stuff seems out of place, and probably should affect the load event...
+exports.createStylesheet = (sheetText, elementImpl, baseURL) => {
+  let sheet;
   try {
-    elementImpl.sheet = cssom.parse(data);
+    sheet = cssom.parse(sheetText);
   } catch (e) {
     if (elementImpl._ownerDocument._defaultView) {
       const error = new Error("Could not parse CSS stylesheet");
-      error.detail = data;
+      error.detail = sheetText;
       error.type = "css parsing";
 
       elementImpl._ownerDocument._defaultView._virtualConsole.emit("jsdomError", error);
@@ -29,10 +41,20 @@ exports.evaluateStylesheet = (elementImpl, data, baseURL) => {
     return;
   }
 
-  scanForImportRules(elementImpl, elementImpl.sheet.cssRules, baseURL);
+  scanForImportRules(elementImpl, sheet.cssRules, baseURL);
 
-  styleSheets.push(elementImpl.sheet);
+  addStylesheet(sheet, elementImpl);
 };
+
+// https://drafts.csswg.org/cssom/#add-a-css-style-sheet
+function addStylesheet(sheet, elementImpl) {
+  elementImpl._ownerDocument.styleSheets.push(sheet);
+
+  // Set the association explicitly; in the spec it's implicit.
+  elementImpl.sheet = sheet;
+
+  // TODO: title and disabled stuff
+}
 
 function fetchStylesheetInternal(elementImpl, urlString, parsedURL) {
   let defaultEncoding = elementImpl._ownerDocument._encoding;
@@ -42,10 +64,15 @@ function fetchStylesheetInternal(elementImpl, urlString, parsedURL) {
 
   resourceLoader.load(elementImpl, urlString, { defaultEncoding }, data => {
     // TODO: MIME type checking?
-    exports.evaluateStylesheet(elementImpl, data, parsedURL);
+    if (elementImpl.sheet) {
+      exports.removeStylesheet(elementImpl.sheet, elementImpl);
+    }
+    exports.createStylesheet(data, elementImpl, parsedURL);
   });
 }
 
+// TODO this is actually really messed up and overwrites the sheet on elementImpl
+// Tracking in https://github.com/tmpvar/jsdom/issues/2124
 function scanForImportRules(elementImpl, cssRules, baseURL) {
   if (!cssRules) {
     return;

--- a/lib/jsdom/living/nodes/HTMLStyleElement-impl.js
+++ b/lib/jsdom/living/nodes/HTMLStyleElement-impl.js
@@ -1,8 +1,9 @@
 "use strict";
 const HTMLElementImpl = require("./HTMLElement-impl").implementation;
-const { evaluateStylesheet } = require("../helpers/stylesheets");
+const { removeStylesheet, createStylesheet } = require("../helpers/stylesheets");
 const { documentBaseURL } = require("../helpers/document-base-url");
 const { childTextContent } = require("../helpers/text");
+const { asciiCaseInsensitiveMatch } = require("../helpers/strings");
 
 class HTMLStyleElementImpl extends HTMLElementImpl {
   constructor(args, privateData) {
@@ -11,13 +12,40 @@ class HTMLStyleElementImpl extends HTMLElementImpl {
     this.sheet = null;
   }
 
+  _attach() {
+    super._attach();
+    this._updateAStyleBlock();
+  }
+
+  _detach() {
+    super._detach();
+    this._updateAStyleBlock();
+  }
+
   _childTextContentChangeSteps() {
-    if (this.type && this.type !== "text/css") {
+    this._updateAStyleBlock();
+    super._childTextContentChangeSteps();
+  }
+
+  _updateAStyleBlock() {
+    if (this.sheet) {
+      removeStylesheet(this.sheet, this);
+    }
+
+    if (!this._attached) {
       return;
     }
 
+    const type = this.getAttribute("type");
+    if (type !== null && type !== "" && !asciiCaseInsensitiveMatch(type, "text/css")) {
+      return;
+    }
+
+    // Not implemented: CSP
+
     const content = childTextContent(this);
-    evaluateStylesheet(this, content, documentBaseURL(this._ownerDocument));
+    // Not implemented: a bunch of other state, e.g. title/media attributes
+    createStylesheet(content, this, documentBaseURL(this._ownerDocument));
   }
 }
 

--- a/test/web-platform-tests/to-run.yaml
+++ b/test/web-platform-tests/to-run.yaml
@@ -435,6 +435,18 @@ base_multiple.html: [timeout, We don't support navigation via <a target>]
 
 ---
 
+DIR: html/semantics/document-metadata/the-style-element
+
+style-error-01.html: [timeout, Unknown]
+style_disabled.html: [fail, Unimplemented]
+style_events.html: [timeout, Unknown]
+style_load_async.html: [timeout, Unknown]
+style_media.html: [fail, Unimplemented]
+style_media_change.html: [fail, Unimplemented]
+style_type_change.html: [fail, Spec mismatches tests https://github.com/whatwg/html/issues/3391]
+
+---
+
 DIR: html/semantics/forms/attributes-common-to-form-controls
 
 dirname-ltr.html: [timeout, Unknown]

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/sheet-with-disconnected-style.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/sheet-with-disconnected-style.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The sheet property should be null for disconnected style elements</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">
+<link rel="help" href="https://drafts.csswg.org/cssom/#the-linkstyle-interface">
+
+<style id="remove-me">p.foo { color: blue; }</style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const el = document.createElement("style");
+  el.textContent = "p.bar { color: red; }";
+  assert_equals(el.sheet, null);
+}, "Never-connected style elements should have a null sheet property");
+
+test(() => {
+  const el = document.querySelector("style");
+  assert_not_equals(el.sheet, null, "It starts out with a sheet");
+  el.remove();
+  assert_equals(el.sheet, null);
+  assert_array_equals(document.styleSheets, []);
+}, "After removing a style element, it should have a null sheet property");
+</script>

--- a/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/sheet-with-empty-style.html
+++ b/test/web-platform-tests/to-upstream/html/semantics/document-metadata/the-style-element/sheet-with-empty-style.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The sheet property should work even with an empty style element</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">
+<link rel="help" href="https://drafts.csswg.org/cssom/#the-linkstyle-interface">
+
+<style></style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+assert_not_equals(document.querySelector("style").sheet, null);
+assert_true(document.querySelector("style").sheet instanceof CSSStyleSheet);
+
+done();
+</script>


### PR DESCRIPTION
In particular, fixes #2122, where it was discovered that as of 8c84ebf3b7f3420b6e6cc68612ed3e0b9c1f4455 we wrongly made the sheet null for empty `<style>` elements.

There are a lot more issues with this area of the codebase, as discovered in https://github.com/tmpvar/jsdom/issues/2122#issuecomment-359992111. But we'll tackle them incrementally in #2124. This fixes one of them, about disconnected sheets, but leaves the ones having to do with `<link>` and @import and parsing alone for now.